### PR TITLE
fix: coerce nested BaseModel fields

### DIFF
--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -38,7 +38,19 @@ module OpenAI
         # @param other [Object]
         #
         # @return [Boolean]
-        def ===(other) = other.is_a?(Array) && other.all?(item_type)
+        def ===(other)
+          type = item_type
+          other.is_a?(Array) && other.all? do |item|
+            case item
+            in ^type
+              true
+            in nil
+              nilable?
+            else
+              false
+            end
+          end
+        end
 
         # @api public
         #

--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -84,16 +84,21 @@ module OpenAI
 
           target = item_type
           exactness[:yes] += 1
-          value
-            .map do |item|
-              case [nilable?, item]
-              in [true, nil]
-                exactness[:yes] += 1
-                nil
-              else
-                OpenAI::Internal::Type::Converter.coerce(target, item, state: state)
-              end
+          error = state.fetch(:error)
+          converted = value.map do |item|
+            case [nilable?, item]
+            in [true, nil]
+              exactness[:yes] += 1
+              nil
+            else
+              coerced, item_error =
+                OpenAI::Internal::Type::Converter.coerce_with_error(target, item, state: state)
+              error ||= item_error
+              coerced
             end
+          end
+          state[:error] = error
+          converted
         end
 
         # @api private

--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -83,12 +83,15 @@ module OpenAI
               target = type_fn.call
               state = OpenAI::Internal::Type::Converter.new_coerce_state(translate_names: false)
               coerced = OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
-              error = @coerced.store(name_sym, state.fetch(:error) || true)
+              status = state.fetch(:error) || true
+              @coerced.store(name_sym, status)
               stored =
-                case [target, error]
-                in [OpenAI::Internal::Type::Converter | Symbol, nil]
+                case [target, status, value]
+                in [OpenAI::Internal::Type::Converter | Symbol, true, ^target]
+                  value
+                in [OpenAI::Internal::Type::Converter | Symbol, true, _]
                   coerced
-                else
+                else # rubocop:disable Lint/DuplicateBranch
                   value
                 end
               @data.store(name_sym, stored)

--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -82,7 +82,12 @@ module OpenAI
             define_method(setter) do |value|
               target = type_fn.call
               state = OpenAI::Internal::Type::Converter.new_coerce_state(translate_names: false)
-              coerced = OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
+              coerced =
+                if value.nil? && (nilable || !required)
+                  nil
+                else
+                  OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
+                end
               error = state.fetch(:error)
               @coerced.store(name_sym, error || true)
               stored =

--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -82,16 +82,19 @@ module OpenAI
             define_method(setter) do |value|
               target = type_fn.call
               state = OpenAI::Internal::Type::Converter.new_coerce_state(translate_names: false)
-              coerced = OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
-              status = state.fetch(:error) || true
+              coerced, error =
+                OpenAI::Internal::Type::Converter.coerce_with_error(target, value, state: state)
+              status = error || true
               @coerced.store(name_sym, status)
               stored =
-                case [target, status, value]
-                in [OpenAI::Internal::Type::Converter | Symbol, true, ^target]
-                  value
-                in [OpenAI::Internal::Type::Converter | Symbol, true, _]
-                  coerced
-                else # rubocop:disable Lint/DuplicateBranch
+                case [target, status]
+                in [OpenAI::Internal::Type::Converter | Symbol, true]
+                  if value in ^target
+                    value
+                  else
+                    coerced
+                  end
+                else
                   value
                 end
               @data.store(name_sym, stored)
@@ -250,7 +253,7 @@ module OpenAI
           def coerce(value, state:)
             exactness = state.fetch(:exactness)
 
-            if value.is_a?(self.class)
+            if value.is_a?(self)
               exactness[:yes] += 1
               return value
             end
@@ -268,6 +271,7 @@ module OpenAI
             viability = instance.instance_variable_get(:@coerced)
 
             # rubocop:disable Metrics/BlockLength
+            error = state.fetch(:error)
             fields.each do |name, field|
               mode, required, target = field.fetch_values(:mode, :required, :type)
               api_name, nilable, const = field.fetch_values(:api_name, :nilable, :const)
@@ -285,13 +289,14 @@ module OpenAI
               item = val.fetch(src_name)
               keys.delete(src_name)
 
-              state[:error] = nil
+              field_error = nil
               converted =
                 if item.nil? && (nilable || !required)
                   exactness[nilable ? :yes : :maybe] += 1
                   nil
                 else
-                  coerced = OpenAI::Internal::Type::Converter.coerce(target, item, state: state)
+                  coerced, field_error =
+                    OpenAI::Internal::Type::Converter.coerce_with_error(target, item, state: state)
                   case target
                   in OpenAI::Internal::Type::Converter | Symbol
                     coerced
@@ -300,11 +305,13 @@ module OpenAI
                   end
                 end
 
-              viability.store(name, state.fetch(:error) || true)
+              error ||= field_error
+              viability.store(name, field_error || true)
               data.store(name, converted)
             end
             # rubocop:enable Metrics/BlockLength
 
+            state[:error] = error
             keys.each { data.store(_1, val.fetch(_1)) }
             instance
           end

--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -82,13 +82,12 @@ module OpenAI
             define_method(setter) do |value|
               target = type_fn.call
               state = OpenAI::Internal::Type::Converter.new_coerce_state(translate_names: false)
-              coerced, error =
-                OpenAI::Internal::Type::Converter.coerce_with_error(target, value, state: state)
-              status = error || true
-              @coerced.store(name_sym, status)
+              coerced = OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
+              error = state.fetch(:error)
+              @coerced.store(name_sym, error || true)
               stored =
-                case [target, status]
-                in [OpenAI::Internal::Type::Converter | Symbol, true]
+                case [target, error]
+                in [OpenAI::Internal::Type::Converter | Symbol, nil]
                   if value in ^target
                     value
                   else

--- a/lib/openai/internal/type/converter.rb
+++ b/lib/openai/internal/type/converter.rb
@@ -270,6 +270,26 @@ module OpenAI
 
           # @api private
           #
+          # Coerces a value while isolating its error from sibling coercions.
+          #
+          # @param target [OpenAI::Internal::Type::Converter, Class]
+          #
+          # @param value [Object]
+          #
+          # @param state [Hash{Symbol=>Object}]
+          #
+          # @return [Array(Object, StandardError, nil)]
+          def coerce_with_error(target, value, state:)
+            previous_error = state.fetch(:error)
+            state[:error] = nil
+            coerced = coerce(target, value, state: state)
+            [coerced, state.fetch(:error)]
+          ensure
+            state[:error] = previous_error
+          end
+
+          # @api private
+          #
           # @param target [OpenAI::Internal::Type::Converter, Class]
           #
           # @param value [Object]

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -99,21 +99,26 @@ module OpenAI
 
           target = item_type
           exactness[:yes] += 1
-          value
-            .to_h do |key, val|
-              k = key.is_a?(String) ? key.to_sym : key
-              v =
-                case [nilable?, val]
-                in [true, nil]
-                  exactness[:yes] += 1
-                  nil
-                else
-                  OpenAI::Internal::Type::Converter.coerce(target, val, state: state)
-                end
+          error = state.fetch(:error)
+          converted = value.to_h do |key, val|
+            k = key.is_a?(String) ? key.to_sym : key
+            v =
+              case [nilable?, val]
+              in [true, nil]
+                exactness[:yes] += 1
+                nil
+              else
+                coerced, value_error =
+                  OpenAI::Internal::Type::Converter.coerce_with_error(target, val, state: state)
+                error ||= value_error
+                coerced
+              end
 
-              exactness[:no] += 1 unless k.is_a?(Symbol)
-              [k, v]
-            end
+            exactness[:no] += 1 unless k.is_a?(Symbol)
+            [k, v]
+          end
+          state[:error] = error
+          converted
         end
 
         # @api private

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -46,6 +46,8 @@ module OpenAI
               case [key, val]
               in [Symbol | String, ^type]
                 true
+              in [Symbol | String, nil]
+                nilable?
               else
                 false
               end

--- a/lib/openai/internal/type/union.rb
+++ b/lib/openai/internal/type/union.rb
@@ -159,11 +159,11 @@ module OpenAI
         #
         # @return [Object]
         def coerce(value, state:)
+          strictness = state.fetch(:strictness)
           if (target = resolve_variant(value))
             return OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
           end
 
-          strictness = state.fetch(:strictness)
           exactness = state.fetch(:exactness)
 
           alternatives = []
@@ -172,14 +172,16 @@ module OpenAI
             exact = state[:exactness] = {yes: 0, no: 0, maybe: 0}
             state[:branched] += 1
 
-            coerced = OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
+            coerced, error =
+              OpenAI::Internal::Type::Converter.coerce_with_error(target, value, state: state)
             yes, no, maybe = exact.values
             if (no + maybe).zero? || (!strictness && yes.positive?)
               exact.each { exactness[_1] += _2 }
               state[:exactness] = exactness
+              state[:error] = error
               return coerced
             elsif maybe.positive?
-              alternatives << [[-yes, -maybe, no], exact, coerced]
+              alternatives << [[-yes, -maybe, no], exact, coerced, error]
             end
           end
 
@@ -188,8 +190,9 @@ module OpenAI
             exactness[:no] += 1
             state[:error] = ArgumentError.new("no matching variant for #{value.inspect}")
             value
-          in [[_, exact, coerced], *]
+          in [[_, exact, coerced, error], *]
             exact.each { exactness[_1] += _2 }
+            state[:error] = error
             coerced
           end
             .tap { state[:exactness] = exactness }

--- a/test/openai/internal/type/base_model_test.rb
+++ b/test/openai/internal/type/base_model_test.rb
@@ -345,6 +345,15 @@ class OpenAI::Test::BaseModelTest < Minitest::Test
     optional :b, M6
   end
 
+  class M7 < OpenAI::Internal::Type::BaseModel
+    required :a, Integer
+  end
+
+  class M8 < OpenAI::Internal::Type::BaseModel
+    optional :item, M7
+    optional :items, OpenAI::Internal::Type::ArrayOf[M7]
+  end
+
   def test_coerce
     cases = {
       [M1, {}] => [{yes: 1, no: 1}, {}],
@@ -446,6 +455,23 @@ class OpenAI::Test::BaseModelTest < Minitest::Test
         end
       end
     end
+  end
+
+  def test_constructor_stores_coerced_nested_models
+    model = M8.new(item: {a: 1}, items: [{a: 2}])
+
+    assert_instance_of(M7, model.item)
+    assert_instance_of(M7, model.items.fetch(0))
+    assert_instance_of(M7, model.to_h.fetch(:item))
+    assert_instance_of(M7, model.to_h.fetch(:items).fetch(0))
+
+    model.item = {a: 3}
+    model.items = [{a: 4}]
+
+    assert_instance_of(M7, model.item)
+    assert_instance_of(M7, model.items.fetch(0))
+    assert_instance_of(M7, model.to_h.fetch(:item))
+    assert_instance_of(M7, model.to_h.fetch(:items).fetch(0))
   end
 
   def test_inplace_modification

--- a/test/openai/internal/type/base_model_test.rb
+++ b/test/openai/internal/type/base_model_test.rb
@@ -354,6 +354,25 @@ class OpenAI::Test::BaseModelTest < Minitest::Test
     optional :items, OpenAI::Internal::Type::ArrayOf[M7]
   end
 
+  class M9 < OpenAI::Internal::Type::BaseModel
+    required :a, Integer
+    required :b, Integer
+  end
+
+  module NestedUnion
+    extend OpenAI::Internal::Type::Union
+
+    variant Integer
+    variant M9
+  end
+
+  class M10 < OpenAI::Internal::Type::BaseModel
+    optional :item, M9
+    optional :items, OpenAI::Internal::Type::ArrayOf[M9]
+    optional :map, OpenAI::Internal::Type::HashOf[M9]
+    optional :choice, NestedUnion
+  end
+
   def test_coerce
     cases = {
       [M1, {}] => [{yes: 1, no: 1}, {}],
@@ -457,21 +476,77 @@ class OpenAI::Test::BaseModelTest < Minitest::Test
     end
   end
 
-  def test_constructor_stores_coerced_nested_models
-    model = M8.new(item: {a: 1}, items: [{a: 2}])
+  def test_constructor_and_assignment_store_coerced_nested_models
+    model = M8.new(item: {a: "1"}, items: [{a: "2"}])
 
     assert_instance_of(M7, model.item)
     assert_instance_of(M7, model.items.fetch(0))
     assert_instance_of(M7, model.to_h.fetch(:item))
     assert_instance_of(M7, model.to_h.fetch(:items).fetch(0))
+    assert_equal(1, model.item.a)
+    assert_equal(2, model.items.fetch(0).a)
 
-    model.item = {a: 3}
-    model.items = [{a: 4}]
+    model.item = {a: "3"}
+    model.items = [{a: "4"}]
 
     assert_instance_of(M7, model.item)
     assert_instance_of(M7, model.items.fetch(0))
     assert_instance_of(M7, model.to_h.fetch(:item))
     assert_instance_of(M7, model.to_h.fetch(:items).fetch(0))
+    assert_equal(3, model.item.a)
+    assert_equal(4, model.items.fetch(0).a)
+    assert_equal({item: {a: "3"}, items: [{a: "4"}]}, model.deep_to_h)
+    assert_equal({item: {a: "3"}, items: [{a: "4"}]}, JSON.parse(model.to_json, symbolize_names: true))
+  end
+
+  def test_setter_preserves_already_coerced_nested_model_identity
+    item = M7.new(a: 1)
+    items = [item]
+    model = M8.new(item: item, items: items)
+
+    assert_same(item, model.item)
+    assert_same(items, model.items)
+    assert_same(item, model.items.fetch(0))
+  end
+
+  def test_coerce_preserves_already_coerced_model_identity
+    model = M7.new(a: 1)
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+    assert_same(model, OpenAI::Internal::Type::Converter.coerce(M7, model, state: state))
+  end
+
+  def test_failed_nested_model_coercion_preserves_input_and_error
+    item = {a: "one"}
+    items = [{a: "two"}]
+    model = M8.new(item: item, items: items)
+
+    assert_same(item, model.to_h.fetch(:item))
+    assert_same(items, model.to_h.fetch(:items))
+    assert_raises(OpenAI::Errors::ConversionError) { model.item }
+    assert_raises(OpenAI::Errors::ConversionError) { model.items }
+  end
+
+  def test_later_success_does_not_clear_composite_coercion_errors
+    invalid = {a: "one", b: "2"}
+    valid = {a: "3", b: "4"}
+    items = [invalid, valid]
+    map = {invalid: invalid, valid: valid}
+    model = M10.new(item: invalid, items: items, map: map)
+
+    assert_same(invalid, model.to_h.fetch(:item))
+    assert_same(items, model.to_h.fetch(:items))
+    assert_same(map, model.to_h.fetch(:map))
+    assert_raises(OpenAI::Errors::ConversionError) { model.item }
+    assert_raises(OpenAI::Errors::ConversionError) { model.items }
+    assert_raises(OpenAI::Errors::ConversionError) { model.map }
+  end
+
+  def test_rejected_union_variant_does_not_override_selected_coercion
+    model = M10.new(choice: "1")
+
+    assert_equal(1, model.choice)
+    assert_equal(1, model.to_h.fetch(:choice))
   end
 
   def test_inplace_modification
@@ -581,6 +656,14 @@ class OpenAI::Test::UnionTest < Minitest::Test
     rescue OpenAI::Errors::ConversionError => e
       assert_kind_of(ArgumentError, e.cause)
     end
+  end
+
+  def test_discriminated_coercion_preserves_strictness
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+    OpenAI::Internal::Type::Converter.coerce(U2, {type: :a}, state: state)
+
+    assert_equal(true, state.fetch(:strictness))
   end
 
   def test_coerce

--- a/test/openai/internal/type/base_model_test.rb
+++ b/test/openai/internal/type/base_model_test.rb
@@ -125,6 +125,24 @@ class OpenAI::Test::PrimitiveModelTest < Minitest::Test
     end
   end
 
+  def test_coerce_with_error_isolates_each_attempt
+    previous_error = RuntimeError.new("previous")
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    state[:error] = previous_error
+
+    value, error = OpenAI::Internal::Type::Converter.coerce_with_error(Integer, "one", state: state)
+
+    assert_equal("one", value)
+    assert_instance_of(ArgumentError, error)
+    assert_same(previous_error, state.fetch(:error))
+
+    value, error = OpenAI::Internal::Type::Converter.coerce_with_error(Integer, "1", state: state)
+
+    assert_equal(1, value)
+    assert_nil(error)
+    assert_same(previous_error, state.fetch(:error))
+  end
+
   def test_dump_retry
     types = [
       OpenAI::Internal::Type::Unknown,
@@ -265,6 +283,9 @@ class OpenAI::Test::CollectionModelTest < Minitest::Test
   A3 = OpenAI::Internal::Type::ArrayOf[Integer, nil?: true]
   H3 = OpenAI::Internal::Type::HashOf[Integer, nil?: true]
 
+  A4 = OpenAI::Internal::Type::ArrayOf[OpenAI::Internal::Type::Unknown]
+  H4 = OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]
+
   def test_coerce
     cases = {
       [A1, []] => [{yes: 1}, []],
@@ -298,6 +319,21 @@ class OpenAI::Test::CollectionModelTest < Minitest::Test
         OpenAI::Internal::Type::Converter.coerce(target, input, state: state) => ^expect
         state.fetch(:exactness).filter { _2.nonzero? }.to_h => ^exactness
       end
+    end
+  end
+
+  def test_collection_matchers_respect_nullable_items_and_item_types
+    cases = {
+      [A1, [nil]] => false,
+      [A3, [nil]] => true,
+      [A4, [nil]] => true,
+      [H1, {item: nil}] => false,
+      [H3, {item: nil}] => true,
+      [H4, {item: nil}] => true
+    }
+
+    cases.each do |(target, input), expected|
+      assert_equal(expected, target.public_send(:===, input))
     end
   end
 end
@@ -343,34 +379,6 @@ class OpenAI::Test::BaseModelTest < Minitest::Test
   class M6 < M1
     required :a, OpenAI::Internal::Type::ArrayOf[M6]
     optional :b, M6
-  end
-
-  class M7 < OpenAI::Internal::Type::BaseModel
-    required :a, Integer
-  end
-
-  class M8 < OpenAI::Internal::Type::BaseModel
-    optional :item, M7
-    optional :items, OpenAI::Internal::Type::ArrayOf[M7]
-  end
-
-  class M9 < OpenAI::Internal::Type::BaseModel
-    required :a, Integer
-    required :b, Integer
-  end
-
-  module NestedUnion
-    extend OpenAI::Internal::Type::Union
-
-    variant Integer
-    variant M9
-  end
-
-  class M10 < OpenAI::Internal::Type::BaseModel
-    optional :item, M9
-    optional :items, OpenAI::Internal::Type::ArrayOf[M9]
-    optional :map, OpenAI::Internal::Type::HashOf[M9]
-    optional :choice, NestedUnion
   end
 
   def test_coerce
@@ -474,79 +482,6 @@ class OpenAI::Test::BaseModelTest < Minitest::Test
         end
       end
     end
-  end
-
-  def test_constructor_and_assignment_store_coerced_nested_models
-    model = M8.new(item: {a: "1"}, items: [{a: "2"}])
-
-    assert_instance_of(M7, model.item)
-    assert_instance_of(M7, model.items.fetch(0))
-    assert_instance_of(M7, model.to_h.fetch(:item))
-    assert_instance_of(M7, model.to_h.fetch(:items).fetch(0))
-    assert_equal(1, model.item.a)
-    assert_equal(2, model.items.fetch(0).a)
-
-    model.item = {a: "3"}
-    model.items = [{a: "4"}]
-
-    assert_instance_of(M7, model.item)
-    assert_instance_of(M7, model.items.fetch(0))
-    assert_instance_of(M7, model.to_h.fetch(:item))
-    assert_instance_of(M7, model.to_h.fetch(:items).fetch(0))
-    assert_equal(3, model.item.a)
-    assert_equal(4, model.items.fetch(0).a)
-    assert_equal({item: {a: "3"}, items: [{a: "4"}]}, model.deep_to_h)
-    assert_equal({item: {a: "3"}, items: [{a: "4"}]}, JSON.parse(model.to_json, symbolize_names: true))
-  end
-
-  def test_setter_preserves_already_coerced_nested_model_identity
-    item = M7.new(a: 1)
-    items = [item]
-    model = M8.new(item: item, items: items)
-
-    assert_same(item, model.item)
-    assert_same(items, model.items)
-    assert_same(item, model.items.fetch(0))
-  end
-
-  def test_coerce_preserves_already_coerced_model_identity
-    model = M7.new(a: 1)
-    state = OpenAI::Internal::Type::Converter.new_coerce_state
-
-    assert_same(model, OpenAI::Internal::Type::Converter.coerce(M7, model, state: state))
-  end
-
-  def test_failed_nested_model_coercion_preserves_input_and_error
-    item = {a: "one"}
-    items = [{a: "two"}]
-    model = M8.new(item: item, items: items)
-
-    assert_same(item, model.to_h.fetch(:item))
-    assert_same(items, model.to_h.fetch(:items))
-    assert_raises(OpenAI::Errors::ConversionError) { model.item }
-    assert_raises(OpenAI::Errors::ConversionError) { model.items }
-  end
-
-  def test_later_success_does_not_clear_composite_coercion_errors
-    invalid = {a: "one", b: "2"}
-    valid = {a: "3", b: "4"}
-    items = [invalid, valid]
-    map = {invalid: invalid, valid: valid}
-    model = M10.new(item: invalid, items: items, map: map)
-
-    assert_same(invalid, model.to_h.fetch(:item))
-    assert_same(items, model.to_h.fetch(:items))
-    assert_same(map, model.to_h.fetch(:map))
-    assert_raises(OpenAI::Errors::ConversionError) { model.item }
-    assert_raises(OpenAI::Errors::ConversionError) { model.items }
-    assert_raises(OpenAI::Errors::ConversionError) { model.map }
-  end
-
-  def test_rejected_union_variant_does_not_override_selected_coercion
-    model = M10.new(choice: "1")
-
-    assert_equal(1, model.choice)
-    assert_equal(1, model.to_h.fetch(:choice))
   end
 
   def test_inplace_modification

--- a/test/openai/internal/type/nested_model_coercion_test.rb
+++ b/test/openai/internal/type/nested_model_coercion_test.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::NestedModelCoercionTest < Minitest::Test
+  class Item < OpenAI::Internal::Type::BaseModel
+    required :a, Integer
+    required :b, Integer
+  end
+
+  module ItemOrInteger
+    extend OpenAI::Internal::Type::Union
+
+    variant Integer
+    variant Item
+  end
+
+  module ReversedItemOrInteger
+    extend OpenAI::Internal::Type::Union
+
+    variant Item
+    variant Integer
+  end
+
+  class Container < OpenAI::Internal::Type::BaseModel
+    optional :item, Item
+    optional :items, OpenAI::Internal::Type::ArrayOf[Item]
+    optional :map, OpenAI::Internal::Type::HashOf[Item]
+    optional :nullable_items, OpenAI::Internal::Type::ArrayOf[Item, nil?: true]
+    optional :nullable_map, OpenAI::Internal::Type::HashOf[Item, nil?: true]
+    optional :choice, ItemOrInteger
+    optional :reversed_choice, ReversedItemOrInteger
+  end
+
+  def test_constructor_and_assignment_store_coerced_nested_models
+    model = Container.new(item: {a: "1", b: "2"}, items: [{a: "3", b: "4"}])
+
+    assert_instance_of(Item, model.item)
+    assert_instance_of(Item, model.items.fetch(0))
+    assert_instance_of(Item, model.to_h.fetch(:item))
+    assert_instance_of(Item, model.to_h.fetch(:items).fetch(0))
+    assert_equal([1, 2], [model.item.a, model.item.b])
+    assert_equal([3, 4], [model.items.fetch(0).a, model.items.fetch(0).b])
+
+    model.item = {a: "5", b: "6"}
+    model.items = [{a: "7", b: "8"}]
+
+    assert_instance_of(Item, model.item)
+    assert_instance_of(Item, model.items.fetch(0))
+    assert_instance_of(Item, model.to_h.fetch(:item))
+    assert_instance_of(Item, model.to_h.fetch(:items).fetch(0))
+    assert_equal([5, 6], [model.item.a, model.item.b])
+    assert_equal([7, 8], [model.items.fetch(0).a, model.items.fetch(0).b])
+  end
+
+  def test_constructor_and_assignment_coerce_nested_maps_and_unions
+    map = {"first" => {a: "1", b: "2"}}
+    choice = {a: "3", b: "4"}
+    model = Container.new(map: map, choice: choice, reversed_choice: choice)
+
+    assert_instance_of(Item, model.map.fetch(:first))
+    assert_instance_of(Item, model.choice)
+    assert_instance_of(Item, model.reversed_choice)
+    assert_equal([1, 2], [model.map.fetch(:first).a, model.map.fetch(:first).b])
+    assert_equal([3, 4], [model.choice.a, model.choice.b])
+
+    model.map = {"second" => {a: "5", b: "6"}}
+    model.choice = {a: "7", b: "8"}
+    model.reversed_choice = {a: "9", b: "10"}
+
+    assert_instance_of(Item, model.map.fetch(:second))
+    assert_instance_of(Item, model.choice)
+    assert_instance_of(Item, model.reversed_choice)
+    assert_equal(
+      {
+        map: {second: {a: "5", b: "6"}},
+        choice: {a: "7", b: "8"},
+        reversed_choice: {a: "9", b: "10"}
+      },
+      model.deep_to_h
+    )
+    assert_equal(model.deep_to_h, JSON.parse(model.to_json, symbolize_names: true))
+  end
+
+  def test_setter_preserves_already_coerced_nested_model_identity
+    item = Item.new(a: 1, b: 2)
+    items = [item]
+    map = {item: item}
+    model = Container.new(item: item, items: items, map: map)
+
+    assert_same(item, model.item)
+    assert_same(items, model.items)
+    assert_same(item, model.items.fetch(0))
+    assert_same(map, model.map)
+    assert_same(item, model.map.fetch(:item))
+  end
+
+  def test_setter_preserves_nullable_collection_identity
+    item = Item.new(a: 1, b: 2)
+    items = [item, nil]
+    map = {item: item, empty: nil}
+    model = Container.new(nullable_items: items, nullable_map: map)
+
+    assert_same(items, model.nullable_items)
+    assert_same(map, model.nullable_map)
+  end
+
+  def test_coerce_preserves_already_coerced_model_identity
+    model = Item.new(a: 1, b: 2)
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+    assert_same(model, OpenAI::Internal::Type::Converter.coerce(Item, model, state: state))
+  end
+
+  def test_successful_nested_coercion_isolated_from_raw_input_mutation
+    item = {a: "1", b: "2"}
+    items = [{a: "3", b: "4"}]
+    map = {item: {a: "5", b: "6"}}
+    model = Container.new(item: item, items: items, map: map)
+
+    item[:a] = "changed"
+    items.fetch(0)[:a] = "changed"
+    items << {a: "changed", b: "changed"}
+    map.fetch(:item)[:a] = "changed"
+    map[:later] = {a: "changed", b: "changed"}
+
+    assert_equal(1, model.item.a)
+    assert_equal(3, model.items.fetch(0).a)
+    assert_equal(1, model.items.size)
+    assert_equal(5, model.map.fetch(:item).a)
+    refute(model.map.key?(:later))
+  end
+
+  def test_nested_model_equality_and_hash_use_stored_coerced_values
+    left = Container.new(item: {a: "1", b: "2"}, items: [{a: "3", b: "4"}])
+    right = Container.new(item: {a: "1", b: "2"}, items: [{a: "3", b: "4"}])
+
+    assert_equal(left, right)
+    assert_equal(left.hash, right.hash)
+  end
+
+  def test_failed_nested_model_coercion_preserves_input_and_error
+    item = {a: "one", b: "2"}
+    items = [{a: "1", b: "two"}]
+    model = Container.new(item: item, items: items)
+
+    assert_same(item, model.to_h.fetch(:item))
+    assert_same(items, model.to_h.fetch(:items))
+    assert_raises(OpenAI::Errors::ConversionError) { model.item }
+    assert_raises(OpenAI::Errors::ConversionError) { model.items }
+  end
+
+  def test_assignment_replaces_previous_success_and_error_status
+    valid = {a: "1", b: "2"}
+    invalid = {a: "one", b: "2"}
+    model = Container.new
+
+    model.item = valid
+    assert_instance_of(Item, model.item)
+    model.item = invalid
+    assert_same(invalid, model.to_h.fetch(:item))
+    assert_raises(OpenAI::Errors::ConversionError) { model.item }
+    model.item = valid
+    assert_instance_of(Item, model.item)
+
+    model.items = [valid]
+    assert_instance_of(Item, model.items.fetch(0))
+    invalid_items = [invalid]
+    model.items = invalid_items
+    assert_same(invalid_items, model.to_h.fetch(:items))
+    assert_raises(OpenAI::Errors::ConversionError) { model.items }
+    model.items = [valid]
+    assert_instance_of(Item, model.items.fetch(0))
+
+    model.map = {valid: valid}
+    assert_instance_of(Item, model.map.fetch(:valid))
+    invalid_map = {invalid: invalid}
+    model.map = invalid_map
+    assert_same(invalid_map, model.to_h.fetch(:map))
+    assert_raises(OpenAI::Errors::ConversionError) { model.map }
+    model.map = {valid: valid}
+    assert_instance_of(Item, model.map.fetch(:valid))
+
+    model.choice = valid
+    assert_instance_of(Item, model.choice)
+    model.choice = invalid
+    assert_same(invalid, model.to_h.fetch(:choice))
+    assert_raises(OpenAI::Errors::ConversionError) { model.choice }
+    model.choice = valid
+    assert_instance_of(Item, model.choice)
+  end
+
+  def test_composite_coercion_errors_do_not_depend_on_field_or_item_order
+    valid = {a: "1", b: "2"}
+    invalid_values = [{a: "one", b: "2"}, {a: "1", b: "two"}]
+
+    invalid_values.each do |invalid|
+      [[invalid, valid], [valid, invalid]].each do |items|
+        map = items.each_with_index.to_h { |value, index| [index, value] }
+        model = Container.new(item: invalid, items: items, map: map)
+
+        assert_same(invalid, model.to_h.fetch(:item))
+        assert_same(items, model.to_h.fetch(:items))
+        assert_same(map, model.to_h.fetch(:map))
+        assert_raises(OpenAI::Errors::ConversionError) { model.item }
+        assert_raises(OpenAI::Errors::ConversionError) { model.items }
+        assert_raises(OpenAI::Errors::ConversionError) { model.map }
+      end
+    end
+  end
+
+  def test_rejected_union_variant_does_not_override_selected_coercion
+    model = Container.new(choice: "1", reversed_choice: "2")
+
+    assert_equal(1, model.choice)
+    assert_equal(1, model.to_h.fetch(:choice))
+    assert_equal(2, model.reversed_choice)
+    assert_equal(2, model.to_h.fetch(:reversed_choice))
+  end
+
+  def test_selected_union_variant_preserves_its_conversion_error
+    choice = {a: "one", b: "2"}
+    reversed_choice = {a: "1", b: "two"}
+    model = Container.new(choice: choice, reversed_choice: reversed_choice)
+
+    assert_same(choice, model.to_h.fetch(:choice))
+    assert_same(reversed_choice, model.to_h.fetch(:reversed_choice))
+    assert_raises(OpenAI::Errors::ConversionError) { model.choice }
+    assert_raises(OpenAI::Errors::ConversionError) { model.reversed_choice }
+  end
+end

--- a/test/openai/internal/type/nested_model_coercion_test.rb
+++ b/test/openai/internal/type/nested_model_coercion_test.rb
@@ -32,6 +32,11 @@ class OpenAI::Test::NestedModelCoercionTest < Minitest::Test
     optional :reversed_choice, ReversedItemOrInteger
   end
 
+  class NullableContainer < OpenAI::Internal::Type::BaseModel
+    optional :optional_item, Item
+    required :nullable_item, Item, nil?: true
+  end
+
   def test_constructor_and_assignment_store_coerced_nested_models
     model = Container.new(item: {a: "1", b: "2"}, items: [{a: "3", b: "4"}])
 
@@ -103,6 +108,23 @@ class OpenAI::Test::NestedModelCoercionTest < Minitest::Test
 
     assert_same(items, model.nullable_items)
     assert_same(map, model.nullable_map)
+  end
+
+  def test_constructor_and_assignment_accept_nil_for_optional_and_nilable_models
+    model = NullableContainer.new(optional_item: nil, nullable_item: nil)
+
+    assert_nil(model.optional_item)
+    assert_nil(model.nullable_item)
+    assert_equal({optional_item: nil, nullable_item: nil}, model.to_h)
+
+    model.optional_item = Item.new(a: 1, b: 2)
+    model.nullable_item = Item.new(a: 3, b: 4)
+    model.optional_item = nil
+    model.nullable_item = nil
+
+    assert_nil(model.optional_item)
+    assert_nil(model.nullable_item)
+    assert_equal({optional_item: nil, nullable_item: nil}, model.to_h)
   end
 
   def test_coerce_preserves_already_coerced_model_identity


### PR DESCRIPTION
## Summary

Fixes nested `BaseModel` coercion so generated setters store successfully coerced model values instead of preserving raw hashes and arrays.

## Root cause

The generated setter assigned the return value of `Hash#store` to `error`. Because `Hash#store` returns the value it stores, the successful branch that stored `coerced` was unreachable.

Composite converters also shared one mutable error slot. A later successful field or collection item could clear an earlier error, while a rejected union variant could overwrite the error state of the selected variant.

## Changes

- Store successfully coerced nested models and collections.
- Preserve identity for values that already satisfy their target type.
- Preserve raw input and conversion errors when any model field, array item, or map value fails coercion.
- Isolate errors from rejected union variants and retain the selected variant's state.
- Preserve existing model identity during direct `BaseModel` coercion.
- Preserve union strictness for discriminator-resolved variants.

## Before / after

```ruby
require "openai"

class Item < OpenAI::BaseModel
  required :name, String
end

class Container < OpenAI::BaseModel
  required :item, Item
  required :items, OpenAI::ArrayOf[Item]
end

container = Container.new(
  item: {name: "single"},
  items: [{name: "array"}]
)
```

Before this fix, the generated setter returned raw hashes:

```ruby
container.item.class
# => Hash

container.items.first.class
# => Hash
```

After this fix, successful coercion is stored:

```ruby
container.item.class
# => Item

container.items.first.class
# => Item
```

## Validation

- `./scripts/test` — 437 runs, 1,359 assertions, 0 failures
- `./scripts/lint` — RuboCop, Sorbet, and Steep all pass
