### PR TITLE
fix: use APIStatusError.for instead of APIError.for in stream.rb

### DIFF
--- a/lib/openai/internal/stream.rb
+++ b/lib/openai/internal/stream.rb
@@ -38,7 +38,7 @@ module OpenAI
                   else
                     "An error occurred during streaming"
                   end
-                err = OpenAI::Errors::APIError.for(
+                err = OpenAI::Errors::APIStatusError.for(
                   url: @url,
                   status: @status,
                   body: data,


### PR DESCRIPTION
## Summary
- Fixes a bug where `OpenAI::Errors::APIError.for` was being called in stream.rb, but this method doesn't exist
- Changes it to use `OpenAI::Errors::APIStatusError.for` which is the correct method that handles error creation

## Problem
The `APIError` class doesn't have a `for` class method, but `APIStatusError` does. This was causing a `NoMethodError` when streaming encounters an error response.

## Solution
Updated lib/openai/internal/stream.rb line 41 to call `APIStatusError.for` instead of `APIError.for`.

## Test plan
- [x] Verified that `APIStatusError` class has the `for` method in lib/openai/errors.rb:149
- [x] Verified that `APIError` class does not have a `for` method
- [x] Test streaming with error conditions to ensure proper error handling