### PR TITLE
feat: expose request IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,5 @@
 # Contributor instructions
 
-## Pull requests
-
-- Before pushing code, run the `thermo-nuclear-code-quality-review` skill and address its findings.
-- After submitting a pull request, monitor CI, fix failures, and push the fixes. Once CI is green, ask for review in `#sdk-reviews`, create a thread, and keep follow-up asks in that thread.
-- When addressing pull request feedback, push the fix, reply to each comment with what changed, and then resolve the thread.
-
 ## Ruby implementation guidelines
 
 - Prefer direct method calls over Ruby reflection (`send`, `__send__`, or `public_send`) for internal SDK plumbing. When an internal method must be callable across components without becoming supported public API, keep the method public for direct dispatch and mark it `@api private`. Keep its RBI and RBS declarations at the same visibility.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Contributor instructions
+
+## Pull requests
+
+- Before pushing code, run the `thermo-nuclear-code-quality-review` skill and address its findings.
+- After submitting a pull request, monitor CI, fix failures, and push the fixes. Once CI is green, ask for review in `#sdk-reviews`, create a thread, and keep follow-up asks in that thread.
+- When addressing pull request feedback, push the fix, reply to each comment with what changed, and then resolve the thread.
+
+## Ruby implementation guidelines
+
+- Prefer direct method calls over Ruby reflection (`send`, `__send__`, or `public_send`) for internal SDK plumbing. When an internal method must be callable across components without becoming supported public API, keep the method public for direct dispatch and mark it `@api private`. Keep its RBI and RBS declarations at the same visibility.

--- a/README.md
+++ b/README.md
@@ -565,6 +565,36 @@ Error codes are as follows:
 | Timeout          | `APITimeoutError`          |
 | Network error    | `APIConnectionError`       |
 
+### Request IDs
+
+OpenAI recommends logging request IDs in production so requests can be traced
+during troubleshooting. Successful typed responses expose `_request_id`, which
+is populated from the `x-request-id` response header:
+
+```ruby
+response = openai.responses.create(model: "gpt-5.2", input: "Say 'this is a test'.")
+puts(response._request_id) # req_123
+```
+
+The `_request_id` property is only populated on the top-level response object
+and is not included in `to_h`, JSON, or YAML output. Unlike other properties
+that begin with an underscore, `_request_id` is public.
+
+For failed HTTP requests, catch `OpenAI::Errors::APIStatusError` and use
+`request_id`:
+
+```ruby
+begin
+  openai.responses.create(model: "gpt-5.2", input: "Say 'this is a test'.")
+rescue OpenAI::Errors::APIStatusError => e
+  puts(e.request_id) # req_123
+  raise
+end
+```
+
+See the [official OpenAI request debugging documentation](https://developers.openai.com/api/reference/overview#debugging-requests)
+for more information.
+
 ### Retries
 
 Certain errors will be automatically retried 2 times by default, with a short exponential backoff.

--- a/lib/openai/errors.rb
+++ b/lib/openai/errors.rb
@@ -58,6 +58,13 @@ module OpenAI
       # @return [String, nil]
       attr_accessor :type
 
+      # The ID of the API request, returned via the `x-request-id` response
+      # header. This is nil when no HTTP response was received or the response
+      # did not include the header.
+      #
+      # @return [String, nil]
+      def request_id = headers&.[]("x-request-id")
+
       # @api private
       #
       # @param url [URI::Generic]

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -639,7 +639,11 @@ module OpenAI
             page.new(client: self, req: req, headers: response.headers, page_data: decoded)
           else
             unwrapped = OpenAI::Internal::Util.dig(decoded, unwrap)
-            OpenAI::Internal::Type::Converter.coerce(model, unwrapped)
+            OpenAI::Internal::Type::Converter.coerce(model, unwrapped).tap do |result|
+              if result.is_a?(OpenAI::Internal::Type::BaseModel)
+                result.__send__(:_set_request_id, response.headers["x-request-id"])
+              end
+            end
           end
         end
 

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -641,7 +641,7 @@ module OpenAI
             unwrapped = OpenAI::Internal::Util.dig(decoded, unwrap)
             OpenAI::Internal::Type::Converter.coerce(model, unwrapped).tap do |result|
               if result.is_a?(OpenAI::Internal::Type::BaseModel)
-                result.__send__(:_set_request_id, response.headers["x-request-id"])
+                result._set_request_id(response.headers["x-request-id"])
               end
             end
           end

--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -226,6 +226,24 @@ module OpenAI
         # @return [Integer]
         def hash = [self.class, @data].hash
 
+        # The ID of the API request, returned via the `x-request-id` response
+        # header. This is only populated on top-level response objects returned
+        # by the client.
+        #
+        # @api public
+        #
+        # @return [String, nil]
+        attr_reader :_request_id
+
+        # @api private
+        #
+        # @param request_id [String, nil]
+        # @return [self]
+        private def _set_request_id(request_id)
+          @_request_id = request_id
+          self
+        end
+
         class << self
           # @api private
           #

--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -239,7 +239,7 @@ module OpenAI
         #
         # @param request_id [String, nil]
         # @return [self]
-        private def _set_request_id(request_id)
+        def _set_request_id(request_id)
           @_request_id = request_id
           self
         end

--- a/lib/openai/internal/type/base_page.rb
+++ b/lib/openai/internal/type/base_page.rb
@@ -11,6 +11,15 @@ module OpenAI
       module BasePage
         # rubocop:disable Lint/UnusedMethodArgument
 
+        # The ID of the API request, returned via the `x-request-id` response
+        # header. This is only populated on top-level response objects returned
+        # by the client.
+        #
+        # @api public
+        #
+        # @return [String, nil]
+        attr_reader :_request_id
+
         # @api public
         #
         # @return [Boolean]
@@ -45,6 +54,7 @@ module OpenAI
           @client = client
           @req = req
           @model = req.fetch(:model)
+          @_request_id = headers["x-request-id"]
           super()
         end
 

--- a/rbi/openai/errors.rbi
+++ b/rbi/openai/errors.rbi
@@ -48,6 +48,13 @@ module OpenAI
       sig { returns(T.nilable(String)) }
       attr_accessor :type
 
+      # The ID of the API request, returned via the `x-request-id` response
+      # header. This is nil when no HTTP response was received or the response
+      # did not include the header.
+      sig { returns(T.nilable(String)) }
+      def request_id
+      end
+
       # @api private
       sig do
         params(

--- a/rbi/openai/internal/type/base_model.rbi
+++ b/rbi/openai/internal/type/base_model.rbi
@@ -170,7 +170,7 @@ module OpenAI
 
         # @api private
         sig { params(request_id: T.nilable(String)).returns(T.self_type) }
-        private def _set_request_id(request_id)
+        def _set_request_id(request_id)
         end
 
         class << self

--- a/rbi/openai/internal/type/base_model.rbi
+++ b/rbi/openai/internal/type/base_model.rbi
@@ -161,6 +161,18 @@ module OpenAI
         def hash
         end
 
+        # The ID of the API request, returned via the `x-request-id` response
+        # header. This is only populated on top-level response objects returned
+        # by the client.
+        sig { returns(T.nilable(String)) }
+        def _request_id
+        end
+
+        # @api private
+        sig { params(request_id: T.nilable(String)).returns(T.self_type) }
+        private def _set_request_id(request_id)
+        end
+
         class << self
           # @api private
           sig do

--- a/rbi/openai/internal/type/base_page.rbi
+++ b/rbi/openai/internal/type/base_page.rbi
@@ -9,6 +9,13 @@ module OpenAI
       module BasePage
         Elem = type_member(:out)
 
+        # The ID of the API request, returned via the `x-request-id` response
+        # header. This is only populated on top-level response objects returned
+        # by the client.
+        sig { returns(T.nilable(String)) }
+        def _request_id
+        end
+
         sig { overridable.returns(T::Boolean) }
         def next_page?
         end

--- a/sig/openai/errors.rbs
+++ b/sig/openai/errors.rbs
@@ -31,6 +31,11 @@ module OpenAI
 
       attr_accessor type: String?
 
+      # The ID of the API request, returned via the `x-request-id` response
+      # header. This is nil when no HTTP response was received or the response
+      # did not include the header.
+      def request_id: -> String?
+
       def initialize: (
         url: URI::Generic,
         ?status: Integer?,

--- a/sig/openai/internal/type/base_model.rbs
+++ b/sig/openai/internal/type/base_model.rbs
@@ -58,6 +58,13 @@ module OpenAI
 
         def hash: -> Integer
 
+        # The ID of the API request, returned via the `x-request-id` response
+        # header. This is only populated on top-level response objects returned
+        # by the client.
+        def _request_id: -> String?
+
+        private def _set_request_id: (String? request_id) -> self
+
         def self.coerce: (
           OpenAI::Internal::Type::BaseModel | ::Hash[top, top] | top value,
           state: OpenAI::Internal::Type::Converter::coerce_state

--- a/sig/openai/internal/type/base_model.rbs
+++ b/sig/openai/internal/type/base_model.rbs
@@ -63,7 +63,7 @@ module OpenAI
         # by the client.
         def _request_id: -> String?
 
-        private def _set_request_id: (String? request_id) -> self
+        def _set_request_id: (String? request_id) -> self
 
         def self.coerce: (
           OpenAI::Internal::Type::BaseModel | ::Hash[top, top] | top value,

--- a/sig/openai/internal/type/base_page.rbs
+++ b/sig/openai/internal/type/base_page.rbs
@@ -2,6 +2,11 @@ module OpenAI
   module Internal
     module Type
       module BasePage[Elem]
+        # The ID of the API request, returned via the `x-request-id` response
+        # header. This is only populated on top-level response objects returned
+        # by the client.
+        def _request_id: -> String?
+
         def next_page?: -> bool
 
         def next_page: -> instance

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -150,6 +150,80 @@ class OpenAITest < Minitest::Test
     assert_requested(:get, "http://localhost/responses/resp_123?stream=true", times: 1)
   end
 
+  def test_request_id_on_successful_response
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(
+      status: 200,
+      headers: {"x-request-id" => "req_success"},
+      body: {
+        id: "chatcmpl_123",
+        choices: [],
+        created: 1_700_000_000,
+        model: "gpt-5.4",
+        object: "chat.completion"
+      }
+    )
+
+    openai =
+      OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "My API Key",
+        admin_api_key: "My Admin API Key"
+      )
+
+    response = openai.chat.completions.create(
+      messages: [{content: "string", role: :developer}],
+      model: :"gpt-5.4"
+    )
+
+    assert_equal("req_success", response._request_id)
+    refute_includes(response.to_h, :_request_id)
+    refute_includes(response.to_json, "_request_id")
+    refute_includes(response.to_yaml, "_request_id")
+  end
+
+  def test_request_id_on_paginated_response
+    stub_request(:get, "http://localhost/models").to_return_json(
+      status: 200,
+      headers: {"x-request-id" => "req_page"},
+      body: {data: [], object: "list"}
+    )
+
+    openai =
+      OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "My API Key",
+        admin_api_key: "My Admin API Key"
+      )
+
+    response = openai.models.list
+
+    assert_equal("req_page", response._request_id)
+  end
+
+  def test_request_id_on_error_response
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(
+      status: 400,
+      headers: {"x-request-id" => "req_error"},
+      body: {error: {message: "Invalid request"}}
+    )
+
+    openai =
+      OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "My API Key",
+        admin_api_key: "My Admin API Key"
+      )
+
+    error = assert_raises(OpenAI::Errors::BadRequestError) do
+      openai.chat.completions.create(
+        messages: [{content: "string", role: :developer}],
+        model: :"gpt-5.4"
+      )
+    end
+
+    assert_equal("req_error", error.request_id)
+  end
+
   def test_client_default_request_default_retry_attempts
     stub_request(:post, "http://localhost/chat/completions").to_return_json(status: 500, body: {})
 


### PR DESCRIPTION
## Summary

- expose the server-generated `x-request-id` as `_request_id` on successful typed model and paginated responses
- expose `request_id` on API errors
- add RBI and RBS declarations plus user-facing documentation
- cover model responses, page responses, error responses, and serialization behavior

## Why

The Ruby SDK retained response headers at the transport boundary but discarded them while coercing successful responses into typed objects. Errors retained their headers but required callers to inspect the header hash manually. This left Ruby behind the other official SDKs for request-ID convenience and made production troubleshooting harder.

Request IDs are response metadata, so they are attached only to the top-level returned object and are excluded from `to_h`, JSON, and YAML serialization.

## Validation

- thermo-nuclear code-quality review
- `./scripts/test` on Ruby 4.0.6 — 518 runs, 1702 assertions
- `./scripts/test` on Ruby 3.3.12 — 518 runs, 1702 assertions
- `bundle exec rake lint:rubocop` — 2596 files, no offenses
- `bundle exec rake typecheck:sorbet`
- `bundle exec rake validate:rbs` — 1211 files
- `bundle exec rake build:gem`

Surface gap: https://openai-sdk-surface-atlas.openai.chatgpt.site/?capability=request-id#matrix