### PR TITLE
fixed how array fields are sent in multipart form POSTs

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -578,7 +578,14 @@ module OpenAI
                 case val
                 in Array if val.all? { primitive?(_1) }
                   val.each do |v|
-                    write_multipart_chunk(y, boundary: boundary, key: "#{key}", val: v, closing: closing, is_array: true)
+                    write_multipart_chunk(
+                      y,
+                      boundary: boundary,
+                      key: key,
+                      val: v,
+                      closing: closing,
+                      is_array: true
+                    )
                   end
                 else
                   write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -540,8 +540,7 @@ module OpenAI
           y << "Content-Disposition: form-data"
 
           unless key.nil?
-            name = ERB::Util.url_encode(key.to_s)
-            y << "; name=\"#{name}\""
+            y << "; name=\"#{key}\""
           end
 
           case val
@@ -577,7 +576,7 @@ module OpenAI
                 case val
                 in Array if val.all? { primitive?(_1) }
                   val.each do |v|
-                    write_multipart_chunk(y, boundary: boundary, key: key, val: v, closing: closing)
+                    write_multipart_chunk(y, boundary: boundary, key: "#{key}[]", val: v, closing: closing)
                   end
                 else
                   write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -535,12 +535,14 @@ module OpenAI
         # @param key [Symbol, String]
         # @param val [Object]
         # @param closing [Array<Proc>]
-        private def write_multipart_chunk(y, boundary:, key:, val:, closing:)
+        private def write_multipart_chunk(y, boundary:, key:, val:, closing:, is_array: false)
           y << "--#{boundary}\r\n"
           y << "Content-Disposition: form-data"
 
           unless key.nil?
-            y << "; name=\"#{key}\""
+            name = ERB::Util.url_encode(key.to_s)
+            name = "#{name}[]" if is_array
+            y << "; name=\"#{name}\""
           end
 
           case val
@@ -576,7 +578,7 @@ module OpenAI
                 case val
                 in Array if val.all? { primitive?(_1) }
                   val.each do |v|
-                    write_multipart_chunk(y, boundary: boundary, key: "#{key}[]", val: v, closing: closing)
+                    write_multipart_chunk(y, boundary: boundary, key: "#{key}", val: v, closing: closing, is_array: true)
                   end
                 else
                   write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)

--- a/sig/openai/internal/util.rbs
+++ b/sig/openai/internal/util.rbs
@@ -117,9 +117,9 @@ module OpenAI
         Enumerator::Yielder y,
         boundary: String,
         key: Symbol | String,
-        ?is_array: bool,
         val: top,
-        closing: ::Array[^-> void]
+        closing: ::Array[^-> void],
+        ?is_array: bool
       ) -> void
 
       def self?.encode_multipart_streaming: (

--- a/sig/openai/internal/util.rbs
+++ b/sig/openai/internal/util.rbs
@@ -117,6 +117,7 @@ module OpenAI
         Enumerator::Yielder y,
         boundary: String,
         key: Symbol | String,
+        ?is_array: bool,
         val: top,
         closing: ::Array[^-> void]
       ) -> void

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -264,7 +264,7 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     cases = {
       {a: 2, b: 3} => {"a" => "2", "b" => "3"},
       {a: 2, b: nil} => {"a" => "2", "b" => "null"},
-      {a: 2, b: [1, 2, 3]} => {"a" => "2", "b" => "1"},
+      {a: 2, b: [1, 2, 3]} => {"a" => "2", "b[]" => "1"},
       {strio: StringIO.new("a")} => {"strio" => "a"},
       {strio: OpenAI::FilePart.new("a")} => {"strio" => "a"},
       {pathname: Pathname(__FILE__)} => {"pathname" => -> { _1.read in /^class OpenAI/ }},


### PR DESCRIPTION
This is a naive approach to properly supporting array fields in multipart encoded POST requests.

The issue I was having was that this code was not correctly sending `timestamp_granularities` to the server (see example):

```ruby
response = client.audio.transcriptions.create(
          model:                    "whisper-1",
          file:                     File.open(mp3_filepath.to_s, "rb"),
          response_format:          :verbose_json,
          timestamp_granularities:  [ :word, :segment ],
          language:                 "en"
 )
 ```
 
The server is expecting an array field, where the key is `timestamp_granularities[]`. However, the `url_encode` sanitization pass encodes the square brackets and the server doesn't decode it. Sanitization should be less aggressive, and only escape `LF`, `CR`, `"`, and `\` I believe.