### PR TITLE
chore(internal): configure releases

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,7 +1,5 @@
 name: Create releases
 on:
-  schedule:
-    - cron: '0 5 * * *' # every day at 5am UTC
   push:
     branches:
       - main
@@ -26,6 +24,7 @@ jobs:
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
       - name: Set up Ruby
+	if: ${{ steps.release.outputs.releases_created }}
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: false
@@ -34,6 +33,7 @@ jobs:
           bundle install
 
       - name: Publish to RubyGems.org
+	if: ${{ steps.release.outputs.releases_created }}
         run: |
           bash ./bin/publish-gem
         env:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,16 +1,30 @@
-# Workflow for re-publishing to rubygems.org in case it failed for some reason.
-# You can run this workflow by navigating to https://www.github.com/openai/openai-python/actions/workflows/publish-gem.yml
-name: Publish Gem
+name: Create releases
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *' # every day at 5am UTC
+  push:
+    branches:
+      - main
 
 jobs:
-  publish:
-    name: publish
+  release:
+    name: release
+    if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-ruby'
     runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: stainless-api/trigger-release-please@v1
+        id: release
+        with:
+          repo: ${{ github.event.repository.full_name }}
+          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
configures openai-ruby releases similar to how we have them set-up for other languages, e.g. https://github.com/openai/openai-node/blob/next/.github/workflows/create-releases.yml