### PR TITLE
ci: use upstream release-please

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -22,9 +22,8 @@ jobs:
       github.event.inputs.retry_publish != 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write # Create/update the release branch, tags, and GitHub releases.
+      pull-requests: write # Create/update release PRs and their lifecycle labels.
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
@@ -49,8 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish
     permissions:
-      contents: read
-      id-token: write
+      contents: read # Check out the release and fetch tags.
+      id-token: write # Exchange GitHub OIDC credentials with RubyGems.org.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -16,7 +16,36 @@ permissions: {}
 jobs:
   release:
     name: release
-    if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-ruby'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'openai/openai-ruby' &&
+      github.event.inputs.retry_publish != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: publish
+    needs: release
+    if: >-
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'openai/openai-ruby' &&
+      (needs.release.outputs.releases_created == 'true' ||
+        github.event.inputs.retry_publish == 'true')
     runs-on: ubuntu-latest
     environment: publish
     permissions:
@@ -27,27 +56,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Avoid persisting the default GITHUB_TOKEN; the RubyGems release action
-          # configures the credentials it needs only when a release is published.
+          # configures the credentials it needs only when publishing.
           persist-credentials: false
 
-      - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
-        if: ${{ github.event.inputs.retry_publish != 'true' }}
-        id: release
-        with:
-          repo: ${{ github.event.repository.full_name }}
-          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
-
       - name: Set up Ruby
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.retry_publish == 'true' }}
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           bundler-cache: false
           ruby-version: '4.0'
 
-      - if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.retry_publish == 'true' }}
-        run: |
-          bundle install
+      - run: bundle install
 
       - name: Publish to RubyGems.org
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.retry_publish == 'true' }}
         uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,9 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "versioning": "prerelease",
-  "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",
@@ -62,9 +60,6 @@
   "release-type": "ruby",
   "version-file": "lib/openai/version.rb",
   "extra-files": [
-    {
-      "type": "ruby-readme",
-      "path": "README.md"
-    }
+    "README.md"
   ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "packages": {
-    ".": {}
+    ".": {
+      "package-name": "openai"
+    }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,


### PR DESCRIPTION
## Summary

- replace the Stainless release trigger with the pinned upstream `googleapis/release-please-action` v5.0.0
- run release-please against `main` using the job-scoped `GITHUB_TOKEN`, with only `contents: write` and `pull-requests: write`
- isolate RubyGems publishing in a separate job so only that job receives `contents: read`, `id-token: write`, and the protected `publish` environment
- switch to the upstream config schema and stable versioning
- declare `package-name: openai` so upstream release-please updates the gem's `Gemfile.lock` entry

## Permission audit

- workflow-level `permissions: {}` prevents inheriting the repository's broader default token permissions
- `contents: write` is limited to the release job for release-branch commits, tags, and GitHub releases
- `pull-requests: write` is limited to the release job for creating/updating release PRs and their lifecycle labels; `issues: write` is not granted
- `contents: read` is limited to the publish job for checkout and the RubyGems release action's tag fetch
- `id-token: write` and the branch-restricted `publish` environment are limited to the publish job for RubyGems trusted publishing
- checkout does not persist credentials, and no Stainless secret is referenced

## Validation

- `actionlint` v1.7.12
- config validation against the exact release-please v17.6.0 schema bundled by the pinned action
- release-please v17.6.0 `debug-config` against the pushed branch: stable manifest version 0.76.0 and `packageName: openai`
- direct v17.6.0 Ruby updater check: `Gemfile.lock` changes `openai (0.76.0)` to `openai (0.77.0)`; an empty package name leaves it unchanged
- verified the resulting source branch is `release-please--branches--main--components--openai`, while `include-component-in-tag: false` keeps tags component-free
- reviewed the pinned release-please, checkout, Ruby setup, RubyGems release, and nested trusted-publishing action sources
- verified the `publish` environment allows only `main`
- verified the active release-branch ruleset matches the component-suffixed branch and retains deletion protection
- `git diff --check`
- `./scripts/lint` cannot run locally because this host has Ruby 3.2.11 and the repository requires Ruby >= 3.3; GitHub CI covers the supported Ruby versions

## Rollout notes

- Existing release PR #321 has merged, so there is no longer a competing Stainless-managed release PR.
- GitHub does not allow its built-in Actions app to be a ruleset bypass actor. To use `GITHUB_TOKEN` temporarily, the active `release-please--*` ruleset retains deletion protection but does not restrict branch creation or updates. This does not change `main` protections.
- After this PR lands, remove `STAINLESS_API_KEY` from the `publish` environment.
- Events created with `GITHUB_TOKEN` do not trigger downstream workflow runs; release PR validation must be retriggered by an actor other than the workflow token during this temporary phase.
- The external cross-SDK release monitor does not currently recognize `github-actions[bot]`; that cross-repository follow-up is explicitly deferred and is not part of this Ruby-only PR.
- When moving to the `openai-sdks` App token, add that App to the release-branch ruleset, restore creation/update restrictions, remove the Stainless bypass actor, and update the external monitor for the App identity.