### PR TITLE
chore: require MFA for gem releases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,10 +19,6 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.3
 
-# Whether MFA is required or not should be left to the token configuration.
-Gemspec/RequireMFA:
-  Enabled: false
-
 # Don't require this extra line break, it can be excessive.
 Layout/EmptyLineAfterGuardClause:
   Enabled: false


### PR DESCRIPTION
## Summary

Enable `Gemspec/RequireMFA` by deleting the repository override that disabled it.

The gemspec already sets `rubygems_mfa_required`, so this is a zero-offense policy ratchet with no source changes or suppressions. Baseline: 0 offenses. Final: 0 offenses.

Castiron impact: none. `.rubocop.yml` and `openai.gemspec` are excluded from Castiron generation, and no generated output changes.

## Test plan

- `bundle exec rake lint` — RuboCop inspected 2,612 files with zero offenses; Sorbet and all 1,212 RBS validations passed.

## Stack

Depends on #377.