### PR TITLE
ci: speed up lint checks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -80,6 +80,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ inputs.runner }}
+    env:
+      # Steep defaults to two workers in CI; eight is the measured balance for this runner.
+      STEEP_JOBS: 8
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
-          bundler-cache: false
-      - run: bundle install
+          bundler-cache: true
 
       - name: Get GitHub OIDC token
         id: github-oidc
@@ -49,10 +48,12 @@ jobs:
 
   lint:
     timeout-minutes: 10
-    name: lint
+    name: lint (rubocop)
     permissions:
       contents: read
     runs-on: ${{ inputs.runner }}
+    env:
+      RUBOCOP_CACHE_ROOT: ${{ github.workspace }}/.cache/rubocop
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -61,10 +62,43 @@ jobs:
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: '4.0'
-          bundler-cache: false
-      - run: bundle install
-      - name: Run lints
-        run: ./scripts/lint
+          bundler-cache: true
+      - name: Restore RuboCop cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.RUBOCOP_CACHE_ROOT }}
+          key: >-
+            rubocop-${{ runner.os }}-ruby-4.0-${{ hashFiles('Gemfile.lock', '.rubocop.yml') }}-${{ github.sha }}
+          restore-keys: |
+            rubocop-${{ runner.os }}-ruby-4.0-${{ hashFiles('Gemfile.lock', '.rubocop.yml') }}-
+      - name: Run RuboCop
+        run: bundle exec rake lint:rubocop
+
+  typecheck:
+    timeout-minutes: 10
+    name: typecheck (${{ matrix.format }})
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - format: rbi
+            task: typecheck:sorbet
+          - format: rbs
+            task: typecheck:steep
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+      - name: Typecheck ${{ matrix.format }} files
+        run: bundle exec rake ${{ matrix.task }}
 
   package:
     timeout-minutes: 10
@@ -80,8 +114,7 @@ jobs:
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: '4.0'
-          bundler-cache: false
-      - run: bundle install
+          bundler-cache: true
       - name: Build gem
         run: bundle exec rake build:gem
 
@@ -103,8 +136,7 @@ jobs:
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: false
-      - run: bundle install
+          bundler-cache: true
       - name: Run tests
         run: ./scripts/test
 
@@ -115,6 +147,7 @@ jobs:
     needs:
       - stainless-artifact
       - lint
+      - typecheck
       - package
       - test-ruby
     if: ${{ always() }}
@@ -125,10 +158,12 @@ jobs:
         env:
           ARTIFACT_RESULT: ${{ needs.stainless-artifact.result }}
           LINT_RESULT: ${{ needs.lint.result }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           PACKAGE_RESULT: ${{ needs.package.result }}
           TEST_RESULT: ${{ needs.test-ruby.result }}
         run: |
           test "$ARTIFACT_RESULT" = "success" || test "$ARTIFACT_RESULT" = "skipped"
           test "$LINT_RESULT" = "success"
+          test "$TYPECHECK_RESULT" = "success"
           test "$PACKAGE_RESULT" = "success"
           test "$TEST_RESULT" = "success"

--- a/Rakefile
+++ b/Rakefile
@@ -57,10 +57,8 @@ end
 desc("Lint `*.rb(i)`")
 RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.patterns = FileList[
-    "./lib/**/*.rb",
-    "./test/**/*.rb",
-    "./rbi/**/*.rbi",
-    "./examples/**/*.rb",
+    "./{lib,test,rbi,examples}/**/*.rb",
+    "./{lib,test,rbi,examples}/**/*.rbi",
   ]
   task.formatters = %w[github] if ENV.key?("CI")
 
@@ -134,8 +132,8 @@ multitask(format: [:"format:rb", :"format:rbi", :"format:rbs"])
 desc("Typecheck `*.rbs`")
 multitask(:"typecheck:steep") do
   steep = %w[steep check]
-  # Steep defaults to two workers in CI; eight is the tested balance for this project's runner.
-  steep += %w[--jobs=8 --format=github] if ENV.key?("CI")
+  steep += ["--jobs", ENV.fetch("STEEP_JOBS")] if ENV.key?("STEEP_JOBS")
+  steep += %w[--format=github] if ENV.key?("CI")
   sh(*steep)
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,8 @@ multitask(format: [:"format:rb", :"format:rbi", :"format:rbs"])
 desc("Typecheck `*.rbs`")
 multitask(:"typecheck:steep") do
   steep = %w[steep check]
-  steep += ["--jobs=#{Etc.nprocessors}", "--format=github"] if ENV.key?("CI")
+  # Steep defaults to two workers in CI; eight is the tested balance for this project's runner.
+  steep += %w[--jobs=8 --format=github] if ENV.key?("CI")
   sh(*steep)
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -55,17 +55,17 @@ filtered = ->(ext, dirs) do
 end
 
 desc("Lint `*.rb(i)`")
-multitask(:"lint:rubocop") do
-  find = %w[find ./lib ./test ./rbi ./examples -type f -and ( -name *.rb -or -name *.rbi ) -print0]
-
-  rubocop = %w[rubocop]
-  rubocop += %w[--format github] if ENV.key?("CI")
+RuboCop::RakeTask.new(:"lint:rubocop") do |task|
+  task.patterns = FileList[
+    "./lib/**/*.rb",
+    "./test/**/*.rb",
+    "./rbi/**/*.rbi",
+    "./examples/**/*.rb",
+  ]
+  task.formatters = %w[github] if ENV.key?("CI")
 
   # some lines cannot be shortened
-  rubocop += %w[--except Lint/RedundantCopDisableDirective,Layout/LineLength]
-
-  lint = xargs + rubocop
-  sh("#{find.shelljoin} | #{lint.shelljoin}")
+  task.options = %w[--parallel --except Lint/RedundantCopDisableDirective,Layout/LineLength]
 end
 
 norm_lines = %w[tr -- \n \0].shelljoin
@@ -133,7 +133,9 @@ multitask(format: [:"format:rb", :"format:rbi", :"format:rbs"])
 
 desc("Typecheck `*.rbs`")
 multitask(:"typecheck:steep") do
-  sh(*%w[steep check])
+  steep = %w[steep check]
+  steep += ["--jobs=#{Etc.nprocessors}", "--format=github"] if ENV.key?("CI")
+  sh(*steep)
 end
 
 directory(examples)

--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -113,4 +113,4 @@ done
 
 # Instead of running the tests, use the linter to check if an
 # older test is no longer compatible with the latest SDK.
-./scripts/lint
+bundle exec rake lint

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-cd -- "$(dirname -- "$0")/.."
-
-echo "==> Running linters"
-
-exec -- bundle exec rake lint "$@"


### PR DESCRIPTION
## Summary

- split RuboCop and RBI/RBS typechecking into independent parallel CI jobs
- replace the nested `xargs` RuboCop fan-out with one native parallel RuboCop invocation
- enable the supported `ruby/setup-ruby` Bundler cache for every Ruby job
- persist RuboCop's content-aware cache between runs
- configure eight Steep workers at the GitHub Actions boundary while retaining Steep's upstream default elsewhere
- remove the redundant `scripts/lint` pass-through wrapper and use the canonical Rake task
- keep branch protection on the stable `ci / ci-required` aggregate check

## Why

On PR #326, the lint job took **6m24s** end to end. Its explicit `bundle install` took **31s**, and the combined RuboCop/Sorbet/Steep step took **5m45s**. The three tools competed for one runner, while the `xargs` RuboCop batches each enabled RuboCop's own parallel execution.

This change isolates the tools on separate runners, removes nested RuboCop process pools and a redundant shell wrapper, and caches both gems and RuboCop results.

## CI results

Measured from GitHub Actions timestamps, comparing PR #326's run with this PR:

| Measurement | Before | This PR, cold cache | This PR, warm-cache observations | Observed warm improvement |
| --- | ---: | ---: | ---: | ---: |
| Lint job | 6m24s | 1m08s | 14–19s | **95–96%** |
| RuboCop/combined lint step | 5m45s | 28s | 3s | **99%** |
| Required CI gate | 6m49s | 5m58s | 3m54s–5m07s | **25–43%** |

Steep is now the remaining critical path. The four-worker run took **4m51s**; two eight-worker runs took **4m35s** and **3m33s**. The range reflects normal hosted-runner variance, so the PR reports the observations rather than attributing all of the difference to worker count.

- Baseline: https://github.com/openai/openai-ruby/actions/runs/30837002559
- Cold-cache run: https://github.com/openai/openai-ruby/actions/runs/30840958697
- First warm-cache run: https://github.com/openai/openai-ruby/actions/runs/30841669046
- Final cleanup run: https://github.com/openai/openai-ruby/actions/runs/30843071657

## Validation

- Ruby 4.0.6
- `bundle exec rake lint:rubocop`
- `bundle exec rake typecheck:sorbet`
- `CI=1 STEEP_JOBS=8 bundle exec rake typecheck:steep`
- `./scripts/test` — 468 runs, 1,514 assertions
- `bundle exec rake build:gem`
- `actionlint .github/workflows/ci-checks.yml`
- `shellcheck scripts/detect-breaking-changes`
- exact old/new RuboCop target-list comparison — 2,587 files
- thermo-nuclear maintainability review
- three complete GitHub Actions runs; all required checks green

## Local RuboCop benchmark

Same checkout, Ruby 3.3.12, RuboCop 1.81.7, 16 CPUs, separate empty/restored cache directories:

| RuboCop orchestration | Empty cache | Restored cache |
| --- | ---: | ---: |
| Existing `xargs` batches | 9.62s | 5.19s |
| Native RuboCop runner | 6.90s | 1.44s |
| Improvement | 28% | 72% |
