### PR TITLE
fix: preserve binary multipart stream reads

### DIFF
--- a/lib/openai/internal/read_io_adapter.rb
+++ b/lib/openai/internal/read_io_adapter.rb
@@ -69,18 +69,36 @@ module OpenAI
         #
         # @param max_len [Integer, nil]
         #
-        # @return [String]
+        # @return [String, nil]
         private def read_enum(max_len)
           case max_len
           in nil
-            @stream.to_a.join
+            # `loop` rescues StopIteration, but this method handles it below.
+            # rubocop:disable Style/InfiniteLoop
+            @buf << @stream.next.b while true
+            # rubocop:enable Style/InfiniteLoop
           in Integer
-            @buf << @stream.next while @buf.length < max_len
-            @buf.slice!(..max_len)
+            @buf << @stream.next.b while @buf.bytesize < max_len
+            read_buffer(max_len)
           end
         rescue StopIteration
+          return @buf.slice!(0..) if max_len.nil?
+
           @stream = nil
-          @buf.slice!(0..)
+          return nil if @buf.bytesize.zero?
+
+          read_buffer(max_len)
+        end
+
+        # @api private
+        #
+        # @param max_len [Integer]
+        #
+        # @return [String]
+        private def read_buffer(max_len)
+          read = @buf.byteslice(0, max_len)
+          @buf = @buf.byteslice(max_len..) || String.new.b
+          read
         end
 
         # @api private
@@ -90,19 +108,26 @@ module OpenAI
         #
         # @return [String, nil]
         def read(max_len = nil, out_string = nil)
-          case @stream
-          in nil
-            nil
-          in IO | StringIO
-            @stream.read(max_len, out_string)
-          in Enumerator | InterruptibleEnumerator
-            read = read_enum(max_len)
-            case out_string
-            in String
-              out_string.replace(read)
+          if max_len.is_a?(Integer) && max_len.negative?
+            raise ArgumentError, "negative length #{max_len} given"
+          end
+
+          read =
+            case @stream
             in nil
-              read
+              max_len.nil? || max_len.zero? ? +"" : nil
+            in IO | StringIO
+              return @stream.read(max_len, out_string).tap(&@blk)
+            in Enumerator | InterruptibleEnumerator
+              read_enum(max_len)
             end
+
+          case out_string
+          in String
+            out_string.replace(read || +"")
+            read.nil? ? nil : out_string
+          in nil
+            read
           end
             .tap(&@blk)
         end
@@ -127,7 +152,7 @@ module OpenAI
             else
               src
             end
-          @buf = String.new
+          @buf = String.new.b
           @blk = blk
         end
       end

--- a/rbi/openai/internal/read_io_adapter.rbi
+++ b/rbi/openai/internal/read_io_adapter.rbi
@@ -18,8 +18,13 @@ module OpenAI
         end
 
         # @api private
-        sig { params(max_len: T.nilable(Integer)).returns(String) }
+        sig { params(max_len: T.nilable(Integer)).returns(T.nilable(String)) }
         private def read_enum(max_len)
+        end
+
+        # @api private
+        sig { params(max_len: Integer).returns(String) }
+        private def read_buffer(max_len)
         end
 
         # @api private

--- a/sig/openai/internal/read_io_adapter.rbs
+++ b/sig/openai/internal/read_io_adapter.rbs
@@ -6,7 +6,9 @@ module OpenAI
 
         def close: -> void
 
-        private def read_enum: (Integer? max_len) -> String
+        private def read_enum: (Integer? max_len) -> String?
+
+        private def read_buffer: (Integer max_len) -> String
 
         def read: (?Integer? max_len, ?String? out_string) -> String?
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -445,17 +445,15 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
   def test_io_read_preserves_native_length_conversion
     length = Object.new
     def length.to_int = 2
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(StringIO.new("abc")) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(
+      StringIO.new("abc")
+    ) { |_chunk| nil }
 
     assert_equal("ab", adapter.read(length))
   end
 
   def test_enum_read_respects_max_len
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(%w[abc def].to_enum) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(%w[abc def].to_enum) { |_chunk| nil }
 
     assert_equal("", adapter.read(0))
     assert_equal("a", adapter.read(1))
@@ -466,9 +464,7 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
 
   def test_enum_read_preserves_mixed_encoding_chunks_by_byte_length
     chunks = ["caf\u00E9", "\xFF\xFE".b]
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) { |_chunk| nil }
     actual = String.new.b
 
     while (chunk = adapter.read(2))
@@ -482,9 +478,7 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
 
   def test_enum_read_all_preserves_mixed_encoding_chunks
     chunks = ["caf\u00E9", "\xFF\xFE".b]
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) { |_chunk| nil }
 
     result = adapter.read
 
@@ -493,9 +487,7 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
   end
 
   def test_enum_read_all_includes_buffered_bytes
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(%w[abc def].to_enum) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(%w[abc def].to_enum) { |_chunk| nil }
 
     assert_equal("ab", adapter.read(2))
     assert_equal("cdef", adapter.read)
@@ -504,9 +496,7 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
 
   def test_enum_read_clears_out_string_at_eof
     out = +"stale"
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["abc"].to_enum) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["abc"].to_enum) { |_chunk| nil }
 
     assert_equal("abc", adapter.read(99, out))
     assert_same(out, adapter.read(0, out))
@@ -516,9 +506,7 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
   end
 
   def test_enum_read_rejects_negative_lengths
-    # rubocop:disable Lint/EmptyBlock
-    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["abc"].to_enum) {}
-    # rubocop:enable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["abc"].to_enum) { |_chunk| nil }
 
     assert_raises(ArgumentError) { adapter.read(-1) }
     assert_equal("abc", adapter.read(99))

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -442,6 +442,89 @@ class OpenAI::Test::UtilIOAdapterTest < Minitest::Test
     assert_equal("hello world", adapter.read)
   end
 
+  def test_io_read_preserves_native_length_conversion
+    length = Object.new
+    def length.to_int = 2
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(StringIO.new("abc")) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    assert_equal("ab", adapter.read(length))
+  end
+
+  def test_enum_read_respects_max_len
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(%w[abc def].to_enum) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    assert_equal("", adapter.read(0))
+    assert_equal("a", adapter.read(1))
+    assert_equal("bcd", adapter.read(3))
+    assert_equal("ef", adapter.read(99))
+    assert_nil(adapter.read(1))
+  end
+
+  def test_enum_read_preserves_mixed_encoding_chunks_by_byte_length
+    chunks = ["caf\u00E9", "\xFF\xFE".b]
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) {}
+    # rubocop:enable Lint/EmptyBlock
+    actual = String.new.b
+
+    while (chunk = adapter.read(2))
+      assert_operator(chunk.bytesize, :<=, 2)
+      actual << chunk
+    end
+
+    assert_equal(chunks.map(&:b).join, actual)
+    assert_equal(Encoding::ASCII_8BIT, actual.encoding)
+  end
+
+  def test_enum_read_all_preserves_mixed_encoding_chunks
+    chunks = ["caf\u00E9", "\xFF\xFE".b]
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(chunks.to_enum) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    result = adapter.read
+
+    assert_equal(chunks.map(&:b).join, result)
+    assert_equal(Encoding::ASCII_8BIT, result.encoding)
+  end
+
+  def test_enum_read_all_includes_buffered_bytes
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(%w[abc def].to_enum) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    assert_equal("ab", adapter.read(2))
+    assert_equal("cdef", adapter.read)
+    assert_equal("", adapter.read)
+  end
+
+  def test_enum_read_clears_out_string_at_eof
+    out = +"stale"
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["abc"].to_enum) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    assert_equal("abc", adapter.read(99, out))
+    assert_same(out, adapter.read(0, out))
+    assert_equal("", out)
+    assert_nil(adapter.read(1, out))
+    assert_equal("", out)
+  end
+
+  def test_enum_read_rejects_negative_lengths
+    # rubocop:disable Lint/EmptyBlock
+    adapter = OpenAI::Internal::Util::ReadIOAdapter.new(["abc"].to_enum) {}
+    # rubocop:enable Lint/EmptyBlock
+
+    assert_raises(ArgumentError) { adapter.read(-1) }
+    assert_equal("abc", adapter.read(99))
+    assert_raises(ArgumentError) { adapter.read(-1) }
+  end
+
   def test_copy_write
     cases = {
       StringIO.new => "",


### PR DESCRIPTION
## Summary

- preserve arbitrary binary bytes when multipart request bodies yield a mix of UTF-8 and binary chunks
- honor `IO#read(max_len, out_string)` byte limits, buffering, EOF, negative-length, and output-buffer semantics for Enumerator-backed bodies
- retain native `IO` and `StringIO` delegation, including implicit `to_int` length conversion
- update RBI/RBS contracts and add focused regression coverage

This fixes #317 and consolidates the complete behavior needed from #275, #294, and #324 on the current SDK-owned `ReadIOAdapter` implementation.

## Ownership

This is handwritten SDK runtime behavior introduced as an SDK-owned component in #345. It does not change OpenAPI inputs, Castiron facts, renderer rules, templates, or generator configuration.

## Validation

- `mise exec ruby@4.0.6 -- ./scripts/test` — 531 runs, 1,736 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop, Sorbet, and 1,211 RBS files clean
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem`
- installed-gem adapter probe
- Ruby 3.3.12 mixed-encoding compatibility probe
- 1,000 randomized read sequences compared against `StringIO`
- real local HTTP multipart upload with a 1 MiB binary file and UTF-8 prompt, verified byte-for-byte by SHA-256