### PR TITLE
Clean up CI triggers and required checks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -34,14 +34,12 @@ jobs:
       - run: bundle install
 
       - name: Get GitHub OIDC token
-        if: ${{ !startsWith(github.ref, 'refs/heads/stl/') }}
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: core.setOutput('github_token', await core.getIDToken());
 
       - name: Build and upload gem artifacts
-        if: ${{ !startsWith(github.ref, 'refs/heads/stl/') }}
         env:
           URL: https://pkg.stainless.com/s
           AUTH: ${{ steps.github-oidc.outputs.github_token }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,136 @@
+name: CI checks
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: Runner label for CI jobs
+        required: true
+        type: string
+      publish-stainless-artifact:
+        description: Build and upload an installable Stainless artifact
+        required: true
+        type: boolean
+
+permissions: {}
+
+jobs:
+  stainless-artifact:
+    timeout-minutes: 10
+    name: stainless artifact
+    if: inputs.publish-stainless-artifact
+    permissions:
+      contents: read
+      id-token: write # Authenticate the artifact upload to pkg.stainless.com.
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
+        with:
+          bundler-cache: false
+      - run: bundle install
+
+      - name: Get GitHub OIDC token
+        if: ${{ !startsWith(github.ref, 'refs/heads/stl/') }}
+        id: github-oidc
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: core.setOutput('github_token', await core.getIDToken());
+
+      - name: Build and upload gem artifacts
+        if: ${{ !startsWith(github.ref, 'refs/heads/stl/') }}
+        env:
+          URL: https://pkg.stainless.com/s
+          AUTH: ${{ steps.github-oidc.outputs.github_token }}
+          SHA: ${{ github.sha }}
+          PACKAGE_NAME: openai
+        run: ./scripts/utils/upload-artifact.sh
+
+  lint:
+    timeout-minutes: 10
+    name: lint
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+      - run: bundle install
+      - name: Run lints
+        run: ./scripts/lint
+
+  package:
+    timeout-minutes: 10
+    name: package
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+      - run: bundle install
+      - name: Build gem
+        run: bundle exec rake build:gem
+
+  test-ruby:
+    timeout-minutes: 10
+    name: test (ruby ${{ matrix.ruby-version }})
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: false
+      - run: bundle install
+      - name: Run tests
+        run: ./scripts/test
+
+  required:
+    timeout-minutes: 5
+    name: ci-required
+    # Keep branch protection on one stable context as the job matrix evolves.
+    needs:
+      - stainless-artifact
+      - lint
+      - package
+      - test-ruby
+    if: ${{ always() }}
+    permissions: {}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Check required job results
+        env:
+          ARTIFACT_RESULT: ${{ needs.stainless-artifact.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
+          TEST_RESULT: ${{ needs.test-ruby.result }}
+        run: |
+          test "$ARTIFACT_RESULT" = "success" || test "$ARTIFACT_RESULT" = "skipped"
+          test "$LINT_RESULT" = "success"
+          test "$PACKAGE_RESULT" = "success"
+          test "$TEST_RESULT" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,69 +1,30 @@
 name: CI
+
+# Pull requests are validated by the pull_request run. Limiting push runs to
+# long-lived branches avoids duplicate checks for same-repository PR branches.
 on:
   push:
     branches:
-      - '**'
-      - '!integrated/**'
-      - '!stl-preview-head/**'
-      - '!stl-preview-base/**'
-      - '!generated'
-      - '!codegen/**'
-      - 'codegen/stl/**'
+      - main
+      - next
   pull_request:
-    branches-ignore:
-      - 'stl-preview-head/**'
-      - 'stl-preview-base/**'
+    branches:
+      - main
+      - next
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  build:
-    timeout-minutes: 10
-    name: build
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: |-
-      github.repository == 'stainless-sdks/openai-ruby' &&
-      (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
-        with:
-          bundler-cache: false
-      - run: |-
-          bundle install
-
-      - name: Get GitHub OIDC Token
-        if: |-
-          github.repository == 'stainless-sdks/openai-ruby' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        id: github-oidc
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: core.setOutput('github_token', await core.getIDToken());
-
-      - name: Build and upload gem artifacts
-        if: |-
-          github.repository == 'stainless-sdks/openai-ruby' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        env:
-          URL: https://pkg.stainless.com/s
-          AUTH: ${{ steps.github-oidc.outputs.github_token }}
-          SHA: ${{ github.sha }}
-          PACKAGE_NAME: openai
-        run: ./scripts/utils/upload-artifact.sh
   lint:
     timeout-minutes: 10
     name: lint
     permissions:
       contents: read
-    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,13 +39,33 @@ jobs:
 
       - name: Run lints
         run: ./scripts/lint
+
+  package:
+    timeout-minutes: 10
+    name: package
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+      - run: bundle install
+      - name: Build gem
+        run: bundle exec rake build:gem
+
   test-ruby:
     timeout-minutes: 10
     name: test (ruby ${{ matrix.ruby-version }})
     permissions:
       contents: read
-    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -103,12 +84,25 @@ jobs:
 
       - name: Run tests
         run: ./scripts/test
-  test:
-    name: test
-    needs: test-ruby
-    if: ${{ always() && needs.test-ruby.result != 'skipped' }}
+
+  required:
+    timeout-minutes: 5
+    name: ci-required
+    # Keep branch protection on one stable context as the job matrix evolves.
+    needs:
+      - lint
+      - package
+      - test-ruby
+    if: ${{ always() }}
     permissions: {}
-    runs-on: ${{ github.repository == 'stainless-sdks/openai-ruby' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
-      - if: ${{ needs.test-ruby.result == 'failure' || needs.test-ruby.result == 'cancelled' }}
-        run: exit 1
+      - name: Check required job results
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
+          TEST_RESULT: ${{ needs.test-ruby.result }}
+        run: |
+          test "$LINT_RESULT" = "success"
+          test "$PACKAGE_RESULT" = "success"
+          test "$TEST_RESULT" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,6 @@ jobs:
         ${{
           github.repository == 'stainless-sdks/openai-ruby' &&
           (github.event_name == 'push' || github.event.pull_request.head.repo.fork) &&
-          (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+          (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata') &&
+          !startsWith(github.ref, 'refs/heads/stl/')
         }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,23 @@
 name: CI
 
-# Pull requests are validated by the pull_request run. Limiting push runs to
-# long-lived branches avoids duplicate checks for same-repository PR branches.
+# This workflow is shared by the Stainless staging repository and the OpenAI
+# production repository. Stainless feature branches use push runs so they can
+# publish installable artifacts; production feature branches use PR runs so a
+# commit is validated only once.
 on:
   push:
     branches:
-      - main
-      - next
+      - '**'
+      - '!integrated/**'
+      - '!stl-preview-head/**'
+      - '!stl-preview-base/**'
+      - '!generated'
+      - '!codegen/**'
+      - 'codegen/stl/**'
   pull_request:
-    branches:
-      - main
-      - next
+    branches-ignore:
+      - 'stl-preview-head/**'
+      - 'stl-preview-base/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,90 +26,24 @@ concurrency:
 permissions: {}
 
 jobs:
-  lint:
-    timeout-minutes: 10
-    name: lint
+  checks:
+    name: ci
+    if: >-
+      (startsWith(github.repository, 'stainless-sdks/') &&
+        (github.event_name == 'push' || github.event.pull_request.head.repo.fork)) ||
+      (!startsWith(github.repository, 'stainless-sdks/') &&
+        (github.event_name == 'pull_request' ||
+          github.ref == 'refs/heads/main' ||
+          github.ref == 'refs/heads/next'))
     permissions:
       contents: read
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
-        with:
-          bundler-cache: false
-      - run: |-
-          bundle install
-
-      - name: Run lints
-        run: ./scripts/lint
-
-  package:
-    timeout-minutes: 10
-    name: package
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: false
-      - run: bundle install
-      - name: Build gem
-        run: bundle exec rake build:gem
-
-  test-ruby:
-    timeout-minutes: 10
-    name: test (ruby ${{ matrix.ruby-version }})
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0']
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: false
-      - run: |-
-          bundle install
-
-      - name: Run tests
-        run: ./scripts/test
-
-  required:
-    timeout-minutes: 5
-    name: ci-required
-    # Keep branch protection on one stable context as the job matrix evolves.
-    needs:
-      - lint
-      - package
-      - test-ruby
-    if: ${{ always() }}
-    permissions: {}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check required job results
-        env:
-          LINT_RESULT: ${{ needs.lint.result }}
-          PACKAGE_RESULT: ${{ needs.package.result }}
-          TEST_RESULT: ${{ needs.test-ruby.result }}
-        run: |
-          test "$LINT_RESULT" = "success"
-          test "$PACKAGE_RESULT" = "success"
-          test "$TEST_RESULT" = "success"
+      id-token: write # Allow the called artifact job to mint its Stainless upload token.
+    uses: ./.github/workflows/ci-checks.yml
+    with:
+      runner: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+      publish-stainless-artifact: >-
+        ${{
+          github.repository == 'stainless-sdks/openai-ruby' &&
+          (github.event_name == 'push' || github.event.pull_request.head.repo.fork) &&
+          (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+        }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -13,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # Fetch workflow metadata for CodeQL analysis.
+      contents: read # Check out and analyze repository contents.
+      security-events: write # Upload CodeQL results to code scanning.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- route the shared CI workflow by repository and event so each commit gets one authoritative check set
- keep OpenAI feature branches PR-authoritative while preserving Stainless feature-branch push validation
- retain Stainless Depot runners and OIDC-backed installable gem artifact uploads
- move the common lint, package, and Ruby 3.2–4.0 test matrix into a reusable workflow
- add a stable, fail-closed `ci / ci-required` branch-protection gate
- scan `main` pull requests with CodeQL and cancel stale runs

## Why
This workflow is shared byte-for-byte with `stainless-sdks/openai-ruby`. The previous shape launched both `push` and `pull_request` workflows for same-repository PRs, producing an ambiguous pile of successful and skipped checks. Simply limiting pushes to `main`/`next` would break Stainless: it validates generated feature branches on `push`, uses Depot, and publishes installable artifacts for those commits.

The router preserves both operating modes. On this repository, a feature-branch `push` collapses to one skipped `ci` router and the PR event runs the real checks. In Stainless, feature-branch pushes run the real checks and artifact publishing, while same-repository PR events collapse to the router. The production PR also shows `ci / stainless artifact` as explicitly skipped because that least-privilege OIDC job exists only for Stainless.

## Validation
- `actionlint` v1.7.12
- `zizmor --pedantic` (no findings)
- `./scripts/lint`
- `./scripts/test` (467 runs, 1,512 assertions)
- `bundle exec rake build:gem`
- live PR run: package, lint, Ruby 3.2–4.0, CodeQL security, Code Quality, and `ci / ci-required` all green

## Branch protection
Require the single `ci / ci-required` check. Keep the repository’s separate code-scanning rule for CodeQL rather than requiring individual matrix check names.