### PR TITLE
chore: enforce deprecated constant lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,11 +74,6 @@ Layout/SpaceInsideHashLiteralBraces:
 Lint/BooleanSymbol:
   Enabled: false
 
-# This option occasionally mangles identifier names
-Lint/DeprecatedConstants:
-  Exclude:
-    - "**/*.rbi"
-
 # We use pattern assertion in tests to ensure correctness.
 Lint/DuplicateMatchPattern:
   Exclude:


### PR DESCRIPTION
## Summary

Remove the RBI exclusion for `Lint/DeprecatedConstants`, enforcing the cop across generated and handwritten Sorbet signatures.

A direct audit of all 1,224 RBI files found zero offenses, so this ratchet needs no source changes or suppressions. Baseline: 0 offenses. Final: 0 offenses.

Castiron impact: no companion change is needed. `.rubocop.yml` is not generator-owned, current generated RBI is clean, and Castiron's existing full-lint generation gate will reject future generated violations.

## Test plan

- Direct RBI audit: 1,224 files, zero `Lint/DeprecatedConstants` offenses.
- `bundle exec rake lint` — RuboCop inspected 2,612 files with zero offenses; Sorbet and all 1,212 RBS validations passed.

## Stack

Depends on #378.