### PR TITLE
fix: preserve binary multipart chunks

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -425,9 +425,9 @@ module OpenAI
         private def read_enum(max_len)
           case max_len
           in nil
-            @stream.to_a.join
+            @stream.to_a.map(&:b).join
           in Integer
-            @buf << @stream.next while @buf.length < max_len
+            @buf << @stream.next.b while @buf.length < max_len
             @buf.slice!(..max_len)
           end
         rescue StopIteration
@@ -476,7 +476,7 @@ module OpenAI
             else
               src
             end
-          @buf = String.new
+          @buf = String.new.b
           @blk = blk
         end
       end

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -330,6 +330,37 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
     end
   end
 
+  def test_read_mixed_encoding_chunks
+    chunks = ["caf\u00E9", "\xFF\xFE".b]
+    expected = chunks.map(&:b).join
+
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) do |chunk|
+      chunk
+    end
+    actual = String.new.b
+    loop do
+      chunk = adapter.read(2)
+      break unless chunk
+
+      actual << chunk
+    end
+
+    assert_equal(expected, actual)
+    assert_equal(Encoding::ASCII_8BIT, actual.encoding)
+  end
+
+  def test_read_all_mixed_encoding_chunks
+    chunks = ["caf\u00E9", "\xFF\xFE".b]
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) do |chunk|
+      chunk
+    end
+
+    result = adapter.read
+
+    assert_equal(chunks.map(&:b).join, result)
+    assert_equal(Encoding::ASCII_8BIT, result.encoding)
+  end
+
   def test_copy_write
     cases = {
       StringIO.new => "",


### PR DESCRIPTION
## Summary

- normalize multipart enumerator chunks to binary before buffering
- keep bounded and whole-stream reads in binary encoding
- add regression tests for mixed UTF-8 and binary chunks

Fixes #317.

## Validation

- focused adapter tests pass
- RuboCop passes
- the full util test file has one existing Windows CGI filename failure, reproduced on current `main`