### PR TITLE
docs: clarify file upload metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ end
 
 Request parameters that correspond to file uploads can be passed as raw contents, a [`Pathname`](https://rubyapi.org/3.3/o/pathname) instance, [`StringIO`](https://rubyapi.org/3.3/o/stringio), or more.
 
+Raw `String` and `StringIO` values, and `IO` objects without a path, do not carry format-identifying metadata. The SDK sends them using the fallback filename `upload`; raw `String` values default to `text/plain`, while `StringIO` and pathless `IO` values default to `application/octet-stream`. For format-sensitive endpoints, such as audio transcriptions, wrap each value in `OpenAI::FilePart` and provide an extension-bearing filename and content type.
+
 ```ruby
 require "pathname"
 
@@ -93,12 +95,25 @@ file_object = openai.files.create(file: File.read("input.jsonl"), purpose: "fine
 
 puts(file_object.id)
 
-# Or, to control the filename and/or content type:
-image = OpenAI::FilePart.new(Pathname('dog.jpg'), content_type: 'image/jpeg')
+# For format-sensitive uploads, provide the filename and content type:
+audio_data = StringIO.new(File.binread("audio.wav"))
+audio = OpenAI::FilePart.new(
+  audio_data,
+  filename: "audio.wav",
+  content_type: "audio/wav"
+)
+transcription = openai.audio.transcriptions.create(
+  model: "gpt-4o-transcribe",
+  file: audio
+)
+puts(transcription.text)
+
+# FilePart also accepts a Pathname:
+image = OpenAI::FilePart.new(Pathname("dog.jpg"), content_type: "image/jpeg")
 edited = openai.images.edit(
   prompt: "make this image look like a painting",
   model: "gpt-image-1",
-  size: '1024x1024',
+  size: "1024x1024",
   image: image
 )
 

--- a/lib/openai/models/audio/transcription_create_params.rb
+++ b/lib/openai/models/audio/transcription_create_params.rb
@@ -13,6 +13,12 @@ module OpenAI
         # @!attribute file
         #   The audio file object (not file name) to transcribe, in one of these formats:
         #   flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+        #   The request must include enough format metadata for the file to be identified.
+        #   We recommend an extension-bearing filename and an appropriate content type.
+        #
+        #   `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        #   metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        #   content type.
         #
         #   @return [Pathname, StringIO, IO, String, OpenAI::FilePart]
         required :file, OpenAI::Internal::Type::FileInput

--- a/lib/openai/models/audio/transcription_create_params.rb
+++ b/lib/openai/models/audio/transcription_create_params.rb
@@ -12,9 +12,9 @@ module OpenAI
 
         # @!attribute file
         #   The audio file object (not file name) to transcribe, in one of these formats:
-        #   flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-        #   The request must include enough format metadata for the file to be identified.
-        #   We recommend an extension-bearing filename and an appropriate content type.
+        #   flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+        #   enough format metadata for the file to be identified. We recommend an
+        #   extension-bearing filename and an appropriate content type.
         #
         #   `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
         #   metadata. Use `OpenAI::FilePart` when you need to override the filename or

--- a/lib/openai/models/audio/translation_create_params.rb
+++ b/lib/openai/models/audio/translation_create_params.rb
@@ -11,6 +11,12 @@ module OpenAI
         # @!attribute file
         #   The audio file object (not file name) translate, in one of these formats: flac,
         #   mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+        #   The request must include enough format metadata for the file to be identified.
+        #   We recommend an extension-bearing filename and an appropriate content type.
+        #
+        #   `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        #   metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        #   content type.
         #
         #   @return [Pathname, StringIO, IO, String, OpenAI::FilePart]
         required :file, OpenAI::Internal::Type::FileInput

--- a/lib/openai/models/audio/translation_create_params.rb
+++ b/lib/openai/models/audio/translation_create_params.rb
@@ -10,9 +10,9 @@ module OpenAI
 
         # @!attribute file
         #   The audio file object (not file name) translate, in one of these formats: flac,
-        #   mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-        #   The request must include enough format metadata for the file to be identified.
-        #   We recommend an extension-bearing filename and an appropriate content type.
+        #   mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough
+        #   format metadata for the file to be identified. We recommend an extension-bearing
+        #   filename and an appropriate content type.
         #
         #   `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
         #   metadata. Use `OpenAI::FilePart` when you need to override the filename or

--- a/lib/openai/resources/audio/transcriptions.rb
+++ b/lib/openai/resources/audio/transcriptions.rb
@@ -16,6 +16,10 @@ module OpenAI
         # Returns a transcription object in `json`, `diarized_json`, or `verbose_json`
         # format, or a stream of transcript events.
         #
+        # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        # content type.
+        #
         # @overload create(file:, model:, chunking_strategy: nil, include: nil, keywords: nil, known_speaker_names: nil, known_speaker_references: nil, language: nil, languages: nil, prompt: nil, response_format: nil, temperature: nil, timestamp_granularities: nil, request_options: {})
         #
         # @param file [Pathname, StringIO, IO, String, OpenAI::FilePart] The audio file object (not file name) to transcribe, in one of these formats: fl
@@ -76,6 +80,10 @@ module OpenAI
         #
         # Returns a transcription object in `json`, `diarized_json`, or `verbose_json`
         # format, or a stream of transcript events.
+        #
+        # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        # content type.
         #
         # @overload create_streaming(file:, model:, chunking_strategy: nil, include: nil, keywords: nil, known_speaker_names: nil, known_speaker_references: nil, language: nil, languages: nil, prompt: nil, response_format: nil, temperature: nil, timestamp_granularities: nil, request_options: {})
         #

--- a/lib/openai/resources/audio/translations.rb
+++ b/lib/openai/resources/audio/translations.rb
@@ -10,6 +10,10 @@ module OpenAI
         #
         # Translates audio into English.
         #
+        # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        # content type.
+        #
         # @overload create(file:, model:, prompt: nil, response_format: nil, temperature: nil, request_options: {})
         #
         # @param file [Pathname, StringIO, IO, String, OpenAI::FilePart] The audio file object (not file name) translate, in one of these formats: flac,

--- a/rbi/openai/models/audio/transcription_create_params.rbi
+++ b/rbi/openai/models/audio/transcription_create_params.rbi
@@ -17,6 +17,12 @@ module OpenAI
 
         # The audio file object (not file name) to transcribe, in one of these formats:
         # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+        # The request must include enough format metadata for the file to be identified.
+        # We recommend an extension-bearing filename and an appropriate content type.
+        #
+        # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        # content type.
         sig { returns(OpenAI::Internal::FileInput) }
         attr_accessor :file
 
@@ -203,6 +209,12 @@ module OpenAI
         def self.new(
           # The audio file object (not file name) to transcribe, in one of these formats:
           # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          # The request must include enough format metadata for the file to be identified.
+          # We recommend an extension-bearing filename and an appropriate content type.
+          #
+          # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+          # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+          # content type.
           file:,
           # ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`,
           # `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1`

--- a/rbi/openai/models/audio/transcription_create_params.rbi
+++ b/rbi/openai/models/audio/transcription_create_params.rbi
@@ -16,9 +16,9 @@ module OpenAI
           end
 
         # The audio file object (not file name) to transcribe, in one of these formats:
-        # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-        # The request must include enough format metadata for the file to be identified.
-        # We recommend an extension-bearing filename and an appropriate content type.
+        # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+        # enough format metadata for the file to be identified. We recommend an
+        # extension-bearing filename and an appropriate content type.
         #
         # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
         # metadata. Use `OpenAI::FilePart` when you need to override the filename or
@@ -208,9 +208,9 @@ module OpenAI
         end
         def self.new(
           # The audio file object (not file name) to transcribe, in one of these formats:
-          # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-          # The request must include enough format metadata for the file to be identified.
-          # We recommend an extension-bearing filename and an appropriate content type.
+          # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+          # enough format metadata for the file to be identified. We recommend an
+          # extension-bearing filename and an appropriate content type.
           #
           # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
           # metadata. Use `OpenAI::FilePart` when you need to override the filename or

--- a/rbi/openai/models/audio/translation_create_params.rbi
+++ b/rbi/openai/models/audio/translation_create_params.rbi
@@ -16,9 +16,9 @@ module OpenAI
           end
 
         # The audio file object (not file name) translate, in one of these formats: flac,
-        # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-        # The request must include enough format metadata for the file to be identified.
-        # We recommend an extension-bearing filename and an appropriate content type.
+        # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough
+        # format metadata for the file to be identified. We recommend an extension-bearing
+        # filename and an appropriate content type.
         #
         # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
         # metadata. Use `OpenAI::FilePart` when you need to override the filename or
@@ -84,9 +84,9 @@ module OpenAI
         end
         def self.new(
           # The audio file object (not file name) translate, in one of these formats: flac,
-          # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-          # The request must include enough format metadata for the file to be identified.
-          # We recommend an extension-bearing filename and an appropriate content type.
+          # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough
+          # format metadata for the file to be identified. We recommend an extension-bearing
+          # filename and an appropriate content type.
           #
           # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
           # metadata. Use `OpenAI::FilePart` when you need to override the filename or

--- a/rbi/openai/models/audio/translation_create_params.rbi
+++ b/rbi/openai/models/audio/translation_create_params.rbi
@@ -17,6 +17,12 @@ module OpenAI
 
         # The audio file object (not file name) translate, in one of these formats: flac,
         # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+        # The request must include enough format metadata for the file to be identified.
+        # We recommend an extension-bearing filename and an appropriate content type.
+        #
+        # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+        # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+        # content type.
         sig { returns(OpenAI::Internal::FileInput) }
         attr_accessor :file
 
@@ -79,6 +85,12 @@ module OpenAI
         def self.new(
           # The audio file object (not file name) translate, in one of these formats: flac,
           # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          # The request must include enough format metadata for the file to be identified.
+          # We recommend an extension-bearing filename and an appropriate content type.
+          #
+          # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+          # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+          # content type.
           file:,
           # ID of the model to use. Only `whisper-1` (which is powered by our open source
           # Whisper V2 model) is currently available.

--- a/rbi/openai/resources/audio/transcriptions.rbi
+++ b/rbi/openai/resources/audio/transcriptions.rbi
@@ -45,6 +45,12 @@ module OpenAI
         def create(
           # The audio file object (not file name) to transcribe, in one of these formats:
           # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          # The request must include enough format metadata for the file to be identified.
+          # We recommend an extension-bearing filename and an appropriate content type.
+          #
+          # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+          # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+          # content type.
           file:,
           # ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`,
           # `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1`
@@ -160,6 +166,12 @@ module OpenAI
         def create_streaming(
           # The audio file object (not file name) to transcribe, in one of these formats:
           # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          # The request must include enough format metadata for the file to be identified.
+          # We recommend an extension-bearing filename and an appropriate content type.
+          #
+          # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+          # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+          # content type.
           file:,
           # ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`,
           # `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1`

--- a/rbi/openai/resources/audio/transcriptions.rbi
+++ b/rbi/openai/resources/audio/transcriptions.rbi
@@ -44,9 +44,9 @@ module OpenAI
         end
         def create(
           # The audio file object (not file name) to transcribe, in one of these formats:
-          # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-          # The request must include enough format metadata for the file to be identified.
-          # We recommend an extension-bearing filename and an appropriate content type.
+          # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+          # enough format metadata for the file to be identified. We recommend an
+          # extension-bearing filename and an appropriate content type.
           #
           # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
           # metadata. Use `OpenAI::FilePart` when you need to override the filename or
@@ -165,9 +165,9 @@ module OpenAI
         end
         def create_streaming(
           # The audio file object (not file name) to transcribe, in one of these formats:
-          # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-          # The request must include enough format metadata for the file to be identified.
-          # We recommend an extension-bearing filename and an appropriate content type.
+          # flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+          # enough format metadata for the file to be identified. We recommend an
+          # extension-bearing filename and an appropriate content type.
           #
           # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
           # metadata. Use `OpenAI::FilePart` when you need to override the filename or

--- a/rbi/openai/resources/audio/translations.rbi
+++ b/rbi/openai/resources/audio/translations.rbi
@@ -20,6 +20,12 @@ module OpenAI
         def create(
           # The audio file object (not file name) translate, in one of these formats: flac,
           # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          # The request must include enough format metadata for the file to be identified.
+          # We recommend an extension-bearing filename and an appropriate content type.
+          #
+          # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
+          # metadata. Use `OpenAI::FilePart` when you need to override the filename or
+          # content type.
           file:,
           # ID of the model to use. Only `whisper-1` (which is powered by our open source
           # Whisper V2 model) is currently available.

--- a/rbi/openai/resources/audio/translations.rbi
+++ b/rbi/openai/resources/audio/translations.rbi
@@ -19,9 +19,9 @@ module OpenAI
         end
         def create(
           # The audio file object (not file name) translate, in one of these formats: flac,
-          # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-          # The request must include enough format metadata for the file to be identified.
-          # We recommend an extension-bearing filename and an appropriate content type.
+          # mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough
+          # format metadata for the file to be identified. We recommend an extension-bearing
+          # filename and an appropriate content type.
           #
           # `String`, `StringIO`, and pathless `IO` inputs are sent with generic upload
           # metadata. Use `OpenAI::FilePart` when you need to override the filename or


### PR DESCRIPTION
## Summary

- Explain the fallback filename and MIME metadata used for raw file-upload values.
- Show the idiomatic `OpenAI::FilePart` workaround for format-sensitive audio uploads.
- Update generated transcription and translation documentation from the linked Castiron/OpenAPI change.

## Compatibility

Documentation only. There are no changes to public Ruby methods, keyword arguments, return types, RBI signatures, serializers, retries, authentication, or exceptions.

## Validation

- `bundle exec rake lint` (Sorbet clean, 1,211 RBS files valid, 2,600 RuboCop files with no offenses)
- `bundle exec rake test` against the mock API (552 runs, 1,863 assertions, 0 failures)
- Gem and YARD documentation builds
- Thermo-nuclear code-quality review, including Ruby idiom and compatibility checks, with no remaining findings

Upstream generator/OpenAPI change: https://github.com/openai/openai/pull/1270941

Closes #243