### PR TITLE
chore: enforce symbol conversion lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,10 +83,6 @@ Lint/MissingSuper:
   Exclude:
     - "**/*.rbi"
 
-Lint/SymbolConversion:
-  Exclude:
-    - "**/*.rbi"
-
 # Disabled for safety reasons, this option changes code semantics.
 Lint/UnusedMethodArgument:
   AutoCorrect: false


### PR DESCRIPTION
## Summary

Remove the RBI exclusion for `Lint/SymbolConversion`, enforcing the cop across generated and handwritten Sorbet signatures.

A direct audit of all 1,224 RBI files found zero offenses, so this ratchet needs no source changes or suppressions. Baseline: 0 offenses. Final: 0 offenses.

Castiron impact: no companion change is needed. `.rubocop.yml` is not generator-owned, current generated RBI is clean, and Castiron's existing full-lint generation gate will reject future generated violations.

## Test plan

- Direct RBI audit: 1,224 files, zero `Lint/SymbolConversion` offenses.
- `bundle exec rake lint` — RuboCop inspected 2,612 files with zero offenses; Sorbet and all 1,212 RBS validations passed.

## Stack

Depends on #380.