### PR TITLE
docs: fix wording in Sorbet example comment

### DIFF
--- a/examples/demo_sorbet.rb
+++ b/examples/demo_sorbet.rb
@@ -37,7 +37,7 @@ begin
   # if you have sorbet LSP enabled, and uncomment the two lines below
   #   you will see a red squiggly line on `params` due to a quirk of the sorbet type system.
   #
-  # this file will still infact, run correctly as uncommented.
+  # this file will still in fact, run correctly as uncommented.
 
   # completion = client.chat.completions.create(params)
   # pp(completion.choices.first&.message&.content)


### PR DESCRIPTION
## Summary
- fix `infact` in the Sorbet example comment

## Related issue
- N/A (trivial example-comment fix)

## Guideline alignment
- Followed https://github.com/openai/openai-ruby/blob/main/CONTRIBUTING.md
- Change is limited to `examples/`, which the guide says is not generator-managed.

## Validation
- `git diff --check`