### PR TITLE
fix: preserve stream identity with HTTP logging

### DIFF
--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -109,7 +109,7 @@ module OpenAI
         def observe_stream(stream, response:)
           return stream unless enabled?(:error)
 
-          ObservedStream.new(stream: stream, context: self, response: response)
+          stream.observe(context: self, response: response)
         end
 
         def request_failed(error)
@@ -221,38 +221,6 @@ module OpenAI
 
           remaining = OpenAI::Internal::Logging::MAX_BODY_BYTES - @captured.bytesize
           @captured << chunk.byteslice(0, remaining) if remaining.positive?
-        end
-      end
-
-      class ObservedStream
-        include OpenAI::Internal::Type::BaseStream
-
-        def initialize(stream:, context:, response:)
-          @stream = stream
-          @context = context
-          @response = response
-          @last_response = stream.last_response
-          @iterator = iterator
-        end
-
-        private def iterator
-          source = @stream.to_enum
-          observed = Enumerator.new do |yielder|
-            loop do
-              event =
-                begin
-                  source.next
-                rescue StopIteration
-                  @context.completed(@response)
-                  break
-                rescue StandardError => e
-                  @context.request_failed(e)
-                  raise
-                end
-              yielder << event
-            end
-          end
-          OpenAI::Internal::Util.fused_enum(observed) { @stream.close }
         end
       end
 

--- a/lib/openai/internal/type/base_stream.rb
+++ b/lib/openai/internal/type/base_stream.rb
@@ -31,6 +31,33 @@ module OpenAI
         # @return [void]
         def close = OpenAI::Internal::Util.close_fused!(@iterator)
 
+        # Attach request lifecycle logging without changing the stream's identity.
+        #
+        # @api private
+        #
+        # @param context [OpenAI::Internal::Logging::Context]
+        # @param response [OpenAI::HTTPClient::Response]
+        # @return [self]
+        def observe(context:, response:)
+          source = @iterator
+          @iterator = OpenAI::Internal::Util.chain_fused(source) do |yielder|
+            loop do
+              event =
+                begin
+                  source.next
+                rescue StopIteration
+                  context.completed(response)
+                  break
+                rescue StandardError => e
+                  context.request_failed(e)
+                  raise
+                end
+              yielder << event
+            end
+          end
+          self
+        end
+
         # @api private
         #
         # @return [Enumerable<generic<Elem>>]

--- a/rbi/openai/internal/logging.rbi
+++ b/rbi/openai/internal/logging.rbi
@@ -119,27 +119,6 @@ module OpenAI
         end
       end
 
-      class ObservedStream
-        Message = type_member(:in) { { fixed: T.anything } }
-        Elem = type_member(:out)
-
-        include OpenAI::Internal::Type::BaseStream
-
-        sig do
-          params(
-            stream: T.untyped,
-            context: OpenAI::Internal::Logging::Context,
-            response: OpenAI::HTTPClient::Response
-          ).void
-        end
-        def initialize(stream:, context:, response:)
-        end
-
-        sig { override.returns(T::Enumerable[Elem]) }
-        private def iterator
-        end
-      end
-
       class << self
         sig { params(value: T.any(Symbol, String)).returns(Symbol) }
         def normalize_level(value)

--- a/rbi/openai/internal/type/base_stream.rbi
+++ b/rbi/openai/internal/type/base_stream.rbi
@@ -26,6 +26,16 @@ module OpenAI
         end
 
         # @api private
+        sig do
+          params(
+            context: OpenAI::Internal::Logging::Context,
+            response: OpenAI::HTTPClient::Response
+          ).returns(T.self_type)
+        end
+        def observe(context:, response:)
+        end
+
+        # @api private
         sig { overridable.returns(T::Enumerable[Elem]) }
         private def iterator
         end

--- a/sig/openai/internal/logging.rbs
+++ b/sig/openai/internal/logging.rbs
@@ -62,18 +62,6 @@ module OpenAI
         def close: -> void
       end
 
-      class ObservedStream[Elem]
-        include OpenAI::Internal::Type::BaseStream[top, Elem]
-
-        def initialize: (
-          stream: OpenAI::Internal::Type::BaseStream[top, Elem],
-          context: OpenAI::Internal::Logging::Context,
-          response: OpenAI::HTTPClient::Response
-        ) -> void
-
-        private def iterator: -> Enumerable[Elem]
-      end
-
       def self.normalize_level: (Symbol | String value) -> Symbol
       def self.validate_logger!: (OpenAI::_Logger? logger) -> void
       def self.default_logger: -> OpenAI::_Logger

--- a/sig/openai/internal/type/base_stream.rbs
+++ b/sig/openai/internal/type/base_stream.rbs
@@ -12,6 +12,11 @@ module OpenAI
 
         def close: -> void
 
+        def observe: (
+          context: OpenAI::Internal::Logging::Context,
+          response: OpenAI::HTTPClient::Response
+        ) -> self
+
         private def iterator: -> Enumerable[Elem]
 
         def each: { (Elem arg0) -> void } -> void

--- a/test/openai/logging_test.rb
+++ b/test/openai/logging_test.rb
@@ -586,32 +586,92 @@ class LoggingTest < Minitest::Test
     assert_includes(logger.events.fetch(0).fetch(1), "request complete")
   end
 
-  def test_stream_failures_log_an_error_without_a_success_event
-    logger = CapturingLogger.new
-    http_client = StubHTTPClient.new do |_request|
-      OpenAI::HTTPClient::Response.new(
-        status: 200,
-        headers: {"content-type" => "text/event-stream", "x-request-id" => "req_stream"},
-        body: "data: {\"error\":{\"message\":\"stream failed\"}}\n\n"
-      )
-    end
-    client = diagnostic_client(
-      api_key: "test-key",
-      http_client: http_client,
-      logger: logger,
-      log_level: :info
-    )
-    stream = client.request(
-      method: :get,
-      path: "stream",
-      stream: OpenAI::Internal::Stream
-    )
+  def test_enabled_logging_preserves_stream_identity_metadata_and_lazy_consumption
+    [:error, :warn, :info, :debug].each do |level|
+      logger = CapturingLogger.new
+      source = CloseableBody.new("data: {\"message\":\"done\"}\n\n")
+      http_client = StubHTTPClient.new do |_request|
+        OpenAI::HTTPClient::Response.new(
+          status: 200,
+          headers: {"content-type" => "text/event-stream", "x-request-id" => "req_stream"},
+          body: source
+        )
+      end
+      client = diagnostic_client(http_client: http_client, logger: logger, log_level: level)
 
-    assert_empty(logger.events)
-    assert_raises(OpenAI::Errors::APIStatusError) { stream.to_a }
-    assert_equal([:error], logger.events.map(&:first))
-    assert_includes(logger.events.fetch(0).fetch(1), "request failed")
-    refute_includes(logger.events.fetch(0).fetch(1), "request complete")
+      stream = client.request(method: :get, path: "stream", stream: OpenAI::Internal::Stream)
+
+      assert_instance_of(OpenAI::Internal::Stream, stream)
+      assert_kind_of(OpenAI::Internal::Stream, stream)
+      assert_match(/\A#<OpenAI::Internal::Stream\[/, stream.inspect)
+      assert_includes(stream.inspect, "Unknown")
+      assert_equal(200, stream.status)
+      assert_equal("req_stream", stream.last_response.request_id)
+      assert_same(stream.last_response.headers, stream.headers)
+      assert_equal(0, source.each_count)
+
+      assert_equal([{message: "done"}], stream.to_a)
+      assert_equal(1, source.each_count)
+      assert_equal(1, source.close_count)
+
+      completions = logger.events.select { |_severity, message| message.include?("request complete") }
+      assert_equal([:info, :debug].include?(level) ? 1 : 0, completions.length)
+    end
+  end
+
+  def test_closing_an_observed_stream_preserves_identity_and_does_not_log_completion
+    [:error, :warn, :info, :debug].each do |level|
+      logger = CapturingLogger.new
+      source = CloseableBody.new("data: {\"message\":\"not consumed\"}\n\n")
+      http_client = StubHTTPClient.new do |_request|
+        OpenAI::HTTPClient::Response.new(
+          status: 200,
+          headers: {"content-type" => "text/event-stream"},
+          body: source
+        )
+      end
+      client = diagnostic_client(http_client: http_client, logger: logger, log_level: level)
+
+      stream = client.request(method: :get, path: "stream", stream: OpenAI::Internal::Stream)
+      stream.close
+      stream.close
+
+      assert_instance_of(OpenAI::Internal::Stream, stream)
+      assert_equal(0, source.each_count)
+      assert_equal(1, source.close_count)
+      assert_empty(logger.events.select { |_severity, message| message.include?("request complete") })
+      assert_empty(stream.to_a)
+    end
+  end
+
+  def test_stream_failures_log_an_error_without_a_success_event
+    [:error, :warn, :info, :debug].each do |level|
+      logger = CapturingLogger.new
+      http_client = StubHTTPClient.new do |_request|
+        OpenAI::HTTPClient::Response.new(
+          status: 200,
+          headers: {"content-type" => "text/event-stream", "x-request-id" => "req_stream"},
+          body: "data: {\"error\":{\"message\":\"stream failed\"}}\n\n"
+        )
+      end
+      client = diagnostic_client(
+        api_key: "test-key",
+        http_client: http_client,
+        logger: logger,
+        log_level: level
+      )
+      stream = client.request(
+        method: :get,
+        path: "stream",
+        stream: OpenAI::Internal::Stream
+      )
+
+      assert_raises(OpenAI::Errors::APIStatusError) { stream.to_a }
+      failures = logger.events.filter_map { |severity, message| message if severity == :error }
+      assert_equal(1, failures.length)
+      assert_includes(failures.fetch(0), "request failed")
+      assert_empty(logger.events.select { |_severity, message| message.include?("request complete") })
+    end
   end
 
   def test_consumer_exceptions_are_not_logged_as_request_failures

--- a/test/openai/logging_test.rb
+++ b/test/openai/logging_test.rb
@@ -37,10 +37,11 @@ class LoggingTest < Minitest::Test
   class CloseableBody
     include Enumerable
 
-    attr_reader :close_count, :each_count
+    attr_reader :chunk_count, :close_count, :each_count
 
     def initialize(*chunks)
       @chunks = chunks
+      @chunk_count = 0
       @close_count = 0
       @each_count = 0
     end
@@ -49,7 +50,10 @@ class LoggingTest < Minitest::Test
 
     def each
       @each_count += 1
-      @chunks.each { yield(_1) }
+      @chunks.each do |chunk|
+        @chunk_count += 1
+        yield(chunk)
+      end
     end
   end
 
@@ -530,32 +534,31 @@ class LoggingTest < Minitest::Test
   end
 
   def test_debug_logging_does_not_consume_or_disclose_streamed_responses
-    logger = CapturingLogger.new
-    source = CloseableBody.new(UnbufferableChunk.new("data: {\"message\":\"stream-secret\"}\n\n"))
-    http_client = StubHTTPClient.new do |_request|
-      OpenAI::HTTPClient::Response.new(
-        status: 200,
-        headers: {"content-type" => "text/event-stream", "x-request-id" => "req_stream"},
-        body: source
-      )
+    [nil, OpenAI::Internal::Stream].each do |stream_class|
+      logger = CapturingLogger.new
+      source = CloseableBody.new(UnbufferableChunk.new("data: {\"message\":\"stream-secret\"}\n\n"))
+      http_client = StubHTTPClient.new do |_request|
+        OpenAI::HTTPClient::Response.new(
+          status: 200,
+          headers: {"content-type" => "text/event-stream", "x-request-id" => "req_stream"},
+          body: source
+        )
+      end
+      client = diagnostic_client(http_client: http_client, logger: logger, log_level: :debug)
+
+      events = client.request(method: :get, path: "stream", stream: stream_class)
+
+      assert_instance_of(stream_class, events) if stream_class
+      assert_equal(0, source.each_count)
+      event = events.to_a.fetch(0)
+      data = stream_class ? event : JSON.parse(event.fetch(:data), symbolize_names: true)
+      assert_equal("stream-secret", data.fetch(:message))
+      assert_equal(1, source.each_count)
+      assert_equal(1, source.close_count)
+      debug_log = logger.events.filter_map { _2 if _1 == :debug }.join("\n")
+      assert_includes(debug_log, "[STREAM BODY OMITTED]")
+      refute_includes(debug_log, "stream-secret")
     end
-    client = diagnostic_client(
-      api_key: "test-key",
-      http_client: http_client,
-      logger: logger,
-      log_level: :debug
-    )
-
-    events = client.request(method: :get, path: "stream")
-
-    assert_equal(0, source.each_count)
-    data = JSON.parse(events.to_a.fetch(0).fetch(:data), symbolize_names: true)
-    assert_equal("stream-secret", data.fetch(:message))
-    assert_equal(1, source.each_count)
-    assert_equal(1, source.close_count)
-    debug_log = logger.events.filter_map { _2 if _1 == :debug }.join("\n")
-    assert_includes(debug_log, "[STREAM BODY OMITTED]")
-    refute_includes(debug_log, "stream-secret")
   end
 
   def test_stream_completion_is_logged_only_after_consumption
@@ -644,6 +647,34 @@ class LoggingTest < Minitest::Test
     end
   end
 
+  def test_closing_a_partially_consumed_stream_never_drains_or_double_logs_the_body
+    logger = CapturingLogger.new
+    source = CloseableBody.new(
+      "data: {\"message\":\"first\"}\n\n",
+      "data: {\"message\":\"must not be consumed\"}\n\n"
+    )
+    http_client = StubHTTPClient.new do |_request|
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "text/event-stream"},
+        body: source
+      )
+    end
+    client = diagnostic_client(http_client: http_client, logger: logger, log_level: :debug)
+    stream = client.request(method: :get, path: "stream", stream: OpenAI::Internal::Stream)
+
+    assert_equal({message: "first"}, stream.to_enum.next)
+    stream.close
+    stream.close
+
+    assert_equal(1, source.chunk_count)
+    assert_equal(1, source.close_count)
+    assert_equal(0, logger.events.count { |severity, _message| severity == :error })
+    assert_empty(logger.events.select { |_severity, message| message.include?("request complete") })
+    assert_equal(1, logger.events.count { |_severity, message| message.include?("response body") })
+    assert_empty(stream.to_a)
+  end
+
   def test_stream_failures_log_an_error_without_a_success_event
     [:error, :warn, :info, :debug].each do |level|
       logger = CapturingLogger.new
@@ -672,6 +703,32 @@ class LoggingTest < Minitest::Test
       assert_includes(failures.fetch(0), "request failed")
       assert_empty(logger.events.select { |_severity, message| message.include?("request complete") })
     end
+  end
+
+  def test_midstream_failures_preserve_delivered_events_and_close_the_body_once
+    logger = CapturingLogger.new
+    source = CloseableBody.new(
+      "data: {\"message\":\"first\"}\n\n",
+      "data: {\"error\":{\"message\":\"stream failed\"}}\n\n"
+    )
+    http_client = StubHTTPClient.new do |_request|
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "text/event-stream"},
+        body: source
+      )
+    end
+    client = diagnostic_client(http_client: http_client, logger: logger, log_level: :debug)
+    stream = client.request(method: :get, path: "stream", stream: OpenAI::Internal::Stream)
+    iterator = stream.to_enum
+
+    assert_equal({message: "first"}, iterator.next)
+    assert_raises(OpenAI::Errors::APIStatusError) { iterator.next }
+    assert_equal(2, source.chunk_count)
+    assert_equal(1, source.close_count)
+    assert_equal(1, logger.events.count { |severity, _message| severity == :error })
+    assert_empty(logger.events.select { |_severity, message| message.include?("request complete") })
+    assert_equal(1, logger.events.count { |_severity, message| message.include?("response body") })
   end
 
   def test_consumer_exceptions_are_not_logged_as_request_failures

--- a/test/openai/resources/chat/completions/streaming_test.rb
+++ b/test/openai/resources/chat/completions/streaming_test.rb
@@ -128,6 +128,30 @@ class OpenAI::Test::Resources::Chat::Completions::StreamingTest < Minitest::Test
     stream&.close
   end
 
+  def test_enabled_logging_preserves_raw_and_helper_stream_types
+    stub_streaming_response(basic_text_sse_response)
+
+    [:error, :warn, :info, :debug].each do |level|
+      client = OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "test-key",
+        logger: Logger.new(StringIO.new),
+        log_level: level
+      )
+
+      raw_stream = client.chat.completions.stream_raw(**basic_params)
+      assert_instance_of(OpenAI::Internal::Stream, raw_stream)
+      assert_includes(raw_stream.inspect, "ChatCompletionChunk")
+      assert_equal("req_stream", raw_stream.last_response.request_id)
+      raw_stream.close
+
+      helper_stream = client.chat.completions.stream(**basic_params)
+      assert_instance_of(OpenAI::Helpers::Streaming::ChatCompletionStream, helper_stream)
+      assert_equal("req_stream", helper_stream.last_response.request_id)
+      assert_equal("Hello there! How can I help?", helper_stream.get_output_text)
+    end
+  end
+
   def test_get_output_text
     stub_streaming_response(basic_text_sse_response)
 

--- a/test/openai/resources/responses/streaming_test.rb
+++ b/test/openai/resources/responses/streaming_test.rb
@@ -119,6 +119,30 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     stream&.close
   end
 
+  def test_enabled_logging_preserves_raw_and_helper_stream_types
+    stub_streaming_response(basic_text_sse_response)
+
+    [:error, :warn, :info, :debug].each do |level|
+      client = OpenAI::Client.new(
+        base_url: "http://localhost",
+        api_key: "test-key",
+        logger: Logger.new(StringIO.new),
+        log_level: level
+      )
+
+      raw_stream = client.responses.stream_raw(**basic_params)
+      assert_instance_of(OpenAI::Internal::Stream, raw_stream)
+      assert_includes(raw_stream.inspect, "ResponseStreamEvent")
+      assert_equal("req_stream", raw_stream.last_response.request_id)
+      raw_stream.close
+
+      helper_stream = client.responses.stream(**basic_params)
+      assert_instance_of(OpenAI::Helpers::Streaming::ResponseStream, helper_stream)
+      assert_equal("req_stream", helper_stream.last_response.request_id)
+      assert_equal("Hello there! How can I help you today?", helper_stream.get_output_text)
+    end
+  end
+
   def test_get_output_text
     stub_streaming_response(basic_text_sse_response)
 


### PR DESCRIPTION
## Summary

- Preserve the concrete original `OpenAI::Internal::Stream` instance when HTTP observability is enabled by instrumenting its existing fused iterator instead of returning an unrelated wrapper.
- Remove the obsolete `ObservedStream` runtime class and its RBI/RBS declarations; declare the identity-preserving private stream hook consistently in Ruby, RBI, and RBS.
- Cover `:error`, `:warn`, `:info`, and `:debug` for stream class/`is_a?`, model-aware inspection, response metadata, lazy consumption, completion/error logging, idempotent early close, and Responses/Chat Completions raw and helper streams.
- Regression-test both typed and untyped debug SSE redaction, active-iterator early close without consuming the next chunk, and first-event delivery followed by a midstream API error with exactly-once body closure/logging.

## Verification

- `TEST_API_BASE_URL=http://127.0.0.1:43287 mise exec ruby@4.0.6 -- ./scripts/test` — 619 tests, 2,438 assertions.
- `TEST_API_BASE_URL=http://127.0.0.1:43287 mise exec ruby@3.3.12 -- ./scripts/test` — 619 tests, 2,438 assertions.
- `TEST_API_BASE_URL=http://127.0.0.1:43287 mise exec ruby@3.4.10 -- ./scripts/test` — 619 tests, 2,438 assertions.
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2,611 files, no offenses.
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck:sorbet`.
- `mise exec ruby@4.0.6 -- bundle exec rake validate:rbs` — 1,212 RBS files.
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem`.

The isolated test-server port avoids unrelated contention between concurrent worktrees.

## Castiron impact

No upstream compiler change is required. Castiron's Ruby `render_tree_from_views` emits only package roots/indexes, generated client files, resources, models, and per-resource tests; it does not emit the SDK-owned logging or `internal/type/base_stream` Ruby/RBI/RBS files changed here. Its `resource_test_path` emits `test/pkgxyz/resources/<resource>_test.rb`, not the nested streaming-helper tests modified by this PR. The existing upstream observability companion already generates the only compiler-owned boundary (`logger`, `log_level`, and `on_retry` on the client constructor); this change does not alter that constructor, generated resource signatures, OpenAPI inputs, or generation metadata. A later Castiron generation has already preserved the original SDK-owned stream/logging implementation.