### PR TITLE
fix: prevent symbol-keyed headers from bypassing security filters

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -337,7 +337,7 @@ module OpenAI
       unless provider_runtime.nil?
         provider_runtime.authentication_headers.each { client_headers.delete(_1) }
       end
-      headers = headers.merge(client_headers)
+      headers = OpenAI::Internal::Util.normalized_headers(headers, client_headers)
 
       if workload_identity.nil?
         @api_key = api_key&.to_s

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -322,22 +322,21 @@ module OpenAI
         "openai-organization" => (@organization = organization&.to_s),
         "openai-project" => (@project = project&.to_s)
       }
+      parsed = {}
       custom_headers_env = ENV["OPENAI_CUSTOM_HEADERS"] unless provider_runtime
       unless custom_headers_env.nil?
-        parsed = {}
         custom_headers_env.split("\n").each do |line|
           colon = line.index(":")
           unless colon.nil?
             parsed[line[0...colon].strip] = line[(colon + 1)..].strip
           end
         end
-        headers = parsed.merge(headers)
       end
       client_headers = OpenAI::Internal::Util.normalized_headers(default_headers.to_h)
       unless provider_runtime.nil?
         provider_runtime.authentication_headers.each { client_headers.delete(_1) }
       end
-      headers = OpenAI::Internal::Util.normalized_headers(headers, client_headers)
+      headers = OpenAI::Internal::Util.normalized_headers(parsed, headers, client_headers)
 
       if workload_identity.nil?
         @api_key = api_key&.to_s

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -389,7 +389,7 @@ module OpenAI
         #
         # @return [Hash{String=>String}]
         def normalized_headers(*headers)
-          {}.merge(*headers.compact).to_h do |key, val|
+          headers.compact.flat_map(&:to_a).to_h do |key, val|
             value =
               case val
               in Array
@@ -397,7 +397,7 @@ module OpenAI
               else
                 val&.to_s&.strip
               end
-            [key.downcase, value]
+            [key.to_s.downcase, value]
           end
         end
       end

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -165,12 +165,18 @@ class OpenAITest < Minitest::Test
       x-remove-me: stale
       X-Remove-Me: environment
       X-Ambient: retained
+      openai-organization: stale
+      OpenAI-Organization: injected-organization
+      openai-project: stale
+      OpenAI-Project: injected-project
     HEADERS
     stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
 
     openai = OpenAI::Client.new(
       base_url: "http://localhost",
       api_key: "My API Key",
+      organization: "explicit-organization",
+      project: "explicit-project",
       default_headers: {"x-cost-center" => "explicit", "x-remove-me" => nil}
     )
     openai.request({method: :get, path: "models"})
@@ -179,6 +185,8 @@ class OpenAITest < Minitest::Test
       headers = request.headers.transform_keys(&:downcase)
       assert_equal("explicit", headers["x-cost-center"])
       assert_equal("retained", headers["x-ambient"])
+      assert_equal("explicit-organization", headers["openai-organization"])
+      assert_equal("explicit-project", headers["openai-project"])
       refute_includes(headers, "x-remove-me")
     end
   end

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -106,7 +106,7 @@ class OpenAITest < Minitest::Test
     openai = OpenAI::Client.new(
       base_url: "http://localhost",
       api_key: "My API Key",
-      default_headers: {"x-cost-center" => "finance"}
+      default_headers: {"X-Cost-Center" => "ignored", :"x-cost-center" => "finance"}
     )
     openai.request({method: :get, path: "models"})
 
@@ -160,7 +160,9 @@ class OpenAITest < Minitest::Test
 
   def test_explicit_default_headers_override_or_remove_environment_headers
     ENV["OPENAI_CUSTOM_HEADERS"] = <<~HEADERS
+      x-cost-center: stale
       X-Cost-Center: environment
+      x-remove-me: stale
       X-Remove-Me: environment
       X-Ambient: retained
     HEADERS
@@ -197,14 +199,14 @@ class OpenAITest < Minitest::Test
       {
         method: :get,
         path: "models",
-        options: {extra_headers: {"X-Cost-Center" => "research"}}
+        options: {extra_headers: {"X-Cost-Center": "research"}}
       }
     )
     openai.request(
       {
         method: :get,
         path: "models",
-        options: {extra_headers: {"x-cost-center" => nil}}
+        options: {extra_headers: {"x-cost-center": nil}}
       }
     )
 
@@ -802,6 +804,39 @@ class OpenAITest < Minitest::Test
     assert_requested(:any, "https://example.com/redirected", times: OpenAI::Client::MAX_REDIRECTS) do
       headers = _1.headers.keys.map(&:downcase)
       refute_includes(headers, "authorization")
+    end
+  end
+
+  def test_client_redirect_strips_symbol_sensitive_headers_cross_origin
+    source = "http://localhost/models"
+    destination = "https://example.com/redirected"
+    stub_request(:get, source).to_return(status: 307, headers: {"location" => destination})
+    stub_request(:get, destination).to_return_json(status: 200, body: {})
+
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      default_headers: {
+        Authorization: "Bearer leaked-secret",
+        Cookie: "session=private",
+        "Proxy-Authorization": "Basic leaked-proxy",
+        Host: "spoofed.example"
+      }
+    )
+    openai.request({method: :get, path: "models"})
+
+    assert_requested(:get, source) do |request|
+      headers = request.headers.transform_keys(&:downcase)
+      assert_equal("Bearer My API Key", headers["authorization"])
+      assert_equal("session=private", headers["cookie"])
+      assert_equal("Basic leaked-proxy", headers["proxy-authorization"])
+      assert_equal("spoofed.example", headers["host"])
+    end
+
+    assert_requested(:get, destination) do |request|
+      headers = request.headers.transform_keys(&:downcase)
+      %w[authorization cookie proxy-authorization].each { refute_includes(headers, _1) }
+      assert_equal("example.com", headers["host"])
     end
   end
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -115,6 +115,19 @@ class OpenAI::Test::UtilHeaderHandlingTest < Minitest::Test
 
     assert_equal({"x-request-id" => "third"}, headers)
   end
+
+  def test_normalized_headers_preserves_precedence_for_every_key_spelling
+    keys = ["X-Request-Id", "x-request-id", :"X-Request-Id", :"x-request-id"]
+
+    keys.repeated_permutation(3).each do |first, second, third|
+      headers = OpenAI::Internal::Util.normalized_headers(
+        {first => "first", second => "second"},
+        {third => "third"}
+      )
+
+      assert_equal({"x-request-id" => "third"}, headers)
+    end
+  end
 end
 
 class OpenAI::Test::UtilUriHandlingTest < Minitest::Test

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -94,6 +94,29 @@ class OpenAI::Test::UtilDataHandlingTest < Minitest::Test
   end
 end
 
+class OpenAI::Test::UtilHeaderHandlingTest < Minitest::Test
+  def test_normalized_headers_canonicalizes_symbol_names
+    headers = OpenAI::Internal::Util.normalized_headers(
+      Authorization: " Bearer secret ",
+      "X-Request-Ids": ["first", nil, " second "]
+    )
+
+    assert_equal(
+      {"authorization" => "Bearer secret", "x-request-ids" => "first, second"},
+      headers
+    )
+  end
+
+  def test_normalized_headers_preserves_mixed_key_precedence
+    headers = OpenAI::Internal::Util.normalized_headers(
+      {"X-Request-Id" => "first", :"x-request-id" => "second"},
+      {"X-Request-Id" => "third"}
+    )
+
+    assert_equal({"x-request-id" => "third"}, headers)
+  end
+end
+
 class OpenAI::Test::UtilUriHandlingTest < Minitest::Test
   def test_parsing
     %w[

--- a/test/openai/providers/azure_test.rb
+++ b/test/openai/providers/azure_test.rb
@@ -281,6 +281,23 @@ class OpenAI::Test::AzureProviderTest < Minitest::Test
     end
   end
 
+  def test_provider_rejects_symbol_request_authentication_headers
+    client = OpenAI::Client.new(
+      provider: OpenAI::Providers.azure(
+        endpoint: "https://example-resource.openai.azure.com",
+        api_key: "azure-key"
+      )
+    )
+
+    [{Authorization: "Bearer custom"}, {"Api-Key": "custom-key"}].each do |headers|
+      error = assert_raises(OpenAI::Errors::Error) do
+        client.request({method: :get, path: "models", options: {extra_headers: headers}})
+      end
+
+      assert_match(/cannot be combined with a custom/, error.message)
+    end
+  end
+
   def test_configuration_values_are_validated
     cases = [
       [{api_key: "azure-key"}, /requires an endpoint/],

--- a/test/openai/providers/azure_test.rb
+++ b/test/openai/providers/azure_test.rb
@@ -172,9 +172,11 @@ class OpenAI::Test::AzureProviderTest < Minitest::Test
         api_key: "azure-key"
       ),
       default_headers: {
-        "Authorization" => "Bearer custom",
-        "Api-Key" => "custom-key",
-        "X-Cost-Center" => "finance"
+        "Authorization" => "Bearer string-custom",
+        Authorization: "Bearer symbol-custom",
+        "Api-Key" => "string-custom-key",
+        :"Api-Key" => "symbol-custom-key",
+        :"X-Cost-Center" => "finance"
       }
     )
     client.request({method: :get, path: "models"})

--- a/test/openai/providers/bedrock_test.rb
+++ b/test/openai/providers/bedrock_test.rb
@@ -356,7 +356,12 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
         region: "us-east-1",
         access_key_id: "access-key",
         secret_access_key: "secret-key"
-      )
+      ),
+      default_headers: {
+        "X-Amz-Content-Sha256": "injected-hash",
+        "X-Amz-Date": "injected-date",
+        "X-Amz-Security-Token": "injected-token"
+      }
     )
 
     client.request(
@@ -369,6 +374,8 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
 
     request = requests.fetch(0)
     assert_equal(Digest::SHA256.hexdigest(request.body), request.headers["X-Amz-Content-Sha256"])
+    refute_equal("injected-date", request.headers["X-Amz-Date"])
+    refute_includes(request.headers, "X-Amz-Security-Token")
     assert_includes(request.headers.fetch("Authorization"), "bedrock-mantle/aws4_request")
   end
 
@@ -536,6 +543,20 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
     streaming_body = custom_auth.merge(headers: {}, method: :post, body: StringIO.new("body"))
     error = assert_raises(OpenAI::Errors::Error) { sigv4_runtime.prepare_request.call(streaming_body) }
     assert_match(/replayable request body/, error.message)
+  end
+
+  def test_provider_rejects_symbol_request_authorization_header
+    client = OpenAI::Client.new(
+      provider: OpenAI::Providers.bedrock(region: "us-east-1", api_key: "bedrock-token")
+    )
+
+    error = assert_raises(OpenAI::Errors::Error) do
+      client.request(
+        {method: :get, path: "models", options: {extra_headers: {Authorization: "Bearer custom"}}}
+      )
+    end
+
+    assert_match(/custom `Authorization` header/, error.message)
   end
 
   def test_sigv4_rejects_redirects_and_mismatched_canonical_regions

--- a/test/openai/providers/bedrock_test.rb
+++ b/test/openai/providers/bedrock_test.rb
@@ -110,10 +110,12 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
     client = OpenAI::Client.new(
       provider: OpenAI::Providers.bedrock(region: "us-east-1", api_key: "bedrock-token"),
       default_headers: {
-        "Authorization" => "Bearer custom",
-        "X-Cost-Center" => "finance"
+        "Authorization" => "Bearer string-custom",
+        Authorization: "Bearer symbol-custom",
+        :"X-Cost-Center" => "finance"
       }
     )
+    refute_includes(client.headers, :authorization)
     client.request({method: :get, path: "models"})
 
     assert_requested(:get, url) do |request|


### PR DESCRIPTION
## Summary
- canonicalize every header name to a lowercase String before collisions are resolved, preserving later-header precedence for mixed String/Symbol/case spellings
- compose environment, explicit organization/project routing, and client-default headers in one canonical merge so provider credentials and tenant routing cannot be bypassed
- add end-to-end security regressions proving cross-origin redirects strip symbol-keyed Authorization, Cookie, Proxy-Authorization, and Host; Azure/Bedrock protected request headers and Bedrock SigV4 signing headers resist injection
- permanently check all 64 combinations of String/Symbol and upper/lowercase header spellings so precedence regressions fail CI

## Verification
- `mise exec ruby@4.0.6 -- env TEST_API_BASE_URL=http://localhost:14010 ./scripts/test` — 619 tests, 2,349 assertions
- `mise exec ruby@3.4.10 -- env TEST_API_BASE_URL=http://localhost:14010 ./scripts/test` — 619 tests, 2,349 assertions
- `mise exec ruby@3.3.12 -- env TEST_API_BASE_URL=http://localhost:14010 ./scripts/test` — 619 tests, 2,349 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2,611 files
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck:sorbet`
- `mise exec ruby@4.0.6 -- bundle exec rake validate:rbs` — 1,212 RBS files
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem`
- 1,000 additional randomized mixed String/Symbol/case header-precedence checks
- verified Castiron preserves SDK-local changes through its three-way overlay; no upstream compiler change required