### PR TITLE
fix: package every README-linked guide and example

### DIFF
--- a/openai.gemspec
+++ b/openai.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
     "SECURITY.md",
     "CHANGELOG.md",
     ".ignore"
-  ]
-  s.extra_rdoc_files = ["README.md", "VERSIONING.md", "azure.md"]
+  ] + ["examples/mtls_custom_http_client.rb"]
+  s.extra_rdoc_files = ["README.md", "VERSIONING.md", "azure.md", "bedrock.md"]
   s.add_dependency "base64"
   s.add_dependency "cgi"
   s.add_dependency "connection_pool", ">= 2.2.3"

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.md",
     ".ignore"
   ]
-  s.extra_rdoc_files = ["README.md", "VERSIONING.md"]
+  s.extra_rdoc_files = ["README.md", "VERSIONING.md", "azure.md"]
   s.add_dependency "base64"
   s.add_dependency "cgi"
   s.add_dependency "connection_pool", ">= 2.2.3"

--- a/test/openai/gem_packaging_test.rb
+++ b/test/openai/gem_packaging_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rubygems/package"
+require "tmpdir"
+
+require_relative "test_helper"
+
+class OpenAI::Test::GemPackagingTest < Minitest::Test
+  def test_packages_azure_provider_guide_as_documentation
+    specification = Gem::Specification.load(File.expand_path("../../openai.gemspec", __dir__))
+
+    Dir.mktmpdir("openai-gem-packaging-test") do |directory|
+      gem_file = File.join(directory, "openai.gem")
+      Gem::Package.build(specification, false, false, gem_file)
+      package = Gem::Package.new(gem_file)
+
+      assert(package.contents.include?("azure.md"), "built gem does not include azure.md")
+      assert_includes(package.spec.extra_rdoc_files, "azure.md")
+    end
+  end
+end

--- a/test/openai/gem_packaging_test.rb
+++ b/test/openai/gem_packaging_test.rb
@@ -2,20 +2,28 @@
 
 require "rubygems/package"
 require "tmpdir"
+require "uri"
 
 require_relative "test_helper"
 
 class OpenAI::Test::GemPackagingTest < Minitest::Test
-  def test_packages_azure_provider_guide_as_documentation
+  def test_packages_every_relative_readme_link
     specification = Gem::Specification.load(File.expand_path("../../openai.gemspec", __dir__))
+    readme = File.read(File.expand_path("../../README.md", __dir__))
+    relative_links = readme.scan(/\[[^\]]+\]\(([^\s)]+)(?:\s+[^)]*)?\)/).flatten.filter_map do |target|
+      uri = URI.parse(target)
+      uri.path if uri.relative? && uri.host.nil? && !uri.path.empty?
+    end
 
     Dir.mktmpdir("openai-gem-packaging-test") do |directory|
       gem_file = File.join(directory, "openai.gem")
       Gem::Package.build(specification, false, false, gem_file)
       package = Gem::Package.new(gem_file)
 
-      assert(package.contents.include?("azure.md"), "built gem does not include azure.md")
-      assert_includes(package.spec.extra_rdoc_files, "azure.md")
+      assert_empty(relative_links - package.contents, "README links are missing from the built gem")
+
+      linked_guides = relative_links.select { File.extname(_1) == ".md" }
+      assert_empty(linked_guides - package.spec.extra_rdoc_files, "README guides are missing from RDoc")
     end
   end
 end


### PR DESCRIPTION
## Summary
- package both provider guides, `azure.md` and `bedrock.md`, through `extra_rdoc_files` so RubyGems ships the guides referenced by the installed README and includes them in RDoc metadata
- package the README-linked `examples/mtls_custom_http_client.rb` without including unrelated examples
- build a real gem in the regression test, discover every relative README link automatically, and require every linked file to be present in the artifact; additionally require every linked Markdown guide to appear in the documentation metadata
- preserve all other package contents: the canonical gem grows from 3,680 to 3,683 files, adding only the Azure guide, Bedrock guide, and linked mTLS example

## Verification
- regression reproduced the existing missing `bedrock.md` and `examples/mtls_custom_http_client.rb` targets before the packaging fix
- `mise exec ruby@3.3.12 -- ./scripts/test` — 614 tests, 2,260 assertions
- `mise exec ruby@3.4.10 -- ./scripts/test` — 614 tests, 2,260 assertions
- `mise exec ruby@4.0.6 -- ./scripts/test` — 614 tests, 2,260 assertions
- Azure and Bedrock provider suites — 36 tests, 243 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2,612 files, no offenses
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck:sorbet`
- `mise exec ruby@4.0.6 -- bundle exec rake validate:rbs` — 1,212 files, no errors
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem` and inspection of every linked target in `pkg/openai-0.78.0.gem`