### PR TITLE
chore: enforce redundant directive lint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.formatters = %w[github] if ENV.key?("CI")
 
   # some lines cannot be shortened
-  task.options = %w[--parallel --except Lint/RedundantCopDisableDirective,Layout/LineLength]
+  task.options = %w[--parallel --except Layout/LineLength]
 end
 
 norm_lines = %w[tr -- \n \0].shelljoin

--- a/lib/openai/helpers/structured_output/base_model.rb
+++ b/lib/openai/helpers/structured_output/base_model.rb
@@ -59,9 +59,7 @@ module OpenAI
 
         class << self
           def optional(...)
-            # rubocop:disable Layout/LineLength
             message = "`optional` is not supported for structured output APIs, use `#required` with `nil?: true` instead"
-            # rubocop:enable Layout/LineLength
             raise RuntimeError.new(message)
           end
         end

--- a/lib/openai/helpers/structured_output/json_schema_converter.rb
+++ b/lib/openai/helpers/structured_output/json_schema_converter.rb
@@ -190,9 +190,7 @@ module OpenAI
               OpenAI::UnionOf
               OpenAI::BaseModel
             ]
-            # rubocop:disable Layout/LineLength
             message = "#{type} does not implement the #{OpenAI::Helpers::StructuredOutput::JsonSchemaConverter} interface. Please use one of the supported types: #{models}"
-            # rubocop:enable Layout/LineLength
             raise ArgumentError.new(message)
           end
         end

--- a/lib/openai/internal/conversation_cursor_page.rb
+++ b/lib/openai/internal/conversation_cursor_page.rb
@@ -81,11 +81,9 @@ module OpenAI
       #
       # @return [String]
       def inspect
-        # rubocop:disable Layout/LineLength
         model = OpenAI::Internal::Type::Converter.inspect(@model, depth: 1)
 
         "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} has_more=#{has_more.inspect} last_id=#{last_id.inspect}>"
-        # rubocop:enable Layout/LineLength
       end
     end
   end

--- a/lib/openai/internal/next_cursor_page.rb
+++ b/lib/openai/internal/next_cursor_page.rb
@@ -81,11 +81,9 @@ module OpenAI
       #
       # @return [String]
       def inspect
-        # rubocop:disable Layout/LineLength
         model = OpenAI::Internal::Type::Converter.inspect(@model, depth: 1)
 
         "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} has_more=#{has_more.inspect} next_=#{next_.inspect}>"
-        # rubocop:enable Layout/LineLength
       end
     end
   end

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -652,9 +652,7 @@ module OpenAI
         #
         # @return [String]
         def inspect
-          # rubocop:disable Layout/LineLength
           "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{@base_url} max_retries=#{@max_retries} timeout=#{@timeout}>"
-          # rubocop:enable Layout/LineLength
         end
 
         define_sorbet_constant!(:RequestComponents) do

--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -58,9 +58,7 @@ module OpenAI
         #
         # @return [Boolean]
         def ==(other)
-          # rubocop:disable Layout/LineLength
           other.is_a?(OpenAI::Internal::Type::ArrayOf) && other.nilable? == nilable? && other.item_type == item_type
-          # rubocop:enable Layout/LineLength
         end
 
         # @api public

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -63,9 +63,7 @@ module OpenAI
         #
         # @return [Boolean]
         def ==(other)
-          # rubocop:disable Layout/LineLength
           other.is_a?(OpenAI::Internal::Type::HashOf) && other.nilable? == nilable? && other.item_type == item_type
-          # rubocop:enable Layout/LineLength
         end
 
         # @api public

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -594,7 +594,6 @@ module OpenAI
         # @return [Object]
         def encode_content(headers, body)
           # rubocop:disable Style/CaseEquality
-          # rubocop:disable Layout/LineLength
           content_type = headers["content-type"]
           case [content_type, body]
           in [OpenAI::Internal::Util::JSON_CONTENT, Hash | Array | -> { primitive?(_1) }]
@@ -614,7 +613,6 @@ module OpenAI
           else
             [headers, body]
           end
-          # rubocop:enable Layout/LineLength
           # rubocop:enable Style/CaseEquality
         end
 


### PR DESCRIPTION
## Summary

Enforce `Lint/RedundantCopDisableDirective` in the required RuboCop task by removing its command-line exception. The cleanup deletes eight stale `Layout/LineLength` disable/enable pairs that were ineffective while line length remains the one intentional CI-wide exception.

Baseline: 8 offenses. Final: 0 offenses across 2,607 inspected files. No replacement suppressions were added.

The matching generator contract is being landed first and verifies that generated Ruby keeps its one intentional RuboCop suppression exactly paired and narrowly scoped.

## Test Plan

- Command: `bundle exec rake lint` with Ruby 4.0.6 and the repository bundle path.
- Result: RuboCop inspected 2,607 files with no offenses; Sorbet reported no errors; 1,211 RBS files validated.
