### PR TITLE
examples: fix demo_sorbet comment typo

### DIFF
--- a/examples/demo_sorbet.rb
+++ b/examples/demo_sorbet.rb
@@ -37,7 +37,7 @@ begin
   # if you have sorbet LSP enabled, and uncomment the two lines below
   #   you will see a red squiggly line on `params` due to a quirk of the sorbet type system.
   #
-  # this file will still infact, run correctly as uncommented.
+  # this file will still in fact, run correctly as uncommented.
 
   # completion = client.chat.completions.create(params)
   # pp(completion.choices.first&.message&.content)


### PR DESCRIPTION
## Summary
- fix the "infact" typo in the `demo_sorbet.rb` example comment

## Related issue
- N/A (trivial example comment typo fix)

## Guideline alignment
- follows `CONTRIBUTING.md` guidance by limiting the change to the manually maintained `examples/` directory
- keeps the change to a single comment line with no runtime behavior impact

## Validation
- ran `git diff --check`
- ran `ruby -c examples/demo_sorbet.rb`
