### PR TITLE
ci: use GitHub App for Release Please

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -21,20 +21,29 @@ jobs:
       github.repository == 'openai/openai-ruby' &&
       github.event.inputs.retry_publish != 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Create/update the release branch, tags, and GitHub releases.
-      pull-requests: write # Create/update release PRs and their lifecycle labels.
+    environment: release
+    permissions: {}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
   publish:
     name: publish


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the `openai-sdks` GitHub App from environment configuration
- pass that token to Release Please and disable the release job's built-in `GITHUB_TOKEN` permissions
- preserve the existing RubyGems publish and retry flow

## Why

Release Please currently authenticates with `GITHUB_TOKEN`. Events created with that token do not normally start downstream workflows. A GitHub App installation token triggers the normal push and pull-request workflows for the generated release branch.

This is the Ruby equivalent of https://github.com/openai/openai-python/pull/3577. Ruby does not have Python's manual release-PR workflow-dispatch workaround, so no CI dispatch cleanup is needed here.

## Repository configuration

- verified App: `openai-sdks` (App ID `3705508`, client ID `Iv23li2AtcmhLHO07J87`)
- environment: `release`, restricted to `main` with no required-reviewer gate
- environment variable: `OPENAI_SDKS_APP_CLIENT_ID`
- environment secret: `OPENAI_SDKS_APP_PRIVATE_KEY`

## Validation

- `actionlint` v1.7.7 `.github/workflows/create-releases.yml`
- Ruby YAML parse
- `git diff --check`
- thermo-nuclear code quality review
- all required GitHub checks pass
- OkTest: 237/237 SDK tests pass