### PR TITLE
chore: enforce duplicate match pattern lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,11 +74,6 @@ Layout/SpaceInsideHashLiteralBraces:
 Lint/BooleanSymbol:
   Enabled: false
 
-# We use pattern assertion in tests to ensure correctness.
-Lint/DuplicateMatchPattern:
-  Exclude:
-    - "test/**/*"
-
 # Fairly useful in tests for pattern assertions.
 Lint/EmptyInPattern:
   Exclude:


### PR DESCRIPTION
## Summary

Remove the test-wide exclusion for `Lint/DuplicateMatchPattern`.

A direct audit of the test tree found zero offenses, so this ratchet needs no source changes or suppressions. Baseline: 0 offenses. Final: 0 offenses.

Castiron impact: no companion change is needed. Current generator-owned resource tests are clean, and Castiron's existing full-lint generation gate will reject future generated violations.

## Test plan

- Direct test audit: 120 files, zero `Lint/DuplicateMatchPattern` offenses.
- `bundle exec rake lint` — RuboCop inspected 2,612 files with zero offenses; Sorbet and all 1,212 RBS validations passed.

## Stack

Depends on #379.