### PR TITLE
chore: lint Ruby files repository-wide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
 ---
+# Keep RuboCop's dependency and build-output exclusions alongside ours.
+inherit_mode:
+  merge:
+    - Exclude
+
 # Explicitly disable pending cops for now. This is the default behaviour but
 # this avoids a large warning every time we run it.
 # Stop RuboCop nagging about rubocop-rake.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - "bin/*"
     - "sorbet/rbi/annotations/**/*"
     - "sorbet/rbi/gems/**/*"
+    - "sorbet/tapioca/**/*"
   NewCops: enable
   SuggestExtensions: false
   TargetRubyVersion: 3.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ inherit_mode:
 AllCops:
   Exclude:
     - "bin/*"
+    - "sorbet/rbi/annotations/**/*"
+    - "sorbet/rbi/gems/**/*"
   NewCops: enable
   SuggestExtensions: false
   TargetRubyVersion: 3.3

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.formatters = %w[github] if ENV.key?("CI")
 
   # some lines cannot be shortened
-  task.options = %w[--parallel --except Layout/LineLength]
+  task.options = %w[--parallel --force-exclusion --except Layout/LineLength]
 end
 
 norm_lines = %w[tr -- \n \0].shelljoin

--- a/Rakefile
+++ b/Rakefile
@@ -56,14 +56,7 @@ end
 
 desc("Lint `*.rb(i)`")
 RuboCop::RakeTask.new(:"lint:rubocop") do |task|
-  task.patterns = FileList[
-    "./{lib,test,rbi,examples}/**/*.rb",
-    "./{lib,test,rbi,examples}/**/*.rbi",
-    "./scripts/validate-rbs",
-    "./Gemfile",
-    "./Rakefile",
-    "./openai.gemspec"
-  ]
+  task.patterns = %w[. ./**/*.rbi]
   task.formatters = %w[github] if ENV.key?("CI")
 
   # some lines cannot be shortened


### PR DESCRIPTION
## Summary

Replace the hand-maintained RuboCop path allowlist with repository-root discovery, while retaining an explicit RBI glob because `.rbi` is not a default RuboCop file type.

This makes new first-party Ruby files and Ruby-bearing directories linted automatically. The owned target set grows from 1,387 to 1,388 files by adding the existing `Steepfile`. `--force-exclusion` keeps dependency/build output out of scope, RuboCop's default exclusions are merged with repository exclusions, and the disposable Tapioca trees are explicitly excluded.

Castiron impact: none. `Rakefile` and `.rubocop.yml` are excluded from Castiron generation, and the existing Castiron validation invokes this SDK-owned `lint:rubocop` task, so it inherits the stronger coverage without a generator change.

## Test plan

- `bundle exec rake lint` — RuboCop inspected 1,388 first-party files with zero offenses; Sorbet and all 1,212 RBS validations passed.
- Controlled first-party probe: added an invalid Ruby file under previously unlisted `api_reference/`; `bundle exec rake lint:rubocop` discovered it and failed.
- Controlled dependency probe: added an invalid RBI under `vendor/bundle`; the lint task ignored it and passed.
- Controlled generated-RBI probe: added an invalid RBI under `sorbet/rbi/gems`; the lint task ignored it and passed.
- All probe files were removed before commit.