### PR TITLE
ci: prepare checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -33,6 +36,7 @@ jobs:
         (github.event_name == 'push' || github.event.pull_request.head.repo.fork)) ||
       (!startsWith(github.repository, 'stainless-sdks/') &&
         (github.event_name == 'pull_request' ||
+          github.event_name == 'merge_group' ||
           github.ref == 'refs/heads/main' ||
           github.ref == 'refs/heads/next'))
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - '**'
+      - '!gh-readonly-queue/**'
       - '!integrated/**'
       - '!stl-preview-head/**'
       - '!stl-preview-base/**'


### PR DESCRIPTION
## Summary

- trigger the required CI workflow for GitHub merge-group checks
- allow the aggregate `ci / ci-required` job to run for queued merge commits

## Why

GitHub requires Actions-based required checks to listen for the separate `merge_group` event. Without this change, enabling the queue would leave queued pull requests waiting for a required check that never reports.

## Impact

Once the repository merge queue is enabled, CI will run again when an approved pull request enters the queue, validating it against the latest `main` and any changes ahead of it in the queue. The Stainless staging artifact path remains unchanged.

## Validation

- YAML parsed successfully
- `git diff --check`
- trigger/job-gate alignment check
- thermo-nuclear code-quality review (no findings)

## Follow-up

After this lands, enable the `main` ruleset merge queue with squash-only merging, all-green grouping, one PR per merge, five concurrent builds, and a 60-minute check timeout.