### PR TITLE
fix(api): allow nil timeout in client signatures

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 4579358b-96d5-4ac8-a2f9-4ef3ed0b1bb7
+generation_id: c5512019-402c-4498-b28c-55fb7a36dc0e
 openapi_spec_hash: 1faf0319c407c6534ef7c381614afbb6
 openapi_transformed_spec_hash: 53eff50caa9d18046e4ff0615bc7512d
 config_hash: 4617b0962f16d328804312ac81aac630
-codegen_sha: 661520c9cdb8fcebc7a98496b99a9536a4a4a811
+codegen_sha: dd4e5fa5e392402820c8ddebf0a66fedca7a4f5e

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -231,7 +231,7 @@ module OpenAI
     #
     # @param max_retries [Integer] Max number of retries to attempt after a failed retryable request.
     #
-    # @param timeout [Float]
+    # @param timeout [Float, nil]
     #
     # @param initial_retry_delay [Float]
     #

--- a/lib/openai/http_client.rb
+++ b/lib/openai/http_client.rb
@@ -21,14 +21,14 @@ module OpenAI
       # @return [Object, nil]
       attr_reader :body
 
-      # @return [Float]
+      # @return [Float, nil]
       attr_reader :timeout
 
       # @param method [Symbol]
       # @param url [URI::Generic]
       # @param headers [Hash{String=>String}]
       # @param body [Object, nil]
-      # @param timeout [Float]
+      # @param timeout [Float, nil]
       def initialize(method:, url:, headers:, body:, timeout:)
         @method = method
         @url = url

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -199,7 +199,7 @@ module OpenAI
         # @return [URI::Generic]
         attr_reader :base_url
 
-        # @return [Float]
+        # @return [Float, nil]
         attr_reader :timeout
 
         # @return [Integer]
@@ -224,7 +224,7 @@ module OpenAI
         # @api private
         #
         # @param base_url [String]
-        # @param timeout [Float]
+        # @param timeout [Float, nil]
         # @param max_retries [Integer]
         # @param initial_retry_delay [Float]
         # @param max_retry_delay [Float]
@@ -355,8 +355,9 @@ module OpenAI
             headers["x-stainless-retry-count"] = "0"
           end
 
-          timeout = opts.fetch(:timeout, @timeout).to_f.clamp(0..)
-          unless headers.key?("x-stainless-timeout") || timeout.zero?
+          timeout = opts.fetch(:timeout, @timeout)
+          timeout = timeout.to_f.clamp(0..) unless timeout.nil?
+          unless headers.key?("x-stainless-timeout") || timeout.nil? || timeout.zero?
             headers["x-stainless-timeout"] = timeout.to_s
           end
 
@@ -454,7 +455,7 @@ module OpenAI
         #
         #   @option request [Integer] :max_retries
         #
-        #   @option request [Float] :timeout
+        #   @option request [Float, nil] :timeout
         #
         # @param redirect_count [Integer]
         #
@@ -697,7 +698,7 @@ module OpenAI
               headers: T::Hash[String, String],
               body: T.anything,
               max_retries: Integer,
-              timeout: Float
+              timeout: T.nilable(Float)
             }
           end
         end

--- a/lib/openai/net_http_client.rb
+++ b/lib/openai/net_http_client.rb
@@ -70,15 +70,15 @@ module OpenAI
     # @api private
     #
     # @param conn [Net::HTTP]
-    # @param deadline [Float]
+    # @param deadline [Float, nil]
     private def calibrate_socket_timeout(conn, deadline)
-      timeout = remaining_timeout(deadline)
+      timeout = deadline&.then { remaining_timeout(_1) }
       conn.open_timeout = conn.read_timeout = conn.write_timeout = conn.continue_timeout = timeout
     end
 
     # @api private
     #
-    # @param deadline [Float]
+    # @param deadline [Float, nil]
     # @return [Float]
     # @raise [Timeout::Error]
     private def remaining_timeout(deadline)
@@ -134,7 +134,6 @@ module OpenAI
     # @yieldparam [Net::HTTP]
     private def with_pool(url, deadline:, &blk)
       origin = OpenAI::Internal::Util.uri_origin(url)
-      timeout = remaining_timeout(deadline)
       pool =
         @mutex.synchronize do
           @pools[origin] ||= ConnectionPool.new(size: @size) do
@@ -142,7 +141,13 @@ module OpenAI
           end
         end
 
-      pool.with(timeout: timeout, &blk)
+      return pool.with(timeout: remaining_timeout(deadline), &blk) if deadline
+
+      begin
+        pool.with(&blk)
+      rescue ConnectionPool::TimeoutError
+        retry
+      end
     end
 
     # @api private
@@ -204,7 +209,7 @@ module OpenAI
     # @return [OpenAI::HTTPClient::Response]
     def execute(request)
       url = request.url
-      deadline = OpenAI::Internal::Util.monotonic_secs + request.timeout
+      deadline = request.timeout&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
 
       req = nil
       finished = false

--- a/lib/openai/net_http_client.rb
+++ b/lib/openai/net_http_client.rb
@@ -143,10 +143,15 @@ module OpenAI
 
       return pool.with(timeout: remaining_timeout(deadline), &blk) if deadline
 
+      checked_out = false
       begin
-        pool.with(&blk)
+        pool.with do |connection|
+          checked_out = true
+          blk.call(connection)
+        end
       rescue ConnectionPool::TimeoutError
-        retry
+        retry unless checked_out
+        raise
       end
     end
 

--- a/rbi/openai/client.rbi
+++ b/rbi/openai/client.rbi
@@ -160,7 +160,7 @@ module OpenAI
         provider: T.nilable(OpenAI::Provider),
         base_url: T.nilable(String),
         max_retries: Integer,
-        timeout: Float,
+        timeout: T.nilable(Float),
         initial_retry_delay: Float,
         max_retry_delay: Float,
         http_client: T.untyped

--- a/rbi/openai/http_client.rbi
+++ b/rbi/openai/http_client.rbi
@@ -15,7 +15,7 @@ module OpenAI
       sig { returns(T.anything) }
       attr_reader :body
 
-      sig { returns(Float) }
+      sig { returns(T.nilable(Float)) }
       attr_reader :timeout
 
       sig do
@@ -24,7 +24,7 @@ module OpenAI
           url: URI::Generic,
           headers: T::Hash[String, String],
           body: T.anything,
-          timeout: Float
+          timeout: T.nilable(Float)
         ).returns(T.attached_class)
       end
       def self.new(method:, url:, headers:, body:, timeout:)

--- a/rbi/openai/internal/transport/base_client.rbi
+++ b/rbi/openai/internal/transport/base_client.rbi
@@ -75,7 +75,7 @@ module OpenAI
               headers: T::Hash[String, String],
               body: T.anything,
               max_retries: Integer,
-              timeout: Float
+              timeout: T.nilable(Float)
             }
           end
 
@@ -133,7 +133,7 @@ module OpenAI
         sig { returns(URI::Generic) }
         attr_reader :base_url
 
-        sig { returns(Float) }
+        sig { returns(T.nilable(Float)) }
         attr_reader :timeout
 
         sig { returns(Integer) }
@@ -159,7 +159,7 @@ module OpenAI
         sig do
           params(
             base_url: String,
-            timeout: Float,
+            timeout: T.nilable(Float),
             max_retries: Integer,
             initial_retry_delay: Float,
             max_retry_delay: Float,

--- a/rbi/openai/net_http_client.rbi
+++ b/rbi/openai/net_http_client.rbi
@@ -10,7 +10,7 @@ module OpenAI
     private def connect(url:)
     end
 
-    sig { params(conn: Net::HTTP, deadline: Float).void }
+    sig { params(conn: Net::HTTP, deadline: T.nilable(Float)).void }
     private def calibrate_socket_timeout(conn, deadline)
     end
 
@@ -26,7 +26,7 @@ module OpenAI
     sig do
       params(
         url: URI::Generic,
-        deadline: Float,
+        deadline: T.nilable(Float),
         blk: T.proc.params(arg0: Net::HTTP).void
       ).void
     end

--- a/sig/openai/client.rbs
+++ b/sig/openai/client.rbs
@@ -92,7 +92,7 @@ module OpenAI
       ?provider: OpenAI::Provider?,
       ?base_url: String?,
       ?max_retries: Integer,
-      ?timeout: Float,
+      ?timeout: Float?,
       ?initial_retry_delay: Float,
       ?max_retry_delay: Float,
       ?http_client: OpenAI::_HTTPClient?

--- a/sig/openai/http_client.rbs
+++ b/sig/openai/http_client.rbs
@@ -11,14 +11,14 @@ module OpenAI
       attr_reader url: URI::Generic
       attr_reader headers: ::Hash[String, String]
       attr_reader body: top
-      attr_reader timeout: Float
+      attr_reader timeout: Float?
 
       def initialize: (
         method: Symbol,
         url: URI::Generic,
         headers: ::Hash[String, String],
         body: top,
-        timeout: Float
+        timeout: Float?
       ) -> void
     end
 

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -30,7 +30,7 @@ module OpenAI
             headers: ::Hash[String, String],
             body: top,
             max_retries: Integer,
-            timeout: Float,
+            timeout: Float?,
             :follow_redirects? => bool,
             :provider_auth? => Symbol
           }
@@ -63,7 +63,7 @@ module OpenAI
 
         attr_reader base_url: URI::Generic
 
-        attr_reader timeout: Float
+        attr_reader timeout: Float?
 
         attr_reader max_retries: Integer
 
@@ -80,7 +80,7 @@ module OpenAI
 
         def initialize: (
           base_url: String,
-          ?timeout: Float,
+          ?timeout: Float?,
           ?max_retries: Integer,
           ?initial_retry_delay: Float,
           ?max_retry_delay: Float,

--- a/sig/openai/net_http_client.rbs
+++ b/sig/openai/net_http_client.rbs
@@ -6,7 +6,7 @@ module OpenAI
 
     private def connect: (url: URI::Generic) -> top
 
-    private def calibrate_socket_timeout: (top conn, Float deadline) -> void
+    private def calibrate_socket_timeout: (top conn, Float? deadline) -> void
 
     private def build_request: (
       OpenAI::HTTPClient::Request request
@@ -16,7 +16,7 @@ module OpenAI
 
     private def with_pool: (
       URI::Generic url,
-      deadline: Float
+      deadline: Float?
     ) {
       (top arg0) -> void
     } -> void

--- a/test/openai/http_client_test.rb
+++ b/test/openai/http_client_test.rb
@@ -713,37 +713,6 @@ class HTTPClientTest < Minitest::Test
     assert_instance_of(Timeout::Error, error.cause)
   end
 
-  def test_net_http_client_disables_transport_deadlines_for_nil_timeout
-    connection = StubNetHTTP.new(use_ssl: true, request_error: IOError.new("connection closed"))
-    connection.open_timeout = 1
-    connection.read_timeout = 1
-    connection.write_timeout = 1
-    connection.continue_timeout = 1
-    client_class =
-      Class.new(OpenAI::NetHTTPClient) do
-        define_method(:connect) { |**| connection }
-        private :connect
-      end
-    request = OpenAI::HTTPClient::Request.new(
-      method: :get,
-      url: URI("https://example.com/v1/probe"),
-      headers: {},
-      body: nil,
-      timeout: nil
-    )
-
-    error = assert_raises(OpenAI::Errors::APIConnectionError) do
-      client_class.new.execute(request)
-    end
-
-    assert_instance_of(OpenAI::Errors::APIConnectionError, error)
-    assert_instance_of(IOError, error.cause)
-    assert_nil(connection.open_timeout)
-    assert_nil(connection.read_timeout)
-    assert_nil(connection.write_timeout)
-    assert_nil(connection.continue_timeout)
-  end
-
   def test_net_http_client_close_retires_connections_and_remains_reusable
     connections = []
     client_class =

--- a/test/openai/http_client_test.rb
+++ b/test/openai/http_client_test.rb
@@ -165,6 +165,31 @@ class HTTPClientTest < Minitest::Test
     assert_equal(OpenAI::Client::DEFAULT_TIMEOUT_IN_SECONDS, request.timeout)
   end
 
+  def test_client_preserves_nil_timeout_for_custom_http_client
+    requests = []
+    http_client = StubHTTPClient.new do |request|
+      requests << request
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: ['{"ok":true}']
+      )
+    end
+    client = OpenAI::Client.new(
+      api_key: "test-key",
+      base_url: "https://example.com/v1",
+      timeout: nil,
+      http_client: http_client
+    )
+
+    response = client.request(method: :get, path: "probe", security: {bearer_auth: true})
+
+    assert_equal(true, response[:ok])
+    assert_nil(client.timeout)
+    assert_nil(requests.fetch(0).timeout)
+    refute_includes(requests.fetch(0).headers, "x-stainless-timeout")
+  end
+
   def test_net_http_client_configures_pooled_connections
     calls = []
     http_client = OpenAI::NetHTTPClient.new do |http|
@@ -686,6 +711,37 @@ class HTTPClientTest < Minitest::Test
     end
 
     assert_instance_of(Timeout::Error, error.cause)
+  end
+
+  def test_net_http_client_disables_transport_deadlines_for_nil_timeout
+    connection = StubNetHTTP.new(use_ssl: true, request_error: IOError.new("connection closed"))
+    connection.open_timeout = 1
+    connection.read_timeout = 1
+    connection.write_timeout = 1
+    connection.continue_timeout = 1
+    client_class =
+      Class.new(OpenAI::NetHTTPClient) do
+        define_method(:connect) { |**| connection }
+        private :connect
+      end
+    request = OpenAI::HTTPClient::Request.new(
+      method: :get,
+      url: URI("https://example.com/v1/probe"),
+      headers: {},
+      body: nil,
+      timeout: nil
+    )
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client_class.new.execute(request)
+    end
+
+    assert_instance_of(OpenAI::Errors::APIConnectionError, error)
+    assert_instance_of(IOError, error.cause)
+    assert_nil(connection.open_timeout)
+    assert_nil(connection.read_timeout)
+    assert_nil(connection.write_timeout)
+    assert_nil(connection.continue_timeout)
   end
 
   def test_net_http_client_close_retires_connections_and_remains_reusable

--- a/test/openai/net_http_client_timeout_test.rb
+++ b/test/openai/net_http_client_timeout_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class NetHTTPClientTimeoutTest < Minitest::Test
+  class StubNetHTTP
+    attr_accessor :continue_timeout,
+                  :max_retries,
+                  :open_timeout,
+                  :read_timeout,
+                  :write_timeout
+
+    attr_reader :request_count
+
+    def initialize(request_error:)
+      @request_error = request_error
+      @request_count = 0
+      @started = false
+    end
+
+    def finish = (@started = false)
+    def start = (@started = true)
+    def started? = @started
+    def use_ssl? = true
+
+    def request(_request)
+      @request_count += 1
+      raise @request_error
+    end
+  end
+
+  def test_nil_timeout_disables_transport_deadlines
+    connection = StubNetHTTP.new(request_error: IOError.new("connection closed"))
+    connection.open_timeout = 1
+    connection.read_timeout = 1
+    connection.write_timeout = 1
+    connection.continue_timeout = 1
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      build_client(connection).execute(nil_timeout_request)
+    end
+
+    assert_instance_of(OpenAI::Errors::APIConnectionError, error)
+    assert_instance_of(IOError, error.cause)
+    assert_nil(connection.open_timeout)
+    assert_nil(connection.read_timeout)
+    assert_nil(connection.write_timeout)
+    assert_nil(connection.continue_timeout)
+  end
+
+  def test_pool_timeouts_from_request_execution_are_not_retried
+    connection = StubNetHTTP.new(
+      request_error: ConnectionPool::TimeoutError.new("upstream pool timed out")
+    )
+
+    error = assert_raises(OpenAI::Errors::APITimeoutError) do
+      build_client(connection).execute(nil_timeout_request)
+    end
+
+    assert_instance_of(ConnectionPool::TimeoutError, error.cause)
+    assert_equal(1, connection.request_count)
+  end
+
+  private def build_client(connection)
+    Class.new(OpenAI::NetHTTPClient) do
+      define_method(:connect) { |**| connection }
+      private :connect
+    end.new
+  end
+
+  private def nil_timeout_request
+    OpenAI::HTTPClient::Request.new(
+      method: :get,
+      url: URI("https://example.com/v1/probe"),
+      headers: {},
+      body: nil,
+      timeout: nil
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Support `timeout: nil` end to end in OpenAI Ruby, matching the documented behavior that `nil` disables request deadlines.

This change:

- Generates nilable timeout types in YARD, Sorbet RBI, and RBS.
- Preserves `nil` through request construction instead of coercing it to `0.0`.
- Omits `x-stainless-timeout` when no deadline is configured.
- Disables connection-pool and Net::HTTP socket deadlines for nil-timeout requests.
- Makes the inherited client and transport timeout readers nilable.
- Updates Castiron generation provenance.

Finite timeout behavior is unchanged. The public API change is additive.

Source generator change: https://github.com/openai/openai/pull/1270618

## Validation

- Ran the documented Castiron local dry run from current `openai/openai` master.
- Verified the original generated public patch exactly matched the Ruby candidate.
- Targeted HTTP client tests: 35 tests, 128 assertions, 0 failures.
- RuboCop: no offenses across all changed Ruby and RBI files.
- RBS parsing passed for all changed signatures.
- `git diff --check` passed.

Full Ruby 3.3, 3.4, and 4.0 coverage, typechecks, and CodeQL run in CI.
