### PR TITLE
Fix APIConnectionError attr_accessor rbi definition

### DIFF
--- a/rbi/openai/errors.rbi
+++ b/rbi/openai/errors.rbi
@@ -68,19 +68,19 @@ module OpenAI
     end
 
     class APIConnectionError < OpenAI::Errors::APIError
-      sig { void }
+      sig { returns(NilClass) }
       attr_accessor :status
 
-      sig { void }
+      sig { returns(NilClass) }
       attr_accessor :body
 
-      sig { void }
+      sig { returns(NilClass) }
       attr_accessor :code
 
-      sig { void }
+      sig { returns(NilClass) }
       attr_accessor :param
 
-      sig { void }
+      sig { returns(NilClass) }
       attr_accessor :type
 
       # @api private


### PR DESCRIPTION
* Closes https://github.com/openai/openai-ruby/issues/180

This PR fixes an error being encountered when trying to execute tapioca/sorbet on this gem.

In the event of `APIConnectionError` the attr_accessors listed will return nil (not void)