### PR TITLE
ci: Add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - ruby
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- add CodeQL advanced setup for Ruby source and GitHub Actions workflows
- run analysis on pushes to `main`
- scope workflow permissions to read repository metadata and upload code-scanning results
- pin the CodeQL action to v4.37.0 by commit SHA

## Why

This enables GitHub code scanning for the repository while matching the existing hardened GitHub Actions conventions. Scans run after changes land on `main`, without a scheduled or pull-request trigger.

## Impact

CodeQL findings will appear in GitHub code scanning after each push to `main`. The workflow does not affect the gem runtime or test suite.

## Validation

- `actionlint .github/workflows/codeql.yml`
- Ruby YAML parse
- `git diff --check`