### PR TITLE
chore: fix CodeQL parsing of Sorbet fallback

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -926,7 +926,7 @@ module OpenAI
         # @api private
         #
         # @return [Object]
-        def to_sorbet_type = raise NotImplementedError
+        def to_sorbet_type = raise(NotImplementedError)
 
         class << self
           # @api private


### PR DESCRIPTION
## Summary

- parenthesize the `NotImplementedError` argument in the endless Sorbet fallback method
- preserve runtime behavior while allowing CodeQL to parse `lib/openai/internal/util.rb`

## Rationale

The existing `def to_sorbet_type = raise NotImplementedError` is valid Ruby, but CodeQL's underlying tree-sitter Ruby parser misparses a command-style call on the right-hand side of an endless method definition. CodeQL 2.26.0 consequently reports an extraction warning at this line and may provide incomplete analysis around it.

Using `raise(NotImplementedError)` is the minimal workaround recommended in [github/codeql#14279](https://github.com/github/codeql/issues/14279) and tracked upstream in [tree-sitter-ruby#242](https://github.com/tree-sitter/tree-sitter-ruby/issues/242). It does not change runtime behavior.

## Validation

- `ruby -c lib/openai/internal/util.rb`
- `bundle exec rake test TEST=test/openai/internal/util_test.rb` (36 runs, 154 assertions)
- `bundle exec rubocop lib/openai/internal/util.rb --except Lint/RedundantCopDisableDirective,Layout/LineLength`
- `git diff --check`
