### PR TITLE
fix: correct README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ All parameter and response objects inherit from `OpenAI::Internal::Type::BaseMod
 
 You can send undocumented parameters to any endpoint, and read undocumented response properties, like so:
 
-Note: the `extra_` parameters of the same name overrides the documented parameters.
+Note: the `extra_` parameters of the same name override the documented parameters.
 
 ```ruby
 chat_completion =


### PR DESCRIPTION
## Summary

- fix subject-verb agreement in the README's undocumented-parameter guidance

## Why

The sentence uses the plural subject `parameters`, so the verb should be `override`, not `overrides`.

This intentionally uses a conventional `fix:` commit so that, after merge, Release Please should create or update a patch release PR through the new GitHub App authentication path.

## Validation

- `git diff --check`
- thermo-nuclear code quality review
- README-only one-word substitution