### PR TITLE
fix: return values from interruptible enumerator

### DIFF
--- a/lib/openai/internal/read_io_adapter.rb
+++ b/lib/openai/internal/read_io_adapter.rb
@@ -36,7 +36,6 @@ module OpenAI
           def to_a
             values = []
             loop { values << self.next }
-          rescue StopIteration
             values
           end
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -330,6 +330,14 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
     end
   end
 
+  def test_read_all_from_enumerator
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["hello ", "world"].each) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    assert_equal("hello world", adapter.read)
+  end
+
   def test_copy_write
     cases = {
       StringIO.new => "",


### PR DESCRIPTION
## Summary

- return collected values from `InterruptibleEnumerator#to_a`
- cover whole-body reads from Enumerator-backed request bodies

## Root cause

`Kernel#loop` consumes `StopIteration` internally, so the method-level rescue never ran and `to_a` returned `nil`. `ReadIOAdapter#read` then failed when it called `join` on that result.

This restores whole-body reads used by WebMock and other consumers that read an Enumerator-backed body without a length.

Fixes #349

## Validation

- focused adapter tests: 39 runs, 162 assertions
- full suite: 516 runs, 1,693 assertions
- RuboCop: 2,596 files, no offenses
- Sorbet: no errors
- RBS: 1,211 files validated
- gem build
- thermo-nuclear code quality review