### PR TITLE
fix(internal): encode nested multipart fields with bracket notation

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -616,6 +616,32 @@ module OpenAI
 
         # @api private
         #
+        # Flattens nested hashes into `deepObject` style bracket notation
+        # (`expires_after[anchor]`), matching how the OpenAI API expects nested
+        # multipart fields to be encoded.
+        #
+        # @param y [Enumerator::Yielder]
+        # @param boundary [String]
+        # @param key [Symbol, String]
+        # @param val [Object]
+        # @param closing [Array<Proc>]
+        private def write_multipart_value(y, boundary:, key:, val:, closing:)
+          case val
+          in Hash
+            val.each do |k, v|
+              write_multipart_value(y, boundary: boundary, key: "#{key}[#{k}]", val: v, closing: closing)
+            end
+          in Array
+            val.each do |v|
+              write_multipart_value(y, boundary: boundary, key: "#{key}[]", val: v, closing: closing)
+            end
+          else
+            write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)
+          end
+        end
+
+        # @api private
+        #
         # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#special-considerations-for-multipart-content
         #
         # @param body [Object]
@@ -637,7 +663,7 @@ module OpenAI
                     write_multipart_chunk(y, boundary: boundary, key: key, val: v, closing: closing)
                   end
                 else
-                  write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)
+                  write_multipart_value(y, boundary: boundary, key: key, val: val, closing: closing)
                 end
               end
             else

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -361,6 +361,23 @@ module OpenAI
 
         # @api private
         #
+        # Flattens nested hashes into `deepObject` style bracket notation
+        # (`expires_after[anchor]`), matching how the OpenAI API expects nested
+        # multipart fields to be encoded.
+        sig do
+          params(
+            y: Enumerator::Yielder,
+            boundary: String,
+            key: T.any(Symbol, String),
+            val: T.anything,
+            closing: T::Array[T.proc.void]
+          ).void
+        end
+        private def write_multipart_value(y, boundary:, key:, val:, closing:)
+        end
+
+        # @api private
+        #
         # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#special-considerations-for-multipart-content
         sig do
           params(body: T.anything).returns([String, T::Enumerable[String]])

--- a/sig/openai/internal/util.rbs
+++ b/sig/openai/internal/util.rbs
@@ -135,6 +135,14 @@ module OpenAI
         closing: ::Array[^-> void]
       ) -> void
 
+      def self?.write_multipart_value: (
+        Enumerator::Yielder y,
+        boundary: String,
+        key: Symbol | String,
+        val: top,
+        closing: ::Array[^-> void]
+      ) -> void
+
       def self?.encode_multipart_streaming: (
         top body
       ) -> [String, Enumerable[String]]

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -312,6 +312,34 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
       end
     end
   end
+
+  def test_nested_hash_encode
+    headers = {"content-type" => "multipart/form-data"}
+    cases = {
+      {expires_after: {anchor: :created_at, seconds: 3600}} => {
+        "expires_after[anchor]" => "created_at",
+        "expires_after[seconds]" => "3600"
+      },
+      {a: {b: {c: 1}}} => {"a[b][c]" => "1"},
+      {a: {b: [1, 2]}} => {"a[b][]" => "1"}
+    }
+    cases.each do |body, testcase|
+      encoded = OpenAI::Internal::Util.encode_content(headers, body)
+      cgi = FakeCGI.new(*encoded)
+      testcase.each do |key, val|
+        assert_pattern do
+          parsed =
+            case (p = cgi[key])
+            in StringIO
+              p.read
+            else
+              p
+            end
+          parsed => ^val
+        end
+      end
+    end
+  end
 end
 
 class OpenAI::Test::UtilIOAdapterTest < Minitest::Test


### PR DESCRIPTION
The OpenAI API expects nested fields in multipart/form-data bodies to be flattened deepObject-style (e.g. `expires_after[anchor]=created_at`), but nested hashes were serialized as a single JSON part, which the API rejects with "Additional properties are not allowed ('expires_after' was unexpected)".

Flatten nested hashes and arrays inside multipart bodies using bracket notation, matching openai-python's `_serialize_multipartform` (qs "brackets" array format). Top-level primitive arrays keep the existing repeated-key encoding.

Fixes #212