### PR TITLE
feat: require Ruby 3.3 or newer

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0']
+        ruby-version: ['3.3', '3.4', '4.0']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - "bin/*"
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 # Whether MFA is required or not should be left to the token configuration.
 Gemspec/RequireMFA:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 ## Setting up the environment
 
+See the [versioning policy](VERSIONING.md) before changing the public API,
+minimum Ruby version, dependencies, or release behavior.
+
 This repository contains a `.ruby-version` file, which should work with either [rbenv](https://github.com/rbenv/rbenv) or [asdf](https://github.com/asdf-vm/asdf) with the [ruby plugin](https://github.com/asdf-vm/asdf-ruby).
 
 Please follow the instructions for your preferred version manager to install the Ruby version specified in the `.ruby-version` file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAI Ruby API library
 
-The OpenAI Ruby library provides convenient access to the OpenAI REST API from any Ruby 3.2.0+ application. It ships with comprehensive types & docstrings in Yard, RBS, and RBI – [see below](https://github.com/openai/openai-ruby#Sorbet) for usage with Sorbet. The standard library's `net/http` is used as the HTTP transport, with connection pooling via the `connection_pool` gem.
+The OpenAI Ruby library provides convenient access to the OpenAI REST API from any Ruby 3.3.0+ application. It ships with comprehensive types & docstrings in Yard, RBS, and RBI – [see below](https://github.com/openai/openai-ruby#Sorbet) for usage with Sorbet. The standard library's `net/http` is used as the HTTP transport, with connection pooling via the `connection_pool` gem.
 
 ## Documentation
 
@@ -80,7 +80,7 @@ end
 
 ### File uploads
 
-Request parameters that correspond to file uploads can be passed as raw contents, a [`Pathname`](https://rubyapi.org/3.2/o/pathname) instance, [`StringIO`](https://rubyapi.org/3.2/o/stringio), or more.
+Request parameters that correspond to file uploads can be passed as raw contents, a [`Pathname`](https://rubyapi.org/3.3/o/pathname) instance, [`StringIO`](https://rubyapi.org/3.3/o/stringio), or more.
 
 ```ruby
 require "pathname"
@@ -633,13 +633,14 @@ openai.chat.completions.create(
 
 ## Versioning
 
-This package follows [SemVer](https://semver.org/spec/v2.0.0.html) conventions. As the library is in initial development and has a major version of `0`, APIs may change at any time.
-
-This package considers improvements to the (non-runtime) `*.rbi` and `*.rbs` type definitions to be non-breaking changes.
+This package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [versioning policy](VERSIONING.md) for how releases, breaking changes, Ruby support, dependencies, and type definitions are managed.
 
 ## Requirements
 
-Ruby 3.2.0 or higher.
+Ruby 3.3.0 or higher.
+
+Ruby 3.2 users can continue using v0.75.x, the final compatible release line.
+This line will not receive separate maintenance.
 
 ## Contributing
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,77 @@
+# Versioning policy
+
+The OpenAI Ruby SDK follows [Semantic Versioning](https://semver.org/). This
+policy covers the public gem API, supported Ruby runtimes, dependencies, and
+type definitions.
+
+## Gem releases
+
+| Change | While the gem is `0.x` | After `1.0` |
+| --- | --- | --- |
+| Backwards-compatible bug or security fix | Patch | Patch |
+| Additive endpoint, optional argument, response field, or public type | Minor | Minor |
+| Higher minimum Ruby version | Minor | Major by default |
+| Other user-visible breaking change | Minor, with migration guidance | Major |
+
+Breaking changes include removing or renaming public behavior and incompatible
+changes to required arguments, return types, exception families,
+serialization, retries, or authentication. A dependency upgrade follows the
+same rule: its version number does not determine the SDK release; its effect on
+SDK users does.
+
+Corrections to non-runtime RBI or RBS definitions are normally patches. Use a
+minor release when a type-only change is likely to create substantial new type
+errors for users.
+
+Security may require an accelerated breaking release, but an incompatible
+change is never shipped as a routine patch.
+
+## Ruby support
+
+The SDK supports released CRuby versions that are in Ruby Core's normal or
+security maintenance phases. An EOL Ruby may receive up to six months of grace
+only through an explicit SDK and Security exception. See [Ruby maintenance
+branches](https://www.ruby-lang.org/en/downloads/branches/) for the upstream
+lifecycle.
+
+The current supported versions are Ruby 3.3, 3.4, and 4.0. The authoritative
+minimum is `required_ruby_version` in `openai.gemspec`.
+
+When the minimum Ruby version changes:
+
+1. Ship the change in the release category defined above, never in a patch.
+2. Name the final compatible gem release line in the README and release notes.
+3. Keep old releases available, without promising fixes or backports.
+4. Test every supported Ruby minor and verify the built gem rejects the old
+   runtime while installing on the new minimum.
+
+CRuby is the supported implementation and its CI jobs are blocking. JRuby and
+TruffleRuby are best effort until each has an explicitly owned compatibility
+matrix and support decision.
+
+## Dependencies
+
+- Keep the runtime dependency graph small and framework-neutral.
+- Declare standard-library components that are distributed as independent gems.
+- Prefer minimum or open-ended requirements. Add upper bounds only for known
+  incompatibilities.
+- Test the minimum and latest resolvable dependency sets when practical.
+- Keep framework and transport integrations optional or in separate gems when
+  adding them to the core gem would expand its compatibility surface.
+
+## Maintaining the policy
+
+The Ruby version settings serve different purposes:
+
+- `openai.gemspec` declares the customer support floor.
+- `.rubocop.yml` targets the syntax of the oldest supported Ruby minor.
+- The CI matrix tests every supported Ruby minor.
+- `.ruby-version` pins the latest patch of the newest supported Ruby for local
+  development; it is not the customer support floor.
+- Routine lint, package, and release jobs use the newest supported Ruby minor.
+
+After each annual Ruby release, add the new minor to CI and move routine
+development jobs to it once the suite is green. Around each March/April Ruby
+EOL window, explicitly decide whether to raise the customer floor. A floor
+increase must update the gemspec, README, RuboCop target, CI matrix, and release
+notes together; automation must not make that decision by itself.

--- a/examples/advanced_streaming.rb
+++ b/examples/advanced_streaming.rb
@@ -17,7 +17,7 @@ begin
     temperature: 0.0
   )
 
-  # the `stream` itself is an `https://rubyapi.org/3.2/o/enumerable`
+  # the `stream` itself is an `https://rubyapi.org/3.3/o/enumerable`
   #   which means that you can work with the stream almost as if it is an array
   all_choices =
     stream
@@ -49,7 +49,7 @@ begin
 
   stream_of_choices =
     stream
-    # calling `#lazy` will return a deferred `https://rubyapi.org/3.2/o/enumerator/lazy`
+    # calling `#lazy` will return a deferred `https://rubyapi.org/3.3/o/enumerator/lazy`
     .lazy
     # each successive calls to methods that return another `enumerable` will not consume the stream
     #   but rather, return a transformed stream. (see link above)

--- a/lib/openai/internal/type/base_stream.rb
+++ b/lib/openai/internal/type/base_stream.rb
@@ -9,7 +9,7 @@ module OpenAI
       #
       # This module provides a base implementation for streaming responses in the SDK.
       #
-      # @see https://rubyapi.org/3.2/o/enumerable
+      # @see https://rubyapi.org/3.3/o/enumerable
       module BaseStream
         include Enumerable
 

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.metadata["homepage_uri"] = s.homepage
   s.metadata["source_code_uri"] = "https://github.com/openai/openai-ruby"
   s.metadata["rubygems_mfa_required"] = "true"
-  s.required_ruby_version = ">= 3.2.0"
+  s.required_ruby_version = ">= 3.3.0"
   s.license = "Apache-2.0"
 
   s.files = Dir[
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.md",
     ".ignore"
   ]
-  s.extra_rdoc_files = ["README.md"]
+  s.extra_rdoc_files = ["README.md", "VERSIONING.md"]
   s.add_dependency "base64"
   s.add_dependency "cgi"
   s.add_dependency "connection_pool"


### PR DESCRIPTION
## Summary

- require Ruby 3.3 or newer and remove Ruby 3.2 from the supported CI matrix
- add a repository versioning policy covering breaking changes, Ruby support, dependencies, and release maintenance
- retain Ruby 4.0.6 as the contributor default and Ruby 4.0 for routine lint, package, and release jobs
- include the versioning policy in the built gem documentation

## Why

Ruby 3.2 reached upstream end of life on April 1, 2026. The SDK should support maintained CRuby releases by default, with post-EOL grace requiring an explicit exception. The published v0.75.x line remains available to Ruby 3.2 users without a separate maintenance promise.

Because the gem is pre-1.0, this runtime-floor change is a minor release. The `feat:` classification allows release-please to produce v0.76.0 under the repository's existing configuration.

## Impact

Ruby 3.2 users remain on v0.75.x. New SDK releases require Ruby 3.3 or newer. Ruby 3.3, 3.4, and 4.0 remain blocking CI targets.

## Validation

- `./scripts/test` on Ruby 3.3.12, 3.4.10, and 4.0.6: 468 tests / 1,514 assertions on each runtime
- `./scripts/lint` on Ruby 4.0.6
- `bundle exec rake build:gem` on Ruby 4.0.6
- verified the built gem contains `README.md` and `VERSIONING.md`
- verified Ruby 3.2.11 rejects the built gem and Ruby 3.3.12 installs it
- verified published v0.75.0 still installs on Ruby 3.2.11