### PR TITLE
chore: enforce missing RuboCop enable directives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,10 +85,6 @@ Lint/EmptyInPattern:
   Exclude:
     - "test/**/*"
 
-Lint/MissingCopEnableDirective:
-  Exclude:
-    - "examples/**/*.rb"
-
 Lint/MissingSuper:
   Exclude:
     - "**/*.rbi"


### PR DESCRIPTION
## Summary

Remove the `examples/**/*.rb` exclusion for `Lint/MissingCopEnableDirective`, making the cop part of the required lint policy across examples.

The audit found zero existing offenses, so this expands enforcement without source changes or new suppressions. Baseline: 0 offenses. Final: 0 offenses.

Castiron impact: none. Both `.rubocop.yml` and `examples/` are excluded from Castiron generation, so regeneration cannot recreate or overwrite this change and no companion generator PR is needed.

## Test Plan

- Command: `bundle exec rake lint` with Ruby 4.0.6 and the repository bundle path.
- Result: RuboCop inspected 2,611 files with no offenses; Sorbet reported no errors; 1,212 RBS files validated.
