### PR TITLE
fix: encode multipart array and nested fields

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -496,14 +496,14 @@ module OpenAI
 
         # @api private
         #
-        # Multipart filenames are quoted-strings, not URI path segments. Escape header
-        # delimiters and remove CR/LF without encoding ordinary filename characters.
+        # Multipart disposition parameters are quoted-strings, not URI path segments.
+        # Escape header delimiters and remove CR/LF without encoding ordinary characters.
         #
-        # @param filename [Pathname, String]
+        # @param value [Pathname, String, Symbol]
         #
         # @return [String]
-        private def escape_multipart_filename(filename)
-          filename.to_s.gsub(/["\\]/) { "\\#{_1}" }.delete("\r\n").b
+        private def escape_multipart_header_param(value)
+          value.to_s.gsub(/["\\]/) { "\\#{_1}" }.delete("\r\n").b
         end
 
         # @api private
@@ -518,15 +518,16 @@ module OpenAI
           y << "Content-Disposition: form-data"
 
           unless key.nil?
-            y << "; name=\"#{key}\""
+            name = escape_multipart_header_param(key)
+            y << "; name=\"#{name}\""
           end
 
           case val
           in OpenAI::FilePart unless val.filename.nil?
-            filename = escape_multipart_filename(val.filename)
+            filename = escape_multipart_header_param(val.filename)
             y << "; filename=\"#{filename}\""
           in Pathname | IO
-            filename = escape_multipart_filename(::File.basename(val.to_path))
+            filename = escape_multipart_header_param(::File.basename(val.to_path))
             y << "; filename=\"#{filename}\""
           else
           end
@@ -537,13 +538,34 @@ module OpenAI
 
         # @api private
         #
+        # @param y [Enumerator::Yielder]
+        # @param boundary [String]
+        # @param key [Symbol, String]
+        # @param val [Object]
+        # @param closing [Array<Proc>]
+        private def write_multipart_value(y, boundary:, key:, val:, closing:)
+          case val
+          in Hash
+            val.each do |name, value|
+              write_multipart_value(y, boundary: boundary, key: "#{key}[#{name}]", val: value, closing: closing)
+            end
+          in Array
+            val.each do |value|
+              write_multipart_value(y, boundary: boundary, key: "#{key}[]", val: value, closing: closing)
+            end
+          else
+            write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)
+          end
+        end
+
+        # @api private
+        #
         # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#special-considerations-for-multipart-content
         #
         # @param body [Object]
         #
         # @return [Array(String, Enumerable<String>)]
         private def encode_multipart_streaming(body)
-          # rubocop:disable Style/CaseEquality
           # RFC 1521 Section 7.2.1 says we should have 70 char maximum for boundary length
           boundary = SecureRandom.urlsafe_base64(46)
 
@@ -552,14 +574,7 @@ module OpenAI
             case body
             in Hash
               body.each do |key, val|
-                case val
-                in Array if val.all? { primitive?(_1) || OpenAI::Internal::Type::FileInput === _1 }
-                  val.each do |v|
-                    write_multipart_chunk(y, boundary: boundary, key: key, val: v, closing: closing)
-                  end
-                else
-                  write_multipart_chunk(y, boundary: boundary, key: key, val: val, closing: closing)
-                end
+                write_multipart_value(y, boundary: boundary, key: key, val: val, closing: closing)
               end
             else
               write_multipart_chunk(y, boundary: boundary, key: nil, val: body, closing: closing)
@@ -569,7 +584,6 @@ module OpenAI
 
           fused_io = fused_enum(strio) { closing.each(&:call) }
           [boundary, fused_io]
-          # rubocop:enable Style/CaseEquality
         end
 
         # @api private

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -307,6 +307,11 @@ module OpenAI
         end
 
         # @api private
+        sig { params(value: T.any(Pathname, String, Symbol)).returns(String) }
+        private def escape_multipart_header_param(value)
+        end
+
+        # @api private
         sig do
           params(
             y: Enumerator::Yielder,
@@ -317,6 +322,19 @@ module OpenAI
           ).void
         end
         private def write_multipart_chunk(y, boundary:, key:, val:, closing:)
+        end
+
+        # @api private
+        sig do
+          params(
+            y: Enumerator::Yielder,
+            boundary: String,
+            key: T.any(Symbol, String),
+            val: T.anything,
+            closing: T::Array[T.proc.void]
+          ).void
+        end
+        private def write_multipart_value(y, boundary:, key:, val:, closing:)
         end
 
         # @api private

--- a/sig/openai/internal/util.rbs
+++ b/sig/openai/internal/util.rbs
@@ -111,7 +111,19 @@ module OpenAI
         ?content_type: String?
       ) -> void
 
+      def self?.escape_multipart_header_param: (
+        Pathname | String | Symbol value
+      ) -> String
+
       def self?.write_multipart_chunk: (
+        Enumerator::Yielder y,
+        boundary: String,
+        key: Symbol | String,
+        val: top,
+        closing: ::Array[^-> void]
+      ) -> void
+
+      def self?.write_multipart_value: (
         Enumerator::Yielder y,
         boundary: String,
         key: Symbol | String,

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -284,12 +284,116 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     assert_includes(body, "filename=\"\u00E9.png\"".b)
   end
 
+  def test_multipart_field_name_quoting
+    _headers, stream = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      {"a \"b\"\\c\r\nEvil: 1" => "x"}
+    )
+    body = stream.respond_to?(:read) ? stream.read : stream.to_a.join
+
+    assert_includes(body, %q(name="a \"b\"\\\\cEvil: 1"))
+    refute_includes(body, "\r\nEvil:")
+  end
+
+  def test_primitive_arrays_use_bracketed_field_names
+    body, = OpenAI::Audio::TranscriptionCreateParams.dump_request(
+      file: OpenAI::FilePart.new("audio", filename: "audio.wav"),
+      model: :"whisper-1",
+      timestamp_granularities: [:word, :segment]
+    )
+    encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      body
+    )
+    cgi = FakeCGI.new(*encoded)
+
+    assert_equal(%w[word segment], cgi.params.fetch("timestamp_granularities[]"))
+    refute_includes(cgi.params, "timestamp_granularities")
+  end
+
+  def test_file_arrays_use_bracketed_field_names
+    files = [
+      OpenAI::FilePart.new(StringIO.new("a"), filename: "a.png"),
+      OpenAI::FilePart.new(StringIO.new("b"), filename: "b.png")
+    ]
+    body, = OpenAI::ImageEditParams.dump_request(image: files, prompt: "Edit both images")
+    encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      body
+    )
+    parts = FakeCGI.new(*encoded).params
+
+    assert_equal(["image[]"], parts.keys.grep(/^image/))
+    assert_equal(%w[a.png b.png], parts.fetch("image[]").map(&:original_filename))
+    assert_equal(%w[a b], parts.fetch("image[]").map(&:read))
+  end
+
+  def test_scalar_files_keep_unbracketed_field_names
+    body, = OpenAI::ImageEditParams.dump_request(
+      image: OpenAI::FilePart.new(StringIO.new("image"), filename: "image.png"),
+      prompt: "Edit one image"
+    )
+    encoded = OpenAI::Internal::Util.encode_content({"content-type" => "multipart/form-data"}, body)
+    parts = FakeCGI.new(*encoded).params
+
+    assert_equal(["image"], parts.keys.grep(/^image/))
+    assert_equal(["image.png"], parts.fetch("image").map(&:original_filename))
+    assert_equal(["image"], parts.fetch("image").map(&:read))
+  end
+
+  def test_generated_nested_values_use_bracket_notation
+    body, = OpenAI::FileCreateParams.dump_request(
+      file: OpenAI::FilePart.new("{}", filename: "batch.jsonl"),
+      purpose: :batch,
+      expires_after: {anchor: :created_at, seconds: 3600}
+    )
+    encoded = OpenAI::Internal::Util.encode_content({"content-type" => "multipart/form-data"}, body)
+    parts = FakeCGI.new(*encoded).params
+
+    assert_equal(["created_at"], parts.fetch("expires_after[anchor]"))
+    assert_equal(["3600"], parts.fetch("expires_after[seconds]"))
+    refute_includes(parts, "expires_after")
+  end
+
+  def test_nested_values_use_bracket_notation
+    encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      {
+        expires_after: {anchor: :created_at, seconds: 3600},
+        items: [
+          {name: "first", tags: %w[a b]},
+          {name: "second", tags: %w[c]}
+        ]
+      }
+    )
+    cgi = FakeCGI.new(*encoded)
+
+    assert_equal(
+      {
+        "expires_after[anchor]" => ["created_at"],
+        "expires_after[seconds]" => ["3600"],
+        "items[][name]" => %w[first second],
+        "items[][tags][]" => %w[a b c]
+      },
+      cgi.params
+    )
+  end
+
+  def test_empty_collections_are_omitted
+    encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      {empty_array: [], empty_hash: {}, nested: {empty: []}, present: 1}
+    )
+    cgi = FakeCGI.new(*encoded)
+
+    assert_equal({"present" => ["1"]}, cgi.params)
+  end
+
   def test_hash_encode
     headers = {"content-type" => "multipart/form-data"}
     cases = {
       {a: 2, b: 3} => {"a" => "2", "b" => "3"},
       {a: 2, b: nil} => {"a" => "2", "b" => "null"},
-      {a: 2, b: [1, 2, 3]} => {"a" => "2", "b" => "1"},
       {strio: StringIO.new("a")} => {"strio" => "a"},
       {strio: OpenAI::FilePart.new("a")} => {"strio" => "a"},
       {pathname: Pathname(__FILE__)} => {"pathname" => -> { _1.read in /^class OpenAI/ }},


### PR DESCRIPTION
## Summary

- encode multipart arrays recursively as `field[]`, including both primitive and file arrays
- flatten nested multipart objects with bracket notation, including arrays of nested objects
- preserve scalar field names and streaming file behavior
- escape both `name` and `filename` `Content-Disposition` parameters
- keep the fix entirely in the openai-ruby runtime; no generated model, OpenAPI, or Castiron changes are needed

## Root cause

The shared multipart writer repeated top-level primitive and file arrays using the scalar field name and serialized nested hashes as JSON parts. The API's form parser expects the same global brackets format used by openai-python and by the transformed OpenAPI examples.

Before:

- `timestamp_granularities=word` and `timestamp_granularities=segment`
- duplicate scalar `image` file parts
- one JSON `expires_after` part

After:

- `timestamp_granularities[]=word` and `timestamp_granularities[]=segment`
- duplicate `image[]` file parts, while a single image remains `image`
- `expires_after[anchor]=created_at` and `expires_after[seconds]=3600`

The implementation replaces the old top-level array special case with one recursive field writer. It preserves insertion order, array order, duplicate values, and streaming file contents without materializing a flattened body.

This consolidates and supersedes #249, #311, and #339.

Fixes #201.
Fixes #212.
Fixes #253.

## Validation

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/util_test.rb` — 45 runs, 178 assertions
- `mise exec ruby@4.0.6 -- ./scripts/test` — 522 runs, 1,709 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — 2,596 files, no RuboCop offenses; Sorbet clean; 1,211 RBS files valid
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem` — built `openai-0.78.0.gem`
- RBI and RBS formatting plus `git diff --check`
- thermo-nuclear maintainability review and a separate correctness/readability/architecture/security/performance review, repeated after findings until clean
