### PR TITLE
feat(client): add default headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,20 @@ Note that requests that time out are retried by default.
 
 ## Advanced concepts
 
+### Default request headers
+
+Use `default_headers` to send the same custom headers with every request made by a client:
+
+```ruby
+finance = OpenAI::Client.new(
+  default_headers: {"x-cost-center" => "finance"}
+)
+```
+
+Explicit `default_headers` override values from `OPENAI_CUSTOM_HEADERS`. For a single request,
+`request_options[:extra_headers]` can override a client default or remove it by assigning `nil`.
+Authentication and endpoint-specific headers also take precedence over client defaults.
+
 ### BaseModel
 
 All parameter and response objects inherit from `OpenAI::Internal::Type::BaseModel`, which provides several conveniences, including:

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -333,7 +333,11 @@ module OpenAI
         end
         headers = parsed.merge(headers)
       end
-      headers = headers.merge(default_headers.to_h)
+      client_headers = OpenAI::Internal::Util.normalized_headers(default_headers.to_h)
+      unless provider_runtime.nil?
+        provider_runtime.authentication_headers.each { client_headers.delete(_1) }
+      end
+      headers = headers.merge(client_headers)
 
       if workload_identity.nil?
         @api_key = api_key&.to_s

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -229,6 +229,9 @@ module OpenAI
     # @param base_url [String, nil] Override the default base URL for the API, e.g.,
     # `"https://api.example.com/v2/"`. Defaults to `ENV["OPENAI_BASE_URL"]`
     #
+    # @param default_headers [Hash{String=>String, nil}, nil] Extra headers to send
+    #   with every request. Explicit values override `ENV["OPENAI_CUSTOM_HEADERS"]`.
+    #
     # @param max_retries [Integer] Max number of retries to attempt after a failed retryable request.
     #
     # @param timeout [Float, nil]
@@ -255,6 +258,7 @@ module OpenAI
       webhook_secret: OpenAI::Internal::OMIT,
       provider: nil,
       base_url: OpenAI::Internal::OMIT,
+      default_headers: nil,
       max_retries: self.class::DEFAULT_MAX_RETRIES,
       timeout: self.class::DEFAULT_TIMEOUT_IN_SECONDS,
       initial_retry_delay: self.class::DEFAULT_INITIAL_RETRY_DELAY,
@@ -329,6 +333,7 @@ module OpenAI
         end
         headers = parsed.merge(headers)
       end
+      headers = headers.merge(default_headers.to_h)
 
       if workload_identity.nil?
         @api_key = api_key&.to_s

--- a/lib/openai/internal/provider.rb
+++ b/lib/openai/internal/provider.rb
@@ -7,7 +7,13 @@ module OpenAI
     # Provider factories return opaque OpenAI::Provider instances whose public
     # representation does not expose their definition.
     module Provider
-      Runtime = Struct.new(:name, :base_url, :prepare_request, keyword_init: true)
+      Runtime = Struct.new(
+        :name,
+        :base_url,
+        :prepare_request,
+        :authentication_headers,
+        keyword_init: true
+      )
 
       class << self
         # @api private

--- a/lib/openai/providers/azure.rb
+++ b/lib/openai/providers/azure.rb
@@ -33,7 +33,8 @@ module OpenAI
           OpenAI::Internal::Provider::Runtime.new(
             name: name,
             base_url: @base_url,
-            prepare_request: auth.method(:prepare_request)
+            prepare_request: auth.method(:prepare_request),
+            authentication_headers: AUTH_HEADERS
           )
         end
       end

--- a/lib/openai/providers/bedrock.rb
+++ b/lib/openai/providers/bedrock.rb
@@ -6,6 +6,7 @@ module OpenAI
     module Bedrock
       SERVICE = "bedrock-mantle"
       CANONICAL_HOST = /\Abedrock-mantle\.([a-z0-9-]+)\.api\.aws\z/i
+      AUTH_HEADERS = %w[authorization].freeze
       SIGNING_HEADERS = %w[authorization x-amz-content-sha256 x-amz-date x-amz-security-token].freeze
       BEARER_AUTH_MARKER = :openai_bedrock_bearer
       SIGV4_AUTH_MARKER = :openai_bedrock_sigv4
@@ -91,7 +92,8 @@ module OpenAI
           OpenAI::Internal::Provider::Runtime.new(
             name: name,
             base_url: base_url,
-            prepare_request: auth.method(:prepare_request)
+            prepare_request: auth.method(:prepare_request),
+            authentication_headers: AUTH_HEADERS
           )
         end
       end

--- a/rbi/openai/client.rbi
+++ b/rbi/openai/client.rbi
@@ -159,6 +159,7 @@ module OpenAI
         webhook_secret: T.nilable(String),
         provider: T.nilable(OpenAI::Provider),
         base_url: T.nilable(String),
+        default_headers: T.nilable(T::Hash[String, T.nilable(String)]),
         max_retries: Integer,
         timeout: T.nilable(Float),
         initial_retry_delay: Float,
@@ -185,6 +186,9 @@ module OpenAI
       # Override the default base URL for the API, e.g.,
       # `"https://api.example.com/v2/"`. Defaults to `ENV["OPENAI_BASE_URL"]`
       base_url: ENV["OPENAI_BASE_URL"],
+      # Extra headers to send with every request. Explicit values override
+      # `ENV["OPENAI_CUSTOM_HEADERS"]`.
+      default_headers: nil,
       # Max number of retries to attempt after a failed retryable request.
       max_retries: OpenAI::Client::DEFAULT_MAX_RETRIES,
       timeout: OpenAI::Client::DEFAULT_TIMEOUT_IN_SECONDS,

--- a/rbi/openai/internal/provider.rbi
+++ b/rbi/openai/internal/provider.rbi
@@ -23,6 +23,9 @@ module OpenAI
           )
         end
         attr_accessor :prepare_request
+
+        sig { returns(T::Array[String]) }
+        attr_accessor :authentication_headers
       end
 
       class << self

--- a/sig/openai/client.rbs
+++ b/sig/openai/client.rbs
@@ -91,6 +91,7 @@ module OpenAI
       ?webhook_secret: String?,
       ?provider: OpenAI::Provider?,
       ?base_url: String?,
+      ?default_headers: ::Hash[String, String?]?,
       ?max_retries: Integer,
       ?timeout: Float?,
       ?initial_retry_delay: Float,

--- a/sig/openai/internal/provider.rbs
+++ b/sig/openai/internal/provider.rbs
@@ -7,13 +7,15 @@ module OpenAI
         attr_accessor prepare_request: (^(
           OpenAI::Internal::Transport::BaseClient::request_input
         ) -> OpenAI::Internal::Transport::BaseClient::request_input)?
+        attr_accessor authentication_headers: Array[String]
 
         def initialize: (
           name: String,
           base_url: String,
           prepare_request: (^(
             OpenAI::Internal::Transport::BaseClient::request_input
-          ) -> OpenAI::Internal::Transport::BaseClient::request_input)?
+          ) -> OpenAI::Internal::Transport::BaseClient::request_input)?,
+          authentication_headers: Array[String]
         ) -> void
       end
 

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -13,11 +13,18 @@ class OpenAITest < Minitest::Test
 
   def setup
     super
+    @openai_custom_headers = ENV["OPENAI_CUSTOM_HEADERS"]
+    ENV.delete("OPENAI_CUSTOM_HEADERS")
     Thread.current.thread_variable_set(:mock_sleep, [])
   end
 
   def teardown
     Thread.current.thread_variable_set(:mock_sleep, nil)
+    if @openai_custom_headers.nil?
+      ENV.delete("OPENAI_CUSTOM_HEADERS")
+    else
+      ENV["OPENAI_CUSTOM_HEADERS"] = @openai_custom_headers
+    end
     WebMock.reset!
     super
   end
@@ -91,6 +98,141 @@ class OpenAITest < Minitest::Test
     end
 
     assert_match(/Missing credentials/, error.message)
+  end
+
+  def test_client_default_headers_are_sent_with_requests
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"x-cost-center" => "finance"}
+    )
+    openai.request({method: :get, path: "models"})
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      assert_equal("finance", request.headers.transform_keys(&:downcase)["x-cost-center"])
+    end
+  end
+
+  def test_client_default_headers_are_sent_with_streaming_requests
+    stub_request(:post, "http://localhost/chat/completions")
+      .with(headers: {"x-cost-center" => "finance"})
+      .to_return(status: 200, body: "data: [DONE]\n\n", headers: {"Content-Type" => "text/event-stream"})
+
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"x-cost-center" => "finance"}
+    )
+    openai.chat.completions.stream(
+      messages: [{content: "string", role: :developer}],
+      model: :"gpt-5.4"
+    )
+
+    assert_requested(:post, "http://localhost/chat/completions", times: 1) do |request|
+      assert_equal("finance", request.headers.transform_keys(&:downcase)["x-cost-center"])
+    end
+  end
+
+  def test_client_default_headers_are_isolated_between_clients
+    cost_centers = []
+    stub_request(:get, "http://localhost/models").to_return do |request|
+      cost_centers << request.headers.transform_keys(&:downcase).fetch("x-cost-center")
+      {status: 200, body: "{}"}
+    end
+
+    finance = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"x-cost-center" => "finance"}
+    )
+    research = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"x-cost-center" => "research"}
+    )
+    finance.request({method: :get, path: "models"})
+    research.request({method: :get, path: "models"})
+
+    assert_equal(%w[finance research], cost_centers)
+  end
+
+  def test_explicit_default_headers_override_or_remove_environment_headers
+    ENV["OPENAI_CUSTOM_HEADERS"] = <<~HEADERS
+      X-Cost-Center: environment
+      X-Remove-Me: environment
+      X-Ambient: retained
+    HEADERS
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"x-cost-center" => "explicit", "x-remove-me" => nil}
+    )
+    openai.request({method: :get, path: "models"})
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      headers = request.headers.transform_keys(&:downcase)
+      assert_equal("explicit", headers["x-cost-center"])
+      assert_equal("retained", headers["x-ambient"])
+      refute_includes(headers, "x-remove-me")
+    end
+  end
+
+  def test_request_headers_override_or_remove_client_default_headers
+    requests = []
+    stub_request(:get, "http://localhost/models").to_return do |request|
+      requests << request.headers.transform_keys(&:downcase)
+      {status: 200, body: "{}"}
+    end
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"x-cost-center" => "finance"}
+    )
+
+    openai.request(
+      {
+        method: :get,
+        path: "models",
+        options: {extra_headers: {"X-Cost-Center" => "research"}}
+      }
+    )
+    openai.request(
+      {
+        method: :get,
+        path: "models",
+        options: {extra_headers: {"x-cost-center" => nil}}
+      }
+    )
+
+    assert_equal("research", requests.fetch(0).fetch("x-cost-center"))
+    refute_includes(requests.fetch(1), "x-cost-center")
+  end
+
+  def test_client_default_headers_do_not_override_authentication_or_request_headers
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {"authorization" => "Bearer custom", "x-endpoint" => "client"}
+    )
+
+    openai.request(
+      {
+        method: :get,
+        path: "models",
+        headers: {"X-Endpoint" => "generated"},
+        security: {bearer_auth: true}
+      }
+    )
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      assert_equal("Bearer My API Key", request.headers["Authorization"])
+      assert_equal("generated", request.headers["X-Endpoint"])
+    end
   end
 
   def test_chat_completion_stream_uses_bearer_auth

--- a/test/openai/providers/azure_test.rb
+++ b/test/openai/providers/azure_test.rb
@@ -162,7 +162,7 @@ class OpenAI::Test::AzureProviderTest < Minitest::Test
     end
   end
 
-  def test_provider_sends_explicit_default_headers
+  def test_provider_authentication_overrides_explicit_default_headers
     url = "https://example-resource.openai.azure.com/openai/v1/models"
     stub_request(:get, url).to_return_json(status: 200, body: {})
 
@@ -171,12 +171,19 @@ class OpenAI::Test::AzureProviderTest < Minitest::Test
         endpoint: "https://example-resource.openai.azure.com",
         api_key: "azure-key"
       ),
-      default_headers: {"x-cost-center" => "finance"}
+      default_headers: {
+        "Authorization" => "Bearer custom",
+        "Api-Key" => "custom-key",
+        "X-Cost-Center" => "finance"
+      }
     )
     client.request({method: :get, path: "models"})
 
     assert_requested(:get, url) do |request|
-      assert_equal("finance", request.headers.transform_keys(&:downcase)["x-cost-center"])
+      headers = request.headers.transform_keys(&:downcase)
+      assert_equal("azure-key", headers["api-key"])
+      refute_includes(headers, "authorization")
+      assert_equal("finance", headers["x-cost-center"])
     end
   end
 

--- a/test/openai/providers/azure_test.rb
+++ b/test/openai/providers/azure_test.rb
@@ -162,6 +162,24 @@ class OpenAI::Test::AzureProviderTest < Minitest::Test
     end
   end
 
+  def test_provider_sends_explicit_default_headers
+    url = "https://example-resource.openai.azure.com/openai/v1/models"
+    stub_request(:get, url).to_return_json(status: 200, body: {})
+
+    client = OpenAI::Client.new(
+      provider: OpenAI::Providers.azure(
+        endpoint: "https://example-resource.openai.azure.com",
+        api_key: "azure-key"
+      ),
+      default_headers: {"x-cost-center" => "finance"}
+    )
+    client.request({method: :get, path: "models"})
+
+    assert_requested(:get, url) do |request|
+      assert_equal("finance", request.headers.transform_keys(&:downcase)["x-cost-center"])
+    end
+  end
+
   def test_endpoint_normalization
     cases = {
       "https://example.openai.azure.com" => "https://example.openai.azure.com/openai/v1",

--- a/test/openai/providers/bedrock_test.rb
+++ b/test/openai/providers/bedrock_test.rb
@@ -103,18 +103,23 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
     end
   end
 
-  def test_provider_sends_explicit_default_headers
+  def test_provider_authentication_overrides_explicit_default_headers
     url = "https://bedrock-mantle.us-east-1.api.aws/v1/models"
     stub_request(:get, url).to_return_json(status: 200, body: {})
 
     client = OpenAI::Client.new(
       provider: OpenAI::Providers.bedrock(region: "us-east-1", api_key: "bedrock-token"),
-      default_headers: {"x-cost-center" => "finance"}
+      default_headers: {
+        "Authorization" => "Bearer custom",
+        "X-Cost-Center" => "finance"
+      }
     )
     client.request({method: :get, path: "models"})
 
     assert_requested(:get, url) do |request|
-      assert_equal("finance", request.headers.transform_keys(&:downcase)["x-cost-center"])
+      headers = request.headers.transform_keys(&:downcase)
+      assert_equal("Bearer bedrock-token", headers["authorization"])
+      assert_equal("finance", headers["x-cost-center"])
     end
   end
 

--- a/test/openai/providers/bedrock_test.rb
+++ b/test/openai/providers/bedrock_test.rb
@@ -103,6 +103,21 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
     end
   end
 
+  def test_provider_sends_explicit_default_headers
+    url = "https://bedrock-mantle.us-east-1.api.aws/v1/models"
+    stub_request(:get, url).to_return_json(status: 200, body: {})
+
+    client = OpenAI::Client.new(
+      provider: OpenAI::Providers.bedrock(region: "us-east-1", api_key: "bedrock-token"),
+      default_headers: {"x-cost-center" => "finance"}
+    )
+    client.request({method: :get, path: "models"})
+
+    assert_requested(:get, url) do |request|
+      assert_equal("finance", request.headers.transform_keys(&:downcase)["x-cost-center"])
+    end
+  end
+
   def test_provider_rejects_top_level_authentication_and_routing
     provider = OpenAI::Providers.bedrock(region: "us-east-1", api_key: "bedrock-token")
 


### PR DESCRIPTION
## Summary

- add `default_headers:` to `OpenAI::Client`
- merge explicit defaults over `OPENAI_CUSTOM_HEADERS` while preserving authentication, endpoint, and per-request precedence
- document and type the API, with coverage for standard, streaming, Azure, and Bedrock requests

Closes #284

## Validation

- `mise exec ruby@4.0.6 -- ./scripts/test` — 620 tests, 2,320 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop`
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck`
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem`
- `mise exec ruby@4.0.6 -- bundle exec rake build:docs`