### PR TITLE
chore: Cover Ruby files at the SDK root

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,10 @@ RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.patterns = FileList[
     "./{lib,test,rbi,examples}/**/*.rb",
     "./{lib,test,rbi,examples}/**/*.rbi",
-    "./scripts/validate-rbs"
+    "./scripts/validate-rbs",
+    "./Gemfile",
+    "./Rakefile",
+    "./openai.gemspec"
   ]
   task.formatters = %w[github] if ENV.key?("CI")
 
@@ -159,7 +162,7 @@ multitask(:"build:docs") do
 end
 
 desc("Build ruby gem")
-multitask(:"build:gem" => pkg) do
+multitask("build:gem": pkg) do
   # optimizing for grepping through the gem bundle: many tools honour `.ignore` files, including VSCode
   #
   # both `rbi` and `sig` directories are navigable by their respective tool chains and therefore can be ignored by tools such as `rg`


### PR DESCRIPTION
## Summary

The canonical RuboCop task currently omits the Ruby-bearing files at the repository root. This change adds `Gemfile`, `Rakefile`, and `openai.gemspec` to the enforced file set and fixes the one style offense that the wider coverage exposes. RuboCop now checks 2,603 files instead of 2,600 without adding suppressions.

Key review points:
- `Rakefile`: expands the existing `lint:rubocop` task rather than introducing a parallel lint path, and uses compliant hash syntax for the existing `build:gem` task.

A paired generator-side gate will run this same SDK-owned task against fully assembled generated output.

## Test Plan

### Automated

- `bundle exec rake lint`: passed RuboCop for all 2,603 files, Sorbet, and validation for all 1,211 RBS files.
