### PR TITLE
test: cover Bundler autorequire under Tapioca DSL

### DIFF
--- a/test/openai/load_order_test.rb
+++ b/test/openai/load_order_test.rb
@@ -6,6 +6,32 @@ require "rbconfig"
 require_relative "test_helper"
 
 class OpenAI::Test::LoadOrderTest < Minitest::Test
+  def test_bundler_autorequires_openai_during_tapioca_dsl
+    script = <<~RUBY
+      module Tapioca
+      end
+
+      $PROGRAM_NAME = "tapioca"
+      ARGV.replace(["dsl"])
+
+      require "bundler/setup"
+      Bundler.require(:default)
+
+      raise "OpenAI::Client was not autorequired" unless defined?(OpenAI::Client)
+    RUBY
+
+    _, stderr, status =
+      Open3.capture3(
+        {"RUBYOPT" => nil},
+        RbConfig.ruby,
+        "-e",
+        script,
+        chdir: File.expand_path("../..", __dir__)
+      )
+
+    assert_predicate(status, :success?, stderr)
+  end
+
   def test_loads_after_active_support_6_subclass_extensions
     script = <<~RUBY
       class Class


### PR DESCRIPTION
## Summary

- add a subprocess regression test for Bundler autorequiring `OpenAI::Client`
- exercise the historical `tapioca dsl` invocation without an explicit `require "openai"`

## Why

The follow-up investigation for #307 confirmed that normal Rails boot already worked and that the specific Tapioca load failure was fixed in 0.5.0. This test protects the Bundler loading contract Rails relies on and the historical Tapioca guard behavior without adding Rails as a development dependency.

## Validation

- mutation check: restoring the pre-0.5.0 guard makes the new test fail with `OpenAI::Client was not autorequired`
- `TEST=./test/openai/load_order_test.rb ./scripts/test`
- `./scripts/test` — 516 tests, 1,693 assertions
- `bundle exec rubocop test/openai/load_order_test.rb`