### PR TITLE
Preserve nil timeouts through request transport

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -223,7 +223,7 @@ module OpenAI
     #
     # @param max_retries [Integer] Max number of retries to attempt after a failed retryable request.
     #
-    # @param timeout [Float]
+    # @param timeout [Float, nil] Pass `nil` to disable request timeouts.
     #
     # @param initial_retry_delay [Float]
     #

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -168,7 +168,7 @@ module OpenAI
         # @return [URI::Generic]
         attr_reader :base_url
 
-        # @return [Float]
+        # @return [Float, nil]
         attr_reader :timeout
 
         # @return [Integer]
@@ -193,7 +193,7 @@ module OpenAI
         # @api private
         #
         # @param base_url [String]
-        # @param timeout [Float]
+        # @param timeout [Float, nil]
         # @param max_retries [Integer]
         # @param initial_retry_delay [Float]
         # @param max_retry_delay [Float]
@@ -310,8 +310,8 @@ module OpenAI
             headers["x-stainless-retry-count"] = "0"
           end
 
-          timeout = opts.fetch(:timeout, @timeout).to_f.clamp(0..)
-          unless headers.key?("x-stainless-timeout") || timeout.zero?
+          timeout = opts.fetch(:timeout, @timeout)&.to_f&.clamp(0..)
+          unless headers.key?("x-stainless-timeout") || timeout.nil? || timeout.zero?
             headers["x-stainless-timeout"] = timeout.to_s
           end
 
@@ -385,7 +385,7 @@ module OpenAI
         #
         #   @option request [Integer] :max_retries
         #
-        #   @option request [Float] :timeout
+        #   @option request [Float, nil] :timeout
         #
         # @param redirect_count [Integer]
         #
@@ -397,7 +397,7 @@ module OpenAI
         # @return [Array(Integer, Net::HTTPResponse, Enumerable<String>)]
         def send_request(request, redirect_count:, retry_count:, send_retry_header:)
           url, headers, max_retries, timeout = request.fetch_values(:url, :headers, :max_retries, :timeout)
-          input = {**request.except(:timeout), deadline: OpenAI::Internal::Util.monotonic_secs + timeout}
+          input = {**request.except(:timeout), deadline: timeout.nil? ? nil : OpenAI::Internal::Util.monotonic_secs + timeout}
 
           if send_retry_header
             headers["x-stainless-retry-count"] = retry_count.to_s
@@ -590,7 +590,7 @@ module OpenAI
               headers: T::Hash[String, String],
               body: T.anything,
               max_retries: Integer,
-              timeout: Float
+              timeout: T.nilable(Float)
             }
           end
         end

--- a/lib/openai/internal/transport/pooled_net_requester.rb
+++ b/lib/openai/internal/transport/pooled_net_requester.rb
@@ -12,6 +12,7 @@ module OpenAI
         KEEP_ALIVE_TIMEOUT = 30
 
         DEFAULT_MAX_CONNECTIONS = [Etc.nprocessors, 99].max
+        UNBOUNDED_POOL_WAIT_TIMEOUT = 60
 
         class << self
           # @api private
@@ -109,7 +110,12 @@ module OpenAI
             end
 
           if deadline.nil?
-            pool.with(&blk)
+            loop do
+              # `connection_pool` cannot disable checkout timeouts, so retry a long
+              # wait interval indefinitely when the request timeout is disabled.
+              return pool.with(timeout: self.class::UNBOUNDED_POOL_WAIT_TIMEOUT, &blk)
+            rescue ConnectionPool::TimeoutError
+            end
           else
             timeout = deadline - OpenAI::Internal::Util.monotonic_secs
             pool.with(timeout: timeout, &blk)

--- a/lib/openai/internal/transport/pooled_net_requester.rb
+++ b/lib/openai/internal/transport/pooled_net_requester.rb
@@ -42,9 +42,9 @@ module OpenAI
           # @api private
           #
           # @param conn [Net::HTTP]
-          # @param deadline [Float]
+          # @param deadline [Float, nil]
           def calibrate_socket_timeout(conn, deadline)
-            timeout = deadline - OpenAI::Internal::Util.monotonic_secs
+            timeout = deadline&.-(OpenAI::Internal::Util.monotonic_secs)
             conn.open_timeout = conn.read_timeout = conn.write_timeout = conn.continue_timeout = timeout
           end
 
@@ -94,14 +94,13 @@ module OpenAI
         # @api private
         #
         # @param url [URI::Generic]
-        # @param deadline [Float]
+        # @param deadline [Float, nil]
         # @param blk [Proc]
         #
         # @raise [Timeout::Error]
         # @yieldparam [Net::HTTP]
         private def with_pool(url, deadline:, &blk)
           origin = OpenAI::Internal::Util.uri_origin(url)
-          timeout = deadline - OpenAI::Internal::Util.monotonic_secs
           pool =
             @mutex.synchronize do
               @pools[origin] ||= ConnectionPool.new(size: @size) do
@@ -109,7 +108,12 @@ module OpenAI
               end
             end
 
-          pool.with(timeout: timeout, &blk)
+          if deadline.nil?
+            pool.with(&blk)
+          else
+            timeout = deadline - OpenAI::Internal::Util.monotonic_secs
+            pool.with(timeout: timeout, &blk)
+          end
         end
 
         # @api private
@@ -124,7 +128,7 @@ module OpenAI
         #
         #   @option request [Object] :body
         #
-        #   @option request [Float] :deadline
+        #   @option request [Float, nil] :deadline
         #
         # @return [Array(Integer, Net::HTTPResponse, Enumerable<String>)]
         def execute(request)
@@ -202,7 +206,9 @@ module OpenAI
         end
 
         define_sorbet_constant!(:Request) do
-          T.type_alias { {method: Symbol, url: URI::Generic, headers: T::Hash[String, String], body: T.anything, deadline: Float} }
+          T.type_alias do
+            {method: Symbol, url: URI::Generic, headers: T::Hash[String, String], body: T.anything, deadline: T.nilable(Float)}
+          end
         end
       end
     end

--- a/lib/openai/request_options.rb
+++ b/lib/openai/request_options.rb
@@ -60,7 +60,7 @@ module OpenAI
     optional :max_retries, Integer
 
     # @!attribute timeout
-    #   Request timeout in seconds.
+    #   Request timeout in seconds. Pass `nil` to disable the timeout.
     #
     #   @return [Float, nil]
     optional :timeout, Float

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -366,6 +366,50 @@ class OpenAITest < Minitest::Test
     assert_requested(:any, /./, headers: {"x-stainless-retry-count" => "42"}, times: 3)
   end
 
+  def test_request_timeout_nil_omits_timeout_header_and_deadline
+    response_class =
+      Struct.new(:headers) do
+        def each_header = headers.each
+      end
+
+    requester =
+      Class.new do
+        attr_reader :request
+
+        define_method(:initialize) do |response_class|
+          @response_class = response_class
+        end
+
+        def execute(request)
+          @request = request
+          [200, @response_class.new({}), [].each]
+        end
+      end.new(response_class)
+
+    openai =
+      OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "My API Key",
+        admin_api_key: "My Admin API Key",
+        timeout: 30
+      )
+    openai.instance_variable_set(:@requester, requester)
+
+    request =
+      openai.send(
+        :build_request,
+        {method: :post, path: "/chat/completions", body: {}, headers: nil, query: nil},
+        {timeout: nil}
+      )
+
+    assert_nil(request[:timeout])
+    refute_includes(request[:headers].keys.map(&:downcase), "x-stainless-timeout")
+
+    openai.send(:send_request, request, redirect_count: 0, retry_count: 0, send_retry_header: true)
+
+    assert_nil(requester.request[:deadline])
+  end
+
   def test_client_redirect_307
     stub_request(:post, "http://localhost/chat/completions").to_return_json(
       status: 307,
@@ -521,6 +565,46 @@ class OpenAITest < Minitest::Test
       headers = req.headers.transform_keys(&:downcase)
       expected = req.body.nil? ? ["accept"] : %w[accept content-type]
       headers.fetch_values(*expected).each { refute_empty(_1) }
+    end
+  end
+
+  def test_client_timeout_nil_disables_timeout_header
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(status: 200, body: {})
+
+    openai =
+      OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "My API Key",
+        admin_api_key: "My Admin API Key",
+        timeout: nil
+      )
+
+    openai.chat.completions.create(messages: [{content: "string", role: :developer}], model: :"gpt-5.4")
+
+    assert_requested(:post, "http://localhost/chat/completions") do |req|
+      refute_includes(req.headers.keys.map(&:downcase), "x-stainless-timeout")
+    end
+  end
+
+  def test_request_timeout_nil_overrides_client_default_timeout_header
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(status: 200, body: {})
+
+    openai =
+      OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "My API Key",
+        admin_api_key: "My Admin API Key",
+        timeout: 30
+      )
+
+    openai.chat.completions.create(
+      messages: [{content: "string", role: :developer}],
+      model: :"gpt-5.4",
+      request_options: {timeout: nil}
+    )
+
+    assert_requested(:post, "http://localhost/chat/completions") do |req|
+      refute_includes(req.headers.keys.map(&:downcase), "x-stainless-timeout")
     end
   end
 end

--- a/test/openai/internal/transport/pooled_net_requester_test.rb
+++ b/test/openai/internal/transport/pooled_net_requester_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::PooledNetRequesterTest < Minitest::Test
+  def test_with_pool_waits_indefinitely_when_deadline_is_nil
+    requester = OpenAI::Internal::Transport::PooledNetRequester.new(size: 1)
+    pool = ConnectionPool.new(size: 1, timeout: 0.05) { Object.new }
+    origin = OpenAI::Internal::Util.uri_origin(URI("http://localhost"))
+    requester.instance_variable_get(:@pools)[origin] = pool
+
+    pool.checkout
+
+    result = Queue.new
+    waiter =
+      Thread.new do
+        begin
+          requester.send(:with_pool, URI("http://localhost"), deadline: nil) { result << :acquired }
+        rescue StandardError => e
+          result << e
+        end
+      end
+
+    sleep 0.15
+    pool.checkin
+
+    assert(waiter.join(1), "expected waiting thread to finish after the connection was returned")
+    assert_equal(:acquired, result.pop)
+  end
+end


### PR DESCRIPTION
## Summary
- preserve `timeout: nil` as "no timeout" instead of coercing it to `0.0`
- skip deadline and `x-stainless-timeout` handling when a request disables timeouts
- reset pooled `Net::HTTP` socket timeouts and add regressions for default and per-request nil timeout behavior

## Why
The README documents `timeout: nil` as disabling timeouts, but the transport currently calls `to_f` on the timeout value. In Ruby, `nil.to_f` becomes `0.0`, which turns the computed deadline into "right now" rather than removing the deadline.

## Validation
- `ASDF_RUBY_VERSION=3.4.9 asdf exec bundle exec ruby -Itest test/openai/client_test.rb --name=/timeout/`
- `ASDF_RUBY_VERSION=3.4.9 asdf exec bundle exec ruby -Itest test/openai/client_test.rb`
