### PR TITLE
fix: tighten JSON, JSONL, and SSE content type matching

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -501,7 +501,7 @@ module OpenAI
       # @type [Regexp]
       JSON_CONTENT = %r{^application/(?:[a-zA-Z0-9.-]+\+)?json(?!l)}
       # @type [Regexp]
-      JSONL_CONTENT = %r{^application/(:?x-(?:n|l)djson)|(:?(?:x-)?jsonl)}
+      JSONL_CONTENT = %r{\Aapplication/(?:x-(?:n|l)djson|(?:x-)?jsonl)(?:\s*;|\z)}i
 
       class << self
         # @api private

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -422,7 +422,7 @@ module OpenAI
       # @type [Regexp]
       JSON_CONTENT = %r{^application/(?:[a-zA-Z0-9.-]+\+)?json(?!l)}
       # @type [Regexp]
-      JSONL_CONTENT = %r{^application/(:?x-(?:n|l)djson)|(:?(?:x-)?jsonl)}
+      JSONL_CONTENT = %r{\Aapplication/(?:x-(?:n|l)djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i
 
       class << self
         # @api private

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -420,9 +420,9 @@ module OpenAI
       end
 
       # @type [Regexp]
-      JSON_CONTENT = %r{^application/(?:[a-zA-Z0-9.-]+\+)?json(?!l)}
+      JSON_CONTENT = %r{\Aapplication/(?:[a-z0-9.-]+\+)?json[ \t]*(?:;|\z)}i
       # @type [Regexp]
-      JSONL_CONTENT = %r{\Aapplication/(?:x-(?:n|l)djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i
+      JSONL_CONTENT = %r{\Aapplication/(?:x-[nl]djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i
 
       class << self
         # @api private
@@ -667,7 +667,7 @@ module OpenAI
                 y << JSON.parse(_1, symbolize_names: true)
               end
             end
-          in %r{^text/event-stream}
+          in %r{\Atext/event-stream[ \t]*(?:;|\z)}i
             lines = decode_lines(stream)
             decode_sse(lines)
           else

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -306,7 +306,10 @@ module OpenAI
       JSON_CONTENT =
         T.let(%r{^application/(?:[a-zA-Z0-9.-]+\+)?json(?!l)}, Regexp)
       JSONL_CONTENT =
-        T.let(%r{^application/(:?x-(?:n|l)djson)|(:?(?:x-)?jsonl)}, Regexp)
+        T.let(
+          %r{\Aapplication/(?:x-(?:n|l)djson|(?:x-)?jsonl)(?:\s*;|\z)}i,
+          Regexp
+        )
 
       class << self
         # @api private

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -266,7 +266,10 @@ module OpenAI
       JSON_CONTENT =
         T.let(%r{^application/(?:[a-zA-Z0-9.-]+\+)?json(?!l)}, Regexp)
       JSONL_CONTENT =
-        T.let(%r{^application/(:?x-(?:n|l)djson)|(:?(?:x-)?jsonl)}, Regexp)
+        T.let(
+          %r{\Aapplication/(?:x-(?:n|l)djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i,
+          Regexp
+        )
 
       class << self
         # @api private

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -264,10 +264,13 @@ module OpenAI
       end
 
       JSON_CONTENT =
-        T.let(%r{^application/(?:[a-zA-Z0-9.-]+\+)?json(?!l)}, Regexp)
+        T.let(
+          %r{\Aapplication/(?:[a-z0-9.-]+\+)?json[ \t]*(?:;|\z)}i,
+          Regexp
+        )
       JSONL_CONTENT =
         T.let(
-          %r{\Aapplication/(?:x-(?:n|l)djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i,
+          %r{\Aapplication/(?:x-[nl]djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i,
           Regexp
         )
 

--- a/test/openai/internal/content_type_test.rb
+++ b/test/openai/internal/content_type_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ContentTypeMatcherTest < Minitest::Test
+  def test_json_content
+    cases = {
+      "application/json" => true,
+      "application/json; charset=utf-8" => true,
+      "APPLICATION/JSON" => true,
+      "application/json " => true,
+      "application/jsonl" => false,
+      "application/arbitrary+json" => true,
+      "application/ARBITRARY+json" => true,
+      "application/vnd.github.v3+json" => true,
+      "application/vnd.api+json" => true,
+      "application/jsonL" => false,
+      "application/json-seq" => false,
+      "application/jsonlines" => false,
+      "application/jsonfoo" => false
+    }
+    cases.each do |header, verdict|
+      assert_pattern do
+        OpenAI::Internal::Util::JSON_CONTENT.match?(header) => ^verdict
+      end
+    end
+  end
+
+  def test_jsonl_content
+    cases = {
+      "application/x-ndjson" => true,
+      "application/x-ldjson" => true,
+      "application/jsonl" => true,
+      "application/x-jsonl" => true,
+      "application/jsonl; charset=utf-8" => true,
+      "APPLICATION/JSONL" => true,
+      "application/jsonL" => true,
+      "application/jsonl " => true,
+      "application/json" => false,
+      "application/vnd.api+json" => false,
+      "application/jsonlines" => false,
+      "application/jsonl+zip" => false,
+      "application/vnd.api+jsonl" => false,
+      "application/jsonl, text/plain" => false,
+      " application/jsonl" => false,
+      "application/jsonl\n" => false,
+      "text/plain; name=jsonl" => false,
+      "foojsonlbar" => false,
+      "application/notjsonlbutjsonl" => false
+    }
+    cases.each do |header, verdict|
+      assert_pattern do
+        OpenAI::Internal::Util::JSONL_CONTENT.match?(header) => ^verdict
+      end
+    end
+  end
+end
+
+class OpenAI::Test::ContentTypeDispatchTest < Minitest::Test
+  def test_mixed_case_jsonl_is_encoded_as_individual_records
+    _headers, encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "application/jsonL"},
+      [{id: 1}, {id: 2}]
+    )
+
+    assert_equal(['{"id":1}', '{"id":2}'], encoded.to_a)
+  end
+
+  def test_mixed_case_jsonl_is_decoded_as_individual_records
+    decoded = OpenAI::Internal::Util.decode_content(
+      {"content-type" => "application/jsonL"},
+      stream: [%({"id":1}\n{"id":2}\n).b]
+    )
+
+    assert_equal([{id: 1}, {id: 2}], decoded.to_a)
+  end
+
+  def test_unrelated_content_types_remain_raw
+    content_types = [
+      "text/plain; name=jsonl",
+      "foojsonlbar",
+      "application/notjsonlbutjsonl"
+    ]
+
+    content_types.each do |content_type|
+      decoded = OpenAI::Internal::Util.decode_content(
+        {"content-type" => content_type},
+        stream: ["not json\n".b]
+      )
+
+      assert_instance_of(StringIO, decoded)
+      assert_equal("not json\n", decoded.read)
+    end
+  end
+
+  def test_sse_content_type_with_jsonl_parameter_is_decoded_as_sse
+    decoded = OpenAI::Internal::Util.decode_content(
+      {"content-type" => "text/event-stream; name=jsonl"},
+      stream: ['data: {"id"'.b, ":1}\n\n".b]
+    )
+
+    assert_equal(
+      [{event: nil, data: "{\"id\":1}\n", id: nil, retry: nil}],
+      decoded.to_a
+    )
+  end
+
+  def test_mixed_case_sse_content_type_is_decoded_as_sse
+    decoded = OpenAI::Internal::Util.decode_content(
+      {"content-type" => "TEXT/EVENT-STREAM; charset=utf-8"},
+      stream: ['data: {"id"'.b, ":1}\n\n".b]
+    )
+
+    assert_equal(
+      [{event: nil, data: "{\"id\":1}\n", id: nil, retry: nil}],
+      decoded.to_a
+    )
+  end
+
+  def test_unrelated_sse_prefix_remains_raw
+    decoded = OpenAI::Internal::Util.decode_content(
+      {"content-type" => "text/event-streaming"},
+      stream: ["not an event stream\n".b]
+    )
+
+    assert_instance_of(StringIO, decoded)
+    assert_equal("not an event stream\n", decoded.read)
+  end
+end

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -189,8 +189,15 @@ class OpenAI::Test::RegexMatchTest < Minitest::Test
       "application/x-ldjson" => true,
       "application/jsonl" => true,
       "application/x-jsonl" => true,
+      "application/jsonl; charset=utf-8" => true,
+      "APPLICATION/JSONL" => true,
+      "application/jsonl " => true,
       "application/json" => false,
-      "application/vnd.api+json" => false
+      "application/vnd.api+json" => false,
+      "application/jsonlines" => false,
+      "text/plain; name=jsonl" => false,
+      "foojsonlbar" => false,
+      "application/notjsonlbutjsonl" => false
     }
     cases.each do |header, verdict|
       assert_pattern do

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -189,8 +189,13 @@ class OpenAI::Test::RegexMatchTest < Minitest::Test
       "application/x-ldjson" => true,
       "application/jsonl" => true,
       "application/x-jsonl" => true,
+      "application/jsonl; charset=utf-8" => true,
+      "APPLICATION/JSONL" => true,
       "application/json" => false,
-      "application/vnd.api+json" => false
+      "application/vnd.api+json" => false,
+      "text/plain; name=jsonl" => false,
+      "foojsonlbar" => false,
+      "application/notjsonlbutjsonl" => false
     }
     cases.each do |header, verdict|
       assert_pattern do

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -166,47 +166,6 @@ class OpenAI::Test::UtilUriHandlingTest < Minitest::Test
   end
 end
 
-class OpenAI::Test::RegexMatchTest < Minitest::Test
-  def test_json_content
-    cases = {
-      "application/json" => true,
-      "application/jsonl" => false,
-      "application/arbitrary+json" => true,
-      "application/ARBITRARY+json" => true,
-      "application/vnd.github.v3+json" => true,
-      "application/vnd.api+json" => true
-    }
-    cases.each do |header, verdict|
-      assert_pattern do
-        OpenAI::Internal::Util::JSON_CONTENT.match?(header) => ^verdict
-      end
-    end
-  end
-
-  def test_jsonl_content
-    cases = {
-      "application/x-ndjson" => true,
-      "application/x-ldjson" => true,
-      "application/jsonl" => true,
-      "application/x-jsonl" => true,
-      "application/jsonl; charset=utf-8" => true,
-      "APPLICATION/JSONL" => true,
-      "application/jsonl " => true,
-      "application/json" => false,
-      "application/vnd.api+json" => false,
-      "application/jsonlines" => false,
-      "text/plain; name=jsonl" => false,
-      "foojsonlbar" => false,
-      "application/notjsonlbutjsonl" => false
-    }
-    cases.each do |header, verdict|
-      assert_pattern do
-        OpenAI::Internal::Util::JSONL_CONTENT.match?(header) => ^verdict
-      end
-    end
-  end
-end
-
 class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
   class FakeCGI < CGI
     def initialize(headers, io)


### PR DESCRIPTION
## Summary

- require JSON and JSONL content types to match an exact, case-insensitive media type boundary
- keep JSON and JSONL dispatch disjoint, including mixed-case `application/jsonL`
- preserve supported `x-ndjson`, `x-ldjson`, `jsonl`, and `x-jsonl` media types with optional parameters and horizontal whitespace
- apply the same case-insensitive boundary handling to Server-Sent Events
- add matcher and end-to-end encode/decode regressions for valid, malformed, suffixed, and unrelated content types

## Why

`encode_content` and `decode_content` select JSON, JSONL, and SSE behavior by content type. The previous JSONL regex matched unrelated values, while the JSON matcher could claim mixed-case JSONL before JSONL dispatch. Prefix-only matching also accepted invalid suffixes such as `application/json-seq` and `text/event-streaming`.

These cases could parse the wrong format, raise parser errors, or return the wrong decoded shape.

Fixes #276.

## Test plan

- `mise exec ruby@4.0.6 -- ./scripts/test`
- `mise exec ruby@4.0.6 -- bundle exec rake lint`
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem`
- GitHub Actions: 11 passed, 0 failed