### PR TITLE
Fix loading after ActiveSupport 6 subclass extensions

### DIFF
--- a/lib/openai/models.rb
+++ b/lib/openai/models.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 module OpenAI
-  [OpenAI::Internal::Type::BaseModel, *OpenAI::Internal::Type::BaseModel.subclasses].each do |cls|
+  # ActiveSupport 6 implements Class#subclasses using ==, which invokes BaseModel's
+  # structural equality before all model aliases are loaded.
+  base_model = OpenAI::Internal::Type::BaseModel
+  subclasses =
+    ObjectSpace.each_object(base_model.singleton_class).select do |candidate|
+      !candidate.singleton_class? && candidate.superclass.equal?(base_model)
+    end
+
+  [base_model, *subclasses].each do |cls|
     cls.define_sorbet_constant!(:OrHash) { T.type_alias { T.any(cls, OpenAI::Internal::AnyHash) } }
   end
 

--- a/test/openai/load_order_test.rb
+++ b/test/openai/load_order_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rbconfig"
+
+require_relative "test_helper"
+
+class OpenAI::Test::LoadOrderTest < Minitest::Test
+  def test_loads_after_active_support_6_subclass_extensions
+    script = <<~RUBY
+      class Class
+        def descendants
+          ObjectSpace.each_object(singleton_class).reject do |candidate|
+            candidate.singleton_class? || candidate == self
+          end
+        end
+
+        def subclasses
+          descendants.select { |candidate| candidate.superclass == self }
+        end
+      end
+
+      require "openai"
+
+      raise "missing OrHash" unless OpenAI::Models::Batch.sorbet_constant_defined?(:OrHash)
+    RUBY
+
+    _, stderr, status =
+      Open3.capture3(
+        RbConfig.ruby,
+        "-I",
+        File.expand_path("../../lib", __dir__),
+        "-e",
+        script
+      )
+
+    assert_predicate(status, :success?, stderr)
+  end
+end


### PR DESCRIPTION
## Summary

- avoid `Class#subclasses` while registering generated model `OrHash` aliases because ActiveSupport 5 and 6 implement it through `==`
- enumerate only direct `BaseModel` subclasses and compare their superclass by object identity
- add an isolated load-order regression test that reproduces ActiveSupport 6's implementation and verifies model alias registration

Fixes #335.

## Why this is narrow

This does not monkeypatch ActiveSupport or Ruby, and it does not change `BaseModel.==`. The identity-safe enumeration is local to generated model initialization. The generator preserves the existing output for `StainlessParity` and emits this behavior only for the OpenAI codegen profile.

Generator change: [openai/openai#1237327](https://github.com/openai/openai/pull/1237327)

## Test plan

- `mise exec ruby@4.0.6 -- ./scripts/test` — 515 runs, 1,692 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2,596 files, no offenses
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck:sorbet`
- `mise exec ruby@4.0.6 -- bundle exec rake validate:rbs` — 1,211 RBS files
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem`
- load after real ActiveSupport 5.2.8.1, 6.0.6.1, 6.1.7.10, and 7.2.2.1
- verify all 2,266 generated direct model classes receive `OrHash`
