### PR TITLE
docs: document fiber scheduler concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,11 +671,12 @@ response = client.request(
 #### Asynchronous requests with a fiber scheduler
 
 The default HTTP client also cooperates with Ruby's fiber scheduler interface
-(`Fiber.scheduler`). When a scheduler is active, network operations, streaming
-reads, retry delays, and waits for a pooled connection yield to other fibers
-instead of blocking the thread. Resource methods keep their normal return types;
-schedule each complete request or stream operation as a task using the scheduler
-implementation your application already uses.
+(`Fiber.scheduler`). When a request runs inside a non-blocking fiber managed by
+an active scheduler, network operations, streaming reads, retry delays, and
+waits for a pooled connection yield to other fibers instead of blocking the
+thread. Resource methods keep their normal return types; schedule each complete
+request or stream operation as a task using the scheduler implementation your
+application already uses.
 
 For example, with the [`async`](https://github.com/socketry/async) gem:
 
@@ -693,8 +694,9 @@ responses = Async do |task|
 end.wait
 ```
 
-Without an active fiber scheduler, calls block the current thread as usual. The
-SDK does not install a scheduler or depend on a particular scheduler gem.
+Outside a non-blocking fiber managed by an active scheduler, calls block the
+current thread as usual. The SDK does not install a scheduler or depend on a
+particular scheduler gem.
 
 #### Connection pooling
 

--- a/README.md
+++ b/README.md
@@ -668,6 +668,36 @@ response = client.request(
 
 `OpenAI::Client` instances using the default `OpenAI::NetHTTPClient` are threadsafe, but are only fork-safe when there are no in-flight HTTP requests. Injected HTTP clients are responsible for documenting and enforcing their own concurrency guarantees.
 
+#### Asynchronous requests with a fiber scheduler
+
+The default HTTP client also cooperates with Ruby's fiber scheduler interface
+(`Fiber.scheduler`). When a scheduler is active, network operations, streaming
+reads, retry delays, and waits for a pooled connection yield to other fibers
+instead of blocking the thread. Resource methods keep their normal return types;
+schedule each complete request or stream operation as a task using the scheduler
+implementation your application already uses.
+
+For example, with the [`async`](https://github.com/socketry/async) gem:
+
+```ruby
+require "async"
+
+prompts = ["Summarize the incident report.", "Draft the follow-up actions."]
+
+responses = Async do |task|
+  prompts.map do |prompt|
+    task.async do
+      openai.responses.create(model: "gpt-5.2", input: prompt)
+    end
+  end.map(&:wait)
+end.wait
+```
+
+Without an active fiber scheduler, calls block the current thread as usual. The
+SDK does not install a scheduler or depend on a particular scheduler gem.
+
+#### Connection pooling
+
 By default, each `OpenAI::Client` creates its own HTTP connection pool with a size of at least 99 connections. As such, we recommend instantiating the client once per application in most settings. An injected HTTP client may instead share its pool across multiple SDK clients; the caller owns that HTTP client's lifecycle.
 
 When all available connections from the pool are checked out, requests wait for a new connection to become available, with queue time counting towards the request timeout.

--- a/lib/openai/net_http_client.rb
+++ b/lib/openai/net_http_client.rb
@@ -5,8 +5,9 @@ require_relative "internal/read_io_adapter"
 module OpenAI
   # The SDK's pooled Net::HTTP implementation.
   #
-  # Network operations cooperate with an active Ruby Fiber scheduler, allowing
-  # concurrent requests and streams without occupying one thread per request.
+  # Network operations from a non-blocking fiber cooperate with its active Ruby
+  # Fiber scheduler, allowing concurrent requests and streams without occupying
+  # one thread per request.
   #
   # Pass a block to configure each SDK-created connection before it is pooled
   # and started.

--- a/lib/openai/net_http_client.rb
+++ b/lib/openai/net_http_client.rb
@@ -5,6 +5,9 @@ require_relative "internal/read_io_adapter"
 module OpenAI
   # The SDK's pooled Net::HTTP implementation.
   #
+  # Network operations cooperate with an active Ruby Fiber scheduler, allowing
+  # concurrent requests and streams without occupying one thread per request.
+  #
   # Pass a block to configure each SDK-created connection before it is pooled
   # and started.
   class NetHTTPClient < HTTPClient

--- a/test/openai/async_concurrency_test.rb
+++ b/test/openai/async_concurrency_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "socket"
+
+require_relative "test_helper"
+
+class AsyncConcurrencyTest < Minitest::Test
+  extend Minitest::Serial
+
+  def test_net_http_client_requests_cooperate_with_a_fiber_scheduler
+    server = TCPServer.new("127.0.0.1", 0)
+    server_thread = Thread.new do
+      # Neither request can finish until both have reached the server. If the
+      # first request blocks the scheduler's thread, this test times out.
+      connections = 2.times.map { server.accept }
+      connections.each do |socket|
+        socket.gets
+        loop do
+          line = socket.gets
+          break if line.nil? || line == "\r\n"
+        end
+      end
+
+      body = '{"ok":true}'
+      connections.each do |socket|
+        socket.write(
+          "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+          "Content-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}"
+        )
+      end
+    ensure
+      connections&.each do |socket|
+        socket.close
+      rescue IOError
+        nil
+      end
+    end
+
+    http_client = OpenAI::NetHTTPClient.new(size: 2)
+    port = server.local_address.ip_port
+    client = OpenAI::Client.new(
+      api_key: "test-key",
+      base_url: "http://127.0.0.1:#{port}",
+      timeout: 2,
+      max_retries: 0,
+      http_client: http_client
+    )
+
+    responses =
+      Async do |task|
+        2.times.map do
+          task.async { client.request(method: :get, path: "probe") }
+        end.map(&:wait)
+      end.wait
+
+    assert_equal([{ok: true}, {ok: true}], responses)
+    server_thread.value
+  ensure
+    http_client&.close
+    server&.close
+    server_thread&.kill if server_thread&.alive?
+  end
+end


### PR DESCRIPTION
## Summary

- document that the default `Net::HTTP` transport cooperates with an active Ruby fiber scheduler
- add an `async` usage example without introducing a runtime dependency
- add a localhost integration test proving two requests can make progress concurrently on one scheduler thread

## Why

The [SDK Surface Atlas](https://openai-sdk-surface-atlas.openai.chatgpt.site/?capability=async&sdk=ruby#matrix) classifies Ruby async support as a gap because the official SDK does not document a native path. The existing transport already uses scheduler-aware Ruby I/O, so this makes that behavior an explicit, tested SDK contract instead of adding a duplicate async client hierarchy.

Without an active scheduler, requests retain their existing blocking behavior.

## Validation

- `mise exec ruby@4.0.6 -- ./scripts/test` — 525 runs, 1,712 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2,597 files, no offenses
- focused scheduler integration test on Ruby 3.3.12
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck`