### PR TITLE
fix: preserve generic Linux ffi lock entry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     csv (3.3.5)
     drb (2.2.3)
     erubi (1.13.1)
+    ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm64-darwin)


### PR DESCRIPTION
## Summary

- record the generic `ffi` 1.17.2 variant selected by Ruby reporting `x86_64-linux`
- prevent Bundler 4.0.17 from mutating `Gemfile.lock` during Linux x86_64 installs
- preserve every existing lock platform and platform-specific `ffi` variant

## Root cause

The lockfile contained the `x86_64-linux-gnu` and `x86_64-linux-musl` variants, but Ruby 4.0.6 reports `Gem::Platform.local` as `x86_64-linux`. Bundler 4.0.17 selects the generic source `ffi` variant for that platform and added the missing spec on every clean checkout.

## Validation

- reproduced the original one-line drift with Ruby 4.0.6 and Bundler 4.0.17 on Linux x86_64
- ran `bundle install` and `bundle check` twice from a fresh fixed checkout; the lockfile checksum remained unchanged and Git stayed clean after both passes
- loaded FFI successfully as `x86_64/linux`
- preserved all eight existing lock platforms
- focused self-contained tests: 137 runs, 738 assertions, 0 failures or errors
- `git diff --check`