### PR TITLE
docs: fix wording in Sorbet example comment

### DIFF
--- a/examples/demo_sorbet.rb
+++ b/examples/demo_sorbet.rb
@@ -37,7 +37,7 @@ begin
   # if you have sorbet LSP enabled, and uncomment the two lines below
   #   you will see a red squiggly line on `params` due to a quirk of the sorbet type system.
   #
-  # this file will still in fact, run correctly as uncommented.
+  # this file will still, in fact, run correctly as uncommented.
 
   # completion = client.chat.completions.create(params)
   # pp(completion.choices.first&.message&.content)


### PR DESCRIPTION
## Summary

Fix the wording in the Sorbet example comment in `examples/demo_sorbet.rb`.

## Credit

Thanks to @Rohan5commit for catching this and opening #259. This PR preserves their original change and commit authorship while moving the fix onto an `openai/openai-ruby` branch.

## Validation

- `ruby -c examples/demo_sorbet.rb`
- `git diff --check origin/main...HEAD`
