### PR TITLE
docs: fix demo_sorbet comment wording

### DIFF
--- a/examples/demo_sorbet.rb
+++ b/examples/demo_sorbet.rb
@@ -37,7 +37,7 @@ begin
   # if you have sorbet LSP enabled, and uncomment the two lines below
   #   you will see a red squiggly line on `params` due to a quirk of the sorbet type system.
   #
-  # this file will still infact, run correctly as uncommented.
+  # this file will, in fact, still run correctly when uncommented.
 
   # completion = client.chat.completions.create(params)
   # pp(completion.choices.first&.message&.content)


### PR DESCRIPTION
## Summary
- Fixes the demo Sorbet example comment so it reads naturally when explaining the false-positive type error.

## Related issue
- N/A

## Guideline alignment
- Single-file example comment change
- No behavior changes

## Validation
- `git diff --check`
