### PR TITLE
fix: tool parameter mapping for chat completions

### DIFF
--- a/lib/openai/resources/chat/completions.rb
+++ b/lib/openai/resources/chat/completions.rb
@@ -140,7 +140,10 @@ module OpenAI
                 name = func[:name] ||= params.name.split("::").last
                 tool_models.store(name, params)
                 func.update(parameters: params.to_json_schema)
+
+                tool
               else
+                tool
               end
             end
             tools.replace(mapped)


### PR DESCRIPTION
When consumers supply tools that use a full `OpenAI::Chat::ChatCompletionTool` rather than providing only an `OpenAI::BaseModel`, the calls to OpenAI fail because the `tools` argument winds up invalid. The mapping in the library overwrites the `tool` in the array with `nil` because there are missing return values from the second and third options of the case statement.

```
my_function_definition = OpenAI::Models::FunctionDefinition.new(
  name: "my_tool_name",
  description: "My tool description",
  parameters: OpenAI::BaseModel.new({ ... })
)
my_tool_definition = OpenAI::Chat::ChatCompletionTool.new(
  type: :function,
  function: my_function_definition
)
openai_client.chat.completions.create(
  ...
  tools: [my_tool_definition]
)
```