### PR TITLE
fix: multipart filename quoting

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -575,6 +575,18 @@ module OpenAI
 
         # @api private
         #
+        # Multipart filenames are quoted-strings, not URI path segments. Escape header
+        # delimiters and remove CR/LF without encoding ordinary filename characters.
+        #
+        # @param filename [Pathname, String]
+        #
+        # @return [String]
+        private def escape_multipart_filename(filename)
+          filename.to_s.gsub(/["\\]/) { "\\#{_1}" }.delete("\r\n")
+        end
+
+        # @api private
+        #
         # @param y [Enumerator::Yielder]
         # @param boundary [String]
         # @param key [Symbol, String]
@@ -590,10 +602,10 @@ module OpenAI
 
           case val
           in OpenAI::FilePart unless val.filename.nil?
-            filename = encode_path(val.filename)
+            filename = escape_multipart_filename(val.filename)
             y << "; filename=\"#{filename}\""
           in Pathname | IO
-            filename = encode_path(::File.basename(val.to_path))
+            filename = escape_multipart_filename(::File.basename(val.to_path))
             y << "; filename=\"#{filename}\""
           else
           end

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -582,7 +582,7 @@ module OpenAI
         #
         # @return [String]
         private def escape_multipart_filename(filename)
-          filename.to_s.gsub(/["\\]/) { "\\#{_1}" }.delete("\r\n")
+          filename.to_s.gsub(/["\\]/) { "\\#{_1}" }.delete("\r\n").b
         end
 
         # @api private

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -271,6 +271,18 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     refute_includes(body, "\r\nEvil:")
   end
 
+  def test_multipart_filename_encoding_with_binary_content
+    file = OpenAI::FilePart.new(StringIO.new("\xFF".b), filename: "\u00E9.png")
+    _headers, stream = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      {"f" => [file]}
+    )
+    body = stream.respond_to?(:read) ? stream.read : stream.to_a.join
+
+    assert_equal(Encoding::ASCII_8BIT, body.encoding)
+    assert_includes(body, "filename=\"\u00E9.png\"".b)
+  end
+
   def test_hash_encode
     headers = {"content-type" => "multipart/form-data"}
     cases = {

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -245,7 +245,7 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
       fileinput => %w[upload abc],
       OpenAI::FilePart.new(StringIO.new("abc")) => ["", "abc"],
       file => [file.basename.to_path, /^class OpenAI/],
-      OpenAI::FilePart.new(file, filename: "d o g") => ["d%20o%20g", /^class OpenAI/]
+      OpenAI::FilePart.new(file, filename: "d o g") => ["d o g", /^class OpenAI/]
     }
     cases.each do |body, testcase|
       filename, val = testcase
@@ -257,6 +257,18 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
         io.read => ^val
       end
     end
+  end
+
+  def test_multipart_filename_quoting
+    file = OpenAI::FilePart.new(StringIO.new("x"), filename: "a \"b\"\r\nEvil: 1.md")
+    _headers, stream = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      {"f" => [file]}
+    )
+    body = stream.respond_to?(:read) ? stream.read : stream.to_a.join
+
+    assert_includes(body, %q(filename="a \"b\"Evil: 1.md"))
+    refute_includes(body, "\r\nEvil:")
   end
 
   def test_hash_encode


### PR DESCRIPTION
## Summary

- serialize multipart `filename=` values as quoted-strings instead of URI path segments
- escape quote and backslash delimiters and drop CR/LF before writing multipart headers
- cover literal spaces and crafted header-injection input

## Why

Multipart `filename=` parameters are quoted-string values. URL-encoding them changes ordinary filenames such as `d o g` into `d%20o%20g`. Writing literal values instead also needs delimiter escaping and CR/LF removal so crafted filenames cannot inject multipart headers.

## Validation

- `git diff --check`
- standalone Ruby probe for quote escaping and CR/LF removal
- checked changed source lines against the repository's 120-character style

## Remote Linux validation
- `git diff --check`
- `bundle install`
- `./scripts/lint`
- `./scripts/test`