### PR TITLE
feat: add Tapioca typing for structured outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,26 @@ params = OpenAI::Chat::CompletionCreateParams.new(
 openai.chat.completions.create(**params)
 ```
 
+### Structured output models
+
+The SDK includes a Tapioca DSL compiler for application-defined subclasses of
+`OpenAI::BaseModel`. When Tapioca loads your application, running
+`bundle exec tapioca dsl` generates typed readers for fields declared with
+`required`, including nested models, arrays, enums, unions, and fields declared
+with `nil?: true`.
+
+Response `parsed` fields can contain different application-defined models, so
+their generated SDK type remains broad. Cast a parsed value to the structured
+output model supplied with the request before accessing its generated readers:
+
+```ruby
+event = T.cast(content.parsed, CalendarEvent)
+puts(event.name)
+```
+
+The compiler is only loaded by Tapioca; using the SDK normally still does not
+require `sorbet-runtime`.
+
 ### Enums
 
 Since this library does not depend on `sorbet-runtime`, it cannot provide [`T::Enum`](https://sorbet.org/docs/tenum) instances. Instead, we provide "tagged symbols" instead, which is always a primitive at runtime:

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -18,9 +18,12 @@ require "time"
 require "uri"
 # We already ship the preferred sorbet manifests in the package itself.
 # `tapioca` currently does not offer us a way to opt out of unnecessary compilation.
+# Thor removes the selected subcommand from `ARGV` before loading an application,
+# so the DSL loader is the reliable fallback for detecting `tapioca dsl`.
+tapioca_dsl = ARGV.any?(/dsl/) || caller.any?(%r{tapioca[\\/]loaders[\\/]dsl})
 if Object.const_defined?(:Tapioca) &&
    caller.chain([$PROGRAM_NAME]).chain(ARGV).any?(/tapioca/) &&
-   ARGV.none?(/dsl/)
+   !tapioca_dsl
   return
 end
 

--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -137,7 +137,9 @@ module OpenAI
         #
         # @return [Object]
         def to_sorbet_type
-          T::Array[OpenAI::Internal::Util::SorbetRuntimeSupport.to_sorbet_type(item_type)]
+          type = OpenAI::Internal::Util::SorbetRuntimeSupport.to_sorbet_type(item_type)
+          type = T.nilable(type) if nilable?
+          T::Array[type]
         end
 
         # @api private

--- a/lib/tapioca/dsl/compilers/openai_base_model.rb
+++ b/lib/tapioca/dsl/compilers/openai_base_model.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "openai"
+
+return unless defined?(OpenAI::BaseModel)
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # Generates RBI definitions for application-defined structured output models.
+      class OpenAIBaseModel < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { {fixed: T.class_of(::OpenAI::BaseModel)} }
+
+        sig { override.void }
+        def decorate
+          root.create_path(constant) do |model|
+            constant.fields.each do |name, field|
+              type = ::OpenAI::Internal::Util::SorbetRuntimeSupport.to_sorbet_type(field.fetch(:type)).to_s
+              type = as_nilable_type(type) if field.fetch(:nilable) || !field.fetch(:required)
+              model.create_method(name.to_s, return_type: type)
+            end
+          end
+        end
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            all_classes.select { _1 < ::OpenAI::BaseModel }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/openai/load_order_test.rb
+++ b/test/openai/load_order_test.rb
@@ -6,6 +6,32 @@ require "rbconfig"
 require_relative "test_helper"
 
 class OpenAI::Test::LoadOrderTest < Minitest::Test
+  def test_skips_auto_require_during_tapioca_gem
+    script = <<~RUBY
+      module Tapioca
+      end
+
+      $PROGRAM_NAME = "tapioca"
+      ARGV.replace(["gem"])
+
+      require "openai"
+
+      raise "OpenAI::Client was autorequired" if defined?(OpenAI::Client)
+    RUBY
+
+    _, stderr, status =
+      Open3.capture3(
+        {"RUBYOPT" => nil},
+        RbConfig.ruby,
+        "-I",
+        File.expand_path("../../lib", __dir__),
+        "-e",
+        script
+      )
+
+    assert_predicate(status, :success?, stderr)
+  end
+
   def test_bundler_autorequires_openai_during_tapioca_dsl
     script = <<~RUBY
       module Tapioca

--- a/test/openai/tapioca/base_model_compiler_test.rb
+++ b/test/openai/tapioca/base_model_compiler_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rbconfig"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::BaseModelCompilerTest < Minitest::Test
+  ROOT = File.expand_path("../../..", __dir__)
+
+  COMPILER_SCRIPT = <<~RUBY
+    require "openai"
+
+    module OpenAIBaseModelCompilerFixtures
+      class Participant < OpenAI::BaseModel
+        required :name, String
+        required :nickname, String, nil?: true
+      end
+
+      class Event < OpenAI::BaseModel
+        required :active, OpenAI::Boolean
+        required :description, String, nil?: true
+        required :participant, Participant
+        required :participants, OpenAI::ArrayOf[Participant]
+        required :aliases, OpenAI::ArrayOf[String, nil?: true]
+        required :status, OpenAI::EnumOf[:confirmed, :tentative]
+        required :detail, OpenAI::UnionOf[String, Participant]
+      end
+    end
+
+    require "tapioca/helpers/test/dsl_compiler"
+    abort("compiler is not discoverable") unless Gem.find_files(
+      "tapioca/dsl/compilers/openai_base_model.rb"
+    ).any?
+    require "tapioca/dsl/compilers/openai_base_model"
+
+    compiler = Tapioca::Dsl::Compilers::OpenAIBaseModel
+    context = Tapioca::Helpers::Test::DslCompiler::CompilerContext.new(compiler)
+    rbi = context.rbi_for("OpenAIBaseModelCompilerFixtures::Event")
+    participant_rbi = context.rbi_for("OpenAIBaseModelCompilerFixtures::Participant")
+
+    require "tmpdir"
+    Dir.mktmpdir("openai-base-model-compiler-test") do |dir|
+      rbi_path = File.join(dir, "event.rbi")
+      participant_rbi_path = File.join(dir, "participant.rbi")
+      usage_path = File.join(dir, "usage.rb")
+      File.write(rbi_path, rbi)
+      File.write(participant_rbi_path, participant_rbi)
+      File.write(usage_path, <<~USAGE)
+        # typed: true
+
+        parsed = T.let(T.unsafe(nil), T.anything)
+        event = T.cast(parsed, OpenAIBaseModelCompilerFixtures::Event)
+
+        T.let(event.active, T::Boolean)
+        T.let(event.description, T.nilable(String))
+        T.let(event.participant, OpenAIBaseModelCompilerFixtures::Participant)
+        T.let(
+          event.participants,
+          T::Array[OpenAIBaseModelCompilerFixtures::Participant]
+        )
+        T.let(event.aliases, T::Array[T.nilable(String)])
+        T.let(event.status, Symbol)
+        T.let(
+          event.detail,
+          T.any(OpenAIBaseModelCompilerFixtures::Participant, String)
+        )
+      USAGE
+
+      runner = Object.new.extend(Tapioca::SorbetHelper)
+      result = runner.sorbet(
+        "--no-config",
+        "--dir",
+        "rbi",
+        rbi_path,
+        participant_rbi_path,
+        usage_path
+      )
+      abort(result.err) unless result.status
+    end
+
+    puts(rbi)
+  RUBY
+
+  def test_loads_through_the_tapioca_cli
+    stdout, stderr, status =
+      Open3.capture3(
+        {"RUBYOPT" => nil},
+        RbConfig.ruby,
+        Gem.bin_path("bundler", "bundle"),
+        "exec",
+        "tapioca",
+        "dsl",
+        "--list-compilers",
+        "--only",
+        "OpenAIBaseModel",
+        chdir: ROOT
+      )
+
+    assert_predicate(status, :success?, stderr)
+    assert_includes(stdout, "Tapioca::Dsl::Compilers::OpenAIBaseModel")
+    refute_includes(stdout, "Cannot find compiler 'OpenAIBaseModel'")
+  end
+
+  def test_generates_typed_readers_for_structured_output_models
+    stdout, stderr, status =
+      Open3.capture3(
+        {"RUBYOPT" => nil},
+        RbConfig.ruby,
+        "-I",
+        File.join(ROOT, "lib"),
+        "-e",
+        COMPILER_SCRIPT,
+        chdir: ROOT
+      )
+
+    assert_predicate(status, :success?, stderr)
+    assert_includes(stdout, "class OpenAIBaseModelCompilerFixtures::Event")
+    assert_includes(stdout, "sig { returns(T::Boolean) }\n  def active; end")
+    assert_includes(stdout, "sig { returns(T.nilable(String)) }\n  def description; end")
+    assert_includes(
+      stdout,
+      "sig { returns(OpenAIBaseModelCompilerFixtures::Participant) }\n  def participant; end"
+    )
+    assert_includes(
+      stdout,
+      <<~RBI.chomp
+        sig { returns(T::Array[OpenAIBaseModelCompilerFixtures::Participant]) }
+          def participants; end
+      RBI
+    )
+    assert_includes(stdout, "sig { returns(T::Array[T.nilable(String)]) }\n  def aliases; end")
+    assert_includes(stdout, "sig { returns(Symbol) }\n  def status; end")
+    assert_includes(
+      stdout,
+      <<~RBI.chomp
+        sig { returns(T.any(OpenAIBaseModelCompilerFixtures::Participant, String)) }
+          def detail; end
+      RBI
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- ship a Tapioca DSL compiler for application-defined `OpenAI::BaseModel` subclasses
- generate typed readers for nested models, arrays, enums, unions, and nilable fields
- preserve the SDK's no-`sorbet-runtime` runtime dependency and document the required `T.cast` for broad `parsed` values
- fix Sorbet conversion for nilable `OpenAI::ArrayOf` elements
- make real `tapioca dsl` loading work after Thor removes the subcommand from `ARGV`

Fixes #309.

## Validation

- `mise x ruby@4.0.6 -- ./scripts/test` — 571 runs, 1,994 assertions
- `mise x ruby@3.3.12 -- ./scripts/test` — 571 runs, 1,994 assertions
- `mise x ruby@4.0.6 -- bundle exec rake lint` — Sorbet, 1,211 RBS files, and 2,603 RuboCop files pass
- real `bundle exec tapioca dsl --list-compilers --only OpenAIBaseModel` discovery
- built and installed the gem in isolation; verified runtime loading and packaged compiler generation

## Review

Ran the repository-required thermo-nuclear maintainability review plus a two-pass independent correctness review. The second pass caught and drove the real CLI load-order regression test; no actionable findings remain.