### PR TITLE
test: avoid regex in multipart boundary test

### DIFF
--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -228,10 +228,11 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
       {"content-type" => "multipart/form-data"},
       Pathname(__FILE__)
     )
-    assert_pattern do
-      headers.fetch("content-type") => /boundary=(.+)$/
-    end
-    field, = Regexp.last_match.captures
+    boundary_prefix = "multipart/form-data; boundary="
+    content_type = headers.fetch("content-type")
+    assert(content_type.start_with?(boundary_prefix))
+    field = content_type.delete_prefix(boundary_prefix)
+    refute_empty(field)
     assert(field.length < 70 - 6)
   end
 


### PR DESCRIPTION
## Summary

- replace the CodeQL-flagged multipart boundary regex with linear-time string operations
- continue asserting the exact multipart prefix, a non-empty boundary, and the RFC length limit
- keep the change test-only with no SDK runtime behavior changes

Addresses [code scanning alert #1](https://github.com/openai/openai-ruby/security/code-scanning/1).

## Root cause

The multipart encoding test extracted a library-generated boundary with `/boundary=(.+)$/`. CodeQL classified that regex as potentially polynomial on uncontrolled data. The boundary is fixed-length and generated internally, and the gem requires Ruby 3.2+, but the regex is unnecessary; direct prefix validation and removal express the invariant more precisely and avoid the flagged sink entirely.

## Validation

- `bundle exec rake test TEST=test/openai/internal/util_test.rb` — 36 runs, 156 assertions, 0 failures
- `bundle exec rake lint:rubocop` — 2,537 files inspected, no offenses
- `bundle exec ruby -c test/openai/internal/util_test.rb` — syntax OK
- `git diff --check` — passed

The full generated-resource suite was also attempted, but it requires the external Steady mock server at `localhost:4010`; without that server, unrelated API tests fail with connection errors.