### PR TITLE
ci: speed up RBS validation without Steep internals

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -76,21 +76,10 @@ jobs:
 
   typecheck:
     timeout-minutes: 10
-    name: typecheck (${{ matrix.format }})
+    name: typecheck (rbi)
     permissions:
       contents: read
     runs-on: ${{ inputs.runner }}
-    env:
-      # Steep defaults to two workers in CI; eight is the measured balance for this runner.
-      STEEP_JOBS: 8
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - format: rbi
-            task: typecheck:sorbet
-          - format: rbs
-            task: typecheck:steep
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -100,8 +89,26 @@ jobs:
         with:
           ruby-version: '4.0'
           bundler-cache: true
-      - name: Typecheck ${{ matrix.format }} files
-        run: bundle exec rake ${{ matrix.task }}
+      - name: Typecheck rbi files
+        run: bundle exec rake typecheck:sorbet
+
+  validate-rbs:
+    timeout-minutes: 10
+    name: validate (rbs)
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+      - name: Validate rbs files
+        run: bundle exec rake validate:rbs
 
   package:
     timeout-minutes: 10
@@ -151,6 +158,7 @@ jobs:
       - stainless-artifact
       - lint
       - typecheck
+      - validate-rbs
       - package
       - test-ruby
     if: ${{ always() }}
@@ -162,11 +170,13 @@ jobs:
           ARTIFACT_RESULT: ${{ needs.stainless-artifact.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          RBS_VALIDATION_RESULT: ${{ needs.validate-rbs.result }}
           PACKAGE_RESULT: ${{ needs.package.result }}
           TEST_RESULT: ${{ needs.test-ruby.result }}
         run: |
           test "$ARTIFACT_RESULT" = "success" || test "$ARTIFACT_RESULT" = "skipped"
           test "$LINT_RESULT" = "success"
           test "$TYPECHECK_RESULT" = "success"
+          test "$RBS_VALIDATION_RESULT" = "success"
           test "$PACKAGE_RESULT" = "success"
           test "$TEST_RESULT" = "success"

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -98,6 +98,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ inputs.runner }}
+    env:
+      # The consolidated green path always uses one worker; keep the reference
+      # fallback tuned so failing builds produce exact diagnostics promptly.
+      STEEP_JOBS: 8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -59,6 +59,7 @@ RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.patterns = FileList[
     "./{lib,test,rbi,examples}/**/*.rb",
     "./{lib,test,rbi,examples}/**/*.rbi",
+    "./scripts/validate-rbs"
   ]
   task.formatters = %w[github] if ENV.key?("CI")
 
@@ -129,12 +130,9 @@ end
 desc("Format everything")
 multitask(format: [:"format:rb", :"format:rbi", :"format:rbs"])
 
-desc("Typecheck `*.rbs`")
-multitask(:"typecheck:steep") do
-  steep = %w[steep check]
-  steep += ["--jobs", ENV.fetch("STEEP_JOBS")] if ENV.key?("STEEP_JOBS")
-  steep += %w[--format=github] if ENV.key?("CI")
-  sh(*steep)
+desc("Validate `*.rbs`")
+multitask(:"validate:rbs") do
+  ruby(*%w[scripts/validate-rbs])
 end
 
 directory(examples)
@@ -149,8 +147,8 @@ directory(tapioca) do
   sh(*%w[tapioca init])
 end
 
-desc("Typecheck everything")
-multitask(typecheck: [:"typecheck:steep", :"typecheck:sorbet"])
+desc("Typecheck and validate everything")
+multitask(typecheck: [:"typecheck:sorbet", :"validate:rbs"])
 
 desc("Lint and typecheck")
 multitask(lint: [:"lint:rubocop", :typecheck])

--- a/scripts/validate-rbs
+++ b/scripts/validate-rbs
@@ -25,14 +25,15 @@ module OpenAI
         if signatures.any? { contains_file_scoped_directive?(_1) }
           run_reference_check(root, stdout: stdout, stderr: stderr, env: env)
         else
-          consolidated_status = run_consolidated_check(root, steepfile, signatures, env: env)
-          unless consolidated_status.success?
+          fast_status = run_parse_check(root, env: env)
+          fast_status = run_consolidated_check(root, steepfile, signatures, env: env) if fast_status.success?
+          unless fast_status.success?
             stdout.puts(
-              "Consolidated RBS validation failed; checking original signature files for exact diagnostics."
+              "Fast RBS validation failed; checking original signature files for exact diagnostics."
             )
-            consolidated_status = run_reference_check(root, stdout: stdout, stderr: stderr, env: env)
+            fast_status = run_reference_check(root, stdout: stdout, stderr: stderr, env: env)
           end
-          consolidated_status
+          fast_status
         end
 
       if status.success?
@@ -62,6 +63,12 @@ module OpenAI
       File.foreach(path).any? { _1.match?(FILE_SCOPED_DIRECTIVE) }
     end
     private_class_method :contains_file_scoped_directive?
+
+    def run_parse_check(root, env:)
+      _stdout, _stderr, status = Open3.capture3(env, "rbs", "parse", "sig", chdir: root.to_s)
+      status
+    end
+    private_class_method :run_parse_check
 
     def run_consolidated_check(root, steepfile, signatures, env:)
       Dir.mktmpdir("openai-rbs-validation") do |directory|

--- a/scripts/validate-rbs
+++ b/scripts/validate-rbs
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+module OpenAI
+  module RBSValidation
+    # These directives change name resolution on a per-file basis, so signatures
+    # containing them cannot be safely combined and must take the reference path.
+    FILE_SCOPED_DIRECTIVE = /^\s*(?:use(?:\s|$)|#\s*resolve-type-names\s*:)/
+
+    module_function
+
+    def run(root: Pathname.pwd, stdout: $stdout, stderr: $stderr, env: ENV.to_h)
+      steepfile = root.join("Steepfile")
+      raise Errno::ENOENT, steepfile unless steepfile.file?
+
+      signatures = signature_paths(root)
+      raise "No RBS files found under #{root.join('sig')}" if signatures.empty?
+
+      status =
+        if signatures.any? { contains_file_scoped_directive?(_1) }
+          run_reference_check(root, stdout: stdout, stderr: stderr, env: env)
+        else
+          consolidated_status = run_consolidated_check(root, steepfile, signatures, env: env)
+          unless consolidated_status.success?
+            stdout.puts(
+              "Consolidated RBS validation failed; checking original signature files for exact diagnostics."
+            )
+            consolidated_status = run_reference_check(root, stdout: stdout, stderr: stderr, env: env)
+          end
+          consolidated_status
+        end
+
+      if status.success?
+        noun = signatures.one? ? "file" : "files"
+        stdout.puts("Validated #{signatures.size} RBS #{noun} with no errors.")
+        0
+      else
+        1
+      end
+    rescue StandardError => e
+      message =
+        if e.respond_to?(:detailed_message)
+          e.detailed_message(highlight: false)
+        else
+          "#{e.class}: #{e.message}"
+        end
+      stderr.puts(message)
+      1
+    end
+
+    def signature_paths(root)
+      Dir.glob(root.join("sig/**/*.rbs")).map { Pathname(_1) }
+    end
+    private_class_method :signature_paths
+
+    def contains_file_scoped_directive?(path)
+      File.foreach(path).any? { _1.match?(FILE_SCOPED_DIRECTIVE) }
+    end
+    private_class_method :contains_file_scoped_directive?
+
+    def run_consolidated_check(root, steepfile, signatures, env:)
+      Dir.mktmpdir("openai-rbs-validation") do |directory|
+        temporary_root = Pathname(directory)
+        temporary_sig = temporary_root.join("sig")
+        temporary_sig.mkpath
+        temporary_steepfile = temporary_root.join("Steepfile")
+        FileUtils.cp(steepfile, temporary_steepfile)
+        # Steep validates reopened namespaces once per input file. Combining the
+        # generated declarations avoids that repeated work; Steep still performs
+        # all parsing and semantic validation through its public CLI.
+        concatenate(signatures, temporary_sig.join("all.rbs"))
+
+        command = [env.fetch("STEEP_COMMAND", "steep"), "check", "--no-type-check", "--jobs=1"]
+        command << "--steepfile=#{temporary_steepfile}"
+        _stdout, _stderr, status = Open3.capture3(env, *command, chdir: root.to_s)
+        status
+      end
+    end
+    private_class_method :run_consolidated_check
+
+    def concatenate(signatures, destination)
+      destination.open("wb") do |combined|
+        signatures.each do |path|
+          contents = path.binread
+          combined.write(contents)
+          combined.write("\n") unless contents.end_with?("\n")
+          combined.write("\n")
+        end
+      end
+    end
+    private_class_method :concatenate
+
+    def run_reference_check(root, stdout:, stderr:, env:)
+      command = [env.fetch("STEEP_COMMAND", "steep"), "check", "--no-type-check"]
+      command << "--jobs=#{env.fetch('STEEP_JOBS')}" if env.key?("STEEP_JOBS")
+      command << "--format=github" if env.key?("CI")
+      output, errors, status = Open3.capture3(env, *command, chdir: root.to_s)
+      stdout.print(output)
+      stderr.print(errors)
+      status
+    end
+    private_class_method :run_reference_check
+  end
+end
+
+exit(OpenAI::RBSValidation.run) if $PROGRAM_NAME == __FILE__

--- a/scripts/validate-rbs
+++ b/scripts/validate-rbs
@@ -10,7 +10,7 @@ module OpenAI
   module RBSValidation
     # These directives change name resolution on a per-file basis, so signatures
     # containing them cannot be safely combined and must take the reference path.
-    FILE_SCOPED_DIRECTIVE = /^\s*(?:use(?:\s|$)|#\s*resolve-type-names\s*:)/
+    FILE_SCOPED_DIRECTIVE = /^\s*(?:use\b|#\s*resolve-type-names\s*:)/
 
     module_function
 

--- a/scripts/validate-rbs
+++ b/scripts/validate-rbs
@@ -63,7 +63,9 @@ module OpenAI
       contents = path.binread
       # RBS 3.9 treats NUL as EOF. In a combined buffer, that would hide every
       # declaration from later files even though the originals parse separately.
-      contents.include?("\0") || contents.each_line.any? { _1.match?(FILE_SCOPED_DIRECTIVE) }
+      # Match the complete file because RBS's magic-comment grammar permits its
+      # whitespace matcher to span lines (for example, "#\nresolve-type-names:").
+      contents.include?("\0") || contents.match?(FILE_SCOPED_DIRECTIVE)
     end
     private_class_method :requires_reference_check?
 

--- a/scripts/validate-rbs
+++ b/scripts/validate-rbs
@@ -22,7 +22,7 @@ module OpenAI
       raise "No RBS files found under #{root.join('sig')}" if signatures.empty?
 
       status =
-        if signatures.any? { contains_file_scoped_directive?(_1) }
+        if signatures.any? { requires_reference_check?(_1) }
           run_reference_check(root, stdout: stdout, stderr: stderr, env: env)
         else
           fast_status = run_parse_check(root, env: env)
@@ -59,10 +59,13 @@ module OpenAI
     end
     private_class_method :signature_paths
 
-    def contains_file_scoped_directive?(path)
-      File.foreach(path).any? { _1.match?(FILE_SCOPED_DIRECTIVE) }
+    def requires_reference_check?(path)
+      contents = path.binread
+      # RBS 3.9 treats NUL as EOF. In a combined buffer, that would hide every
+      # declaration from later files even though the originals parse separately.
+      contents.include?("\0") || contents.each_line.any? { _1.match?(FILE_SCOPED_DIRECTIVE) }
     end
-    private_class_method :contains_file_scoped_directive?
+    private_class_method :requires_reference_check?
 
     def run_parse_check(root, env:)
       _stdout, _stderr, status = Open3.capture3(env, "rbs", "parse", "sig", chdir: root.to_s)

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -51,7 +51,7 @@ class ValidateRBSScriptTest < Minitest::Test
   def test_rechecks_original_files_when_consolidated_check_fails
     stdout, stderr, status, calls = run_validation(
       {"valid.rbs" => "module Example\nend\n"},
-      env: {"CI" => "1"},
+      env: {"CI" => "1", "STEEP_JOBS" => "8"},
       fake_steep_results: [1, 0]
     )
 
@@ -60,7 +60,7 @@ class ValidateRBSScriptTest < Minitest::Test
     assert_includes(stdout, "checking original signature files")
     assert_equal(2, calls.size)
     assert(calls.first.last.start_with?("--steepfile="), calls.first.inspect)
-    assert_equal(%w[check --no-type-check --format=github], calls.last)
+    assert_equal(%w[check --no-type-check --jobs=8 --format=github], calls.last)
   end
 
   def test_checks_original_files_directly_when_a_signature_has_use_directives

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -47,6 +47,19 @@ class ValidateRBSScriptTest < Minitest::Test
     assert_match(/[ab]\.rbs/, stdout)
   end
 
+  def test_rechecks_original_files_when_a_signature_contains_nul
+    stdout, _stderr, status = run_validation(
+      {
+        "a.rbs" => "module Good\nend\n\x00",
+        "b.rbs" => "module Invalid\n  type bad = MissingType\nend\n"
+      }
+    )
+
+    refute_predicate(status, :success?)
+    assert_includes(stdout, "RBS::UnknownTypeName")
+    assert_includes(stdout, "b.rbs")
+  end
+
   def test_uses_one_consolidated_steep_check_on_success
     stdout, stderr, status, calls = run_validation(
       {"valid.rbs" => "module Example\nend\n"},

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -124,6 +124,19 @@ class ValidateRBSScriptTest < Minitest::Test
     assert_equal([%w[check --no-type-check]], calls)
   end
 
+  def test_checks_original_files_when_type_name_resolution_directive_is_multiline
+    stdout, _stderr, status = run_validation(
+      {
+        "a.rbs" => "#\nresolve-type-names: false\nmodule Good\nend\n",
+        "b.rbs" => "class Broken\n  def call: () -> Missing\nend\n"
+      }
+    )
+
+    refute_predicate(status, :success?)
+    assert_includes(stdout, "RBS::UnknownTypeName")
+    assert_includes(stdout, "b.rbs")
+  end
+
   def test_reports_steep_semantic_errors
     stdout, _stderr, status = run_validation(
       {

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/autorun"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "tmpdir"
+
+class ValidateRBSScriptTest < Minitest::Test
+  SCRIPT = Pathname(__dir__).join("../../scripts/validate-rbs").expand_path
+
+  def test_validates_reopened_namespaces
+    stdout, stderr, status = run_validation(
+      {
+        "first.rbs" => <<~RBS,
+          module Example
+            class First
+              def value: () -> String
+            end
+          end
+        RBS
+        "second.rbs" => <<~RBS
+          module Example
+            class Second
+              def value: () -> Integer
+            end
+          end
+        RBS
+      }
+    )
+
+    assert_predicate(status, :success?, stderr)
+    assert_includes(stdout, "Validated 2 RBS files with no errors.")
+  end
+
+  def test_uses_one_consolidated_steep_check_on_success
+    stdout, stderr, status, calls = run_validation(
+      {"valid.rbs" => "module Example\nend\n"},
+      fake_steep_results: [0]
+    )
+
+    assert_predicate(status, :success?, stderr)
+    assert_empty(stderr)
+    assert_includes(stdout, "Validated 1 RBS file with no errors.")
+    assert_equal(1, calls.size)
+    assert_equal(%w[check --no-type-check --jobs=1], calls.first.take(3))
+    assert(calls.first.last.start_with?("--steepfile="), calls.first.inspect)
+  end
+
+  def test_rechecks_original_files_when_consolidated_check_fails
+    stdout, stderr, status, calls = run_validation(
+      {"valid.rbs" => "module Example\nend\n"},
+      env: {"CI" => "1"},
+      fake_steep_results: [1, 0]
+    )
+
+    assert_predicate(status, :success?, stderr)
+    assert_empty(stderr)
+    assert_includes(stdout, "checking original signature files")
+    assert_equal(2, calls.size)
+    assert(calls.first.last.start_with?("--steepfile="), calls.first.inspect)
+    assert_equal(%w[check --no-type-check --format=github], calls.last)
+  end
+
+  def test_checks_original_files_directly_when_a_signature_has_use_directives
+    _stdout, stderr, status, calls = run_validation(
+      {"uses.rbs" => "use Example::*\nmodule UsesExample\nend\n"},
+      fake_steep_results: [0]
+    )
+
+    assert_predicate(status, :success?, stderr)
+    assert_empty(stderr)
+    assert_equal([%w[check --no-type-check]], calls)
+  end
+
+  def test_checks_original_files_directly_when_type_name_resolution_is_file_scoped
+    _stdout, stderr, status, calls = run_validation(
+      {"unresolved.rbs" => "# resolve-type-names: false\nmodule Example\nend\n"},
+      fake_steep_results: [0]
+    )
+
+    assert_predicate(status, :success?, stderr)
+    assert_empty(stderr)
+    assert_equal([%w[check --no-type-check]], calls)
+  end
+
+  def test_reports_steep_semantic_errors
+    stdout, _stderr, status = run_validation(
+      {
+        "invalid.rbs" => <<~RBS
+          module Example
+            class Box[A < Numeric]
+            end
+
+            class InvalidBox < Box[String]
+            end
+          end
+        RBS
+      }
+    )
+
+    refute_predicate(status, :success?)
+    assert_includes(stdout, "RBS::UnsatisfiableTypeApplication")
+    assert_includes(stdout, "Type application of `::Example::Box` doesn't satisfy the constraints")
+  end
+
+  def test_reports_syntax_errors
+    stdout, _stderr, status = run_validation(
+      {"invalid.rbs" => "module Example\n  def broken: () ->\nend\n"}
+    )
+
+    refute_predicate(status, :success?)
+    assert_includes(stdout, "RBS::SyntaxError")
+  end
+
+  def test_emits_github_annotations_in_ci
+    stdout, _stderr, status = run_validation(
+      {"invalid.rbs" => "module Example\n  type invalid = MissingType\nend\n"},
+      env: {"CI" => "1"}
+    )
+
+    refute_predicate(status, :success?)
+    assert_match(/^::error file=.*invalid\.rbs,line=2,.*::/, stdout)
+    assert_includes(stdout, "RBS::UnknownTypeName")
+  end
+
+  private
+
+  def run_validation(signatures, env: {}, fake_steep_results: nil)
+    env = {"CI" => nil}.merge(env)
+
+    Dir.mktmpdir("openai-rbs-validation-test") do |dir|
+      root = Pathname(dir)
+      sig = root.join("sig")
+      sig.mkpath
+      root.join("Steepfile").write(<<~RUBY)
+        target(:lib) do
+          signature("sig")
+        end
+      RUBY
+
+      signatures.each do |name, contents|
+        path = sig.join(name)
+        path.dirname.mkpath
+        path.write(contents)
+      end
+
+      log = fake_steep_results && install_fake_steep(root)
+      if log
+        env = env.merge(
+          "FAKE_STEEP_LOG" => log.to_s,
+          "FAKE_STEEP_RESULTS" => fake_steep_results.join(","),
+          "STEEP_COMMAND" => root.join("bin/steep").to_s
+        )
+      end
+
+      stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, SCRIPT.to_s, chdir: root.to_s)
+      calls = log&.file? ? log.readlines(chomp: true).map { _1.split("\t") } : []
+      [stdout, stderr, status, calls]
+    end
+  end
+
+  def install_fake_steep(root)
+    bin = root.join("bin")
+    bin.mkpath
+    executable = bin.join("steep")
+    executable.write(<<~RUBY)
+      #!/usr/bin/env ruby
+      # frozen_string_literal: true
+
+      log = ENV.fetch("FAKE_STEEP_LOG")
+      call = File.file?(log) ? File.foreach(log).count : 0
+      File.open(log, "a") { _1.puts(ARGV.join("\\t")) }
+      results = ENV.fetch("FAKE_STEEP_RESULTS").split(",").map { Integer(_1) }
+      exit(results.fetch(call, results.last))
+    RUBY
+    executable.chmod(0o755)
+    root.join("steep.log")
+  end
+end

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -34,6 +34,19 @@ class ValidateRBSScriptTest < Minitest::Test
     assert_includes(stdout, "Validated 2 RBS files with no errors.")
   end
 
+  def test_does_not_allow_invalid_files_to_repair_each_other
+    stdout, _stderr, status = run_validation(
+      {
+        "a.rbs" => "class Example\n",
+        "b.rbs" => "end\n"
+      }
+    )
+
+    refute_predicate(status, :success?)
+    assert_includes(stdout, "RBS::SyntaxError")
+    assert_match(/[ab]\.rbs/, stdout)
+  end
+
   def test_uses_one_consolidated_steep_check_on_success
     stdout, stderr, status, calls = run_validation(
       {"valid.rbs" => "module Example\nend\n"},

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -100,6 +100,19 @@ class ValidateRBSScriptTest < Minitest::Test
     assert_equal([%w[check --no-type-check]], calls)
   end
 
+  def test_checks_original_files_when_a_use_directive_has_no_whitespace
+    stdout, _stderr, status = run_validation(
+      {
+        "a.rbs" => "use::Example::Foo\nmodule Example\n  class Foo\n  end\nend\n",
+        "b.rbs" => "module Invalid\n  type bad = Foo\nend\n"
+      }
+    )
+
+    refute_predicate(status, :success?)
+    assert_includes(stdout, "RBS::UnknownTypeName")
+    assert_includes(stdout, "b.rbs")
+  end
+
   def test_checks_original_files_directly_when_type_name_resolution_is_file_scoped
     _stdout, stderr, status, calls = run_validation(
       {"unresolved.rbs" => "# resolve-type-names: false\nmodule Example\nend\n"},


### PR DESCRIPTION
## Summary

This changes the RBS half of CI from a generic “typecheck” job into an explicit `validate (rbs)` job and replaces the slow per-file Steep invocation with a public-CLI validation pipeline.

The validator now:

1. collects the repository’s 1,209 generated `.rbs` files;
2. runs `rbs parse sig`, which parses every original file independently;
3. rejects parser-boundary hazards and file-scoped semantics before combining independently parseable signatures into one temporary signature file;
4. asks the locked `steep check` CLI to perform semantic validation once over the merged declaration environment;
5. reruns ordinary per-file `steep check` against the original files whenever either fast-path stage fails, preserving exact source paths and GitHub annotations.

The RBS job remains an explicit dependency of `ci-required`, so it cannot be skipped while the aggregate required check passes.

## Root cause

The generated signatures are split across 1,209 files and heavily reopen the same namespaces. Steep validates the merged definition of a reopened namespace in the context of each input signature file. That makes the work grow with both the number of signature files and the size of the merged namespaces, even though there are no Ruby source files configured for Steep to typecheck.

This is the same split-signature performance shape discussed in [steep#661](https://github.com/soutaro/steep/issues/661). Consolidating signatures removes the repeated per-file namespace validation while keeping Steep itself as the semantic validator.

On the current repository:

| Path | Wall time |
| --- | ---: |
| Ordinary per-file `steep check --no-type-check --jobs=8` | 52.38s |
| Independent `rbs parse sig` preflight | 0.40s |
| Complete optimized validator, including preflight | 6.22s |

The reference and optimized commands both pass the full 1,209-file corpus. The optimized path remains roughly 8× faster locally. Before this change, the GitHub job spent roughly 3m31s in RBS validation, so this targets the actual long pole rather than Ruby setup or Sorbet.

## Why this is safe

### Public CLIs are the only tool boundaries

The implementation does not load Steep or RBS as Ruby libraries and does not reference `Steep::` or `RBS::` implementation constants.

It invokes two documented commands from the locked bundle:

- `rbs parse sig` for independent syntax parsing only;
- `steep check` for the existing semantic validation.

The RBS parser preflight is not a replacement for Steep and does not make semantic acceptance decisions. Steep remains the authority for type names, inheritance, aliases, generic bounds, constants, members, and other semantic validity.

### Original file boundaries remain authoritative for syntax

Concatenation cannot be allowed to decide whether the original files are syntactically valid. Without a preflight, two independently invalid files can repair each other. For example:

- `a.rbs`: `class Example`
- `b.rbs`: `end`

Each original file is invalid, but their concatenation is a valid class declaration. Split return types and orphan annotations can create the same class of false green.

The validator therefore runs `rbs parse sig` before creating the combined buffer. The CLI parses every original file independently. A syntax failure skips consolidation and routes directly to ordinary per-file Steep, which reports the exact original file and line. A regression test uses the split `class`/`end` reproduction and requires the wrapper to fail with an original-file `RBS::SyntaxError`.

Independent parsing alone is not sufficient for every parser-boundary byte. Locked RBS 3.9.5 treats an embedded NUL (`\\x00`) as EOF while still exiting successfully. If such a file were concatenated before another signature, the combined parser could silently ignore every later declaration. The eligibility scan therefore reads signatures as binary and routes the whole job through ordinary per-file Steep if any NUL is present. The regression test places a NUL in the first file and an unknown type in the second; validation must fail against the second original file.

### The semantic fast path changes partitioning, not declarations

After every source file has independently parsed, the script writes each file byte-for-byte, in deterministic glob order, into one temporary `sig/all.rbs`, adding only newline separators. The repository’s existing `Steepfile` is copied into the temporary project, so the same target, libraries, diagnostic configuration, and dependency setup are used.

RBS declarations live in a merged environment. For independently parseable declaration files, combining buffers changes how many parser buffers contain those declarations, but not the classes, modules, aliases, constants, methods, type parameters, bounds, or annotations that Steep validates.

### File-scoped semantics are explicitly excluded

Locked RBS 3.9.5 has two constructs that intentionally alter name resolution on a per-file basis:

- `use ...`
- `# resolve-type-names: ...`

Concatenating files containing either construct could change which declarations the directive affects. The validator matches the actual `use` keyword boundary (`use\\b`), including whitespace-free forms such as `use::Example::Foo`, wildcard imports, and comment adjacency. It applies the directive pattern to each complete binary file, rather than physical lines, because locked RBS 3.9.5's magic-comment grammar allows `\\s*` to span newlines (for example, `#\\nresolve-type-names: false`). It scans for both file-scoped forms, alongside the NUL/EOF boundary described above, and bypasses consolidation entirely if any hazard is present anywhere in `sig/`. In that case it immediately runs ordinary per-file Steep.

The current generated corpus contains neither construct. If generation introduces one later, correctness wins automatically and CI becomes slower rather than weaker.

### Any fast-path rejection is checked against the original files

A nonzero result from either independent parsing or consolidated Steep is never reported directly as the final answer. The script reruns Steep over the untouched repository signatures and uses that reference invocation’s exit status.

That has three important properties:

- syntax and semantic errors are reported against their original file and line;
- CI still emits normal GitHub annotations;
- a problem caused only by the optimization cannot create a false CI failure—if ordinary Steep passes, the validation task passes after noting that the reference path was used.

The failure path intentionally retains the old cost. Slow red builds are preferable to fast but ambiguous diagnostics. The workflow preserves `STEEP_JOBS: 8` specifically so this reference fallback produces diagnostics promptly.

### The validation level is not weakened

The command uses `--no-type-check` to state the job’s actual scope: RBS validation. The current `Steepfile` declares `signature("sig")` and no Ruby `check` paths, so the old job was not typechecking Ruby source code. It was already doing signature validation only.

Steep’s normal signature validation remains enabled. Tests demonstrate that the wrapper rejects:

- independently invalid files that become valid when concatenated;
- embedded NUL bytes that would hide later declarations in a combined buffer;
- whitespace-free or comment-adjacent `use` directives whose imports would leak across file boundaries;
- multiline `resolve-type-names` magic directives whose setting would leak into later files;
- ordinary RBS syntax errors;
- unknown type names;
- unsatisfied generic type-parameter bounds;
- other semantic errors surfaced by Steep.

Sorbet’s RBI check remains a separate `typecheck (rbi)` job.

### Operational failures fail closed

Missing signatures, a missing `Steepfile`, unavailable `rbs` or `steep` executables, temporary-file errors, and unexpected exceptions all produce a nonzero exit. The optimization does not turn infrastructure failures into successful validation.

### The required-check contract is explicit

The reusable workflow has separate job IDs for `typecheck` and `validate-rbs`. The `required` job:

- lists `validate-rbs` in `needs`;
- captures `needs.validate-rbs.result`;
- explicitly requires that result to equal `success`.

Branch protection can therefore continue requiring the single aggregate `ci-required` context without losing the RBS gate.

## Intentional tradeoffs

- Green builds pay approximately 0.4s to preserve independent syntax boundaries before taking the consolidated semantic path.
- Red builds rerun the old per-file path to obtain exact diagnostics, so failures remain comparatively slow.
- Repositories that introduce file-scoped RBS directives or NUL-containing signatures lose the optimization until a semantics-preserving strategy is added.
- This job is deliberately named validation, not typechecking, because no Ruby source paths are configured in Steep.

There is no dependency on private Steep/RBS APIs, no new language toolchain, and no reduction in semantic validation.

## Verification

- `ruby test/scripts/validate_rbs_test.rb`: 12 runs, 60 assertions
- Same tests with ambient `CI=1`: 12 runs, 60 assertions
- Full optimized validation: 1,209 RBS files, no errors
- Full reference per-file Steep validation: no errors
- `rbs parse sig`: 1,209 original files parsed independently
- RuboCop: 2,589 files, no offenses
- Ruby syntax check: passes
- Workflow YAML parse: passes
- `git diff --check`: passes

Tests cover the cross-file syntax-repair regression, the NUL/EOF truncation regression, whitespace-free `use` directives, the multiline magic-comment regression, consolidated success, reference fallback, both file-scoped directive families, reopened namespaces, ordinary syntax errors, semantic generic-bound errors, unknown names, fallback worker tuning, and GitHub annotation formatting.

The full local integration harness requires Ruby 3.3 or newer; this machine has Ruby 3.2. PR CI runs all supported Ruby versions and is the authoritative full-suite validation.