### PR TITLE
fix: restore RuboCop coverage for RBI files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
 ---
-# Keep RuboCop's dependency and build-output exclusions alongside ours.
+# Keep RuboCop's standard file types and dependency exclusions alongside ours.
 inherit_mode:
   merge:
+    - Include
     - Exclude
 
 # Explicitly disable pending cops for now. This is the default behaviour but
@@ -10,6 +11,8 @@ inherit_mode:
 # Stop RuboCop nagging about rubocop-rake.
 # Ensure that RuboCop validates according to the lowest version of Ruby that we support.
 AllCops:
+  Include:
+    - "**/*.rbi"
   Exclude:
     - "bin/*"
     - "sorbet/rbi/annotations/**/*"

--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ end
 
 desc("Lint `*.rb(i)`")
 RuboCop::RakeTask.new(:"lint:rubocop") do |task|
-  task.patterns = %w[. ./**/*.rbi]
+  task.patterns = ["."]
   task.formatters = %w[github] if ENV.key?("CI")
 
   # some lines cannot be shortened

--- a/test/openai/rubocop_target_coverage_test.rb
+++ b/test/openai/rubocop_target_coverage_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "open3"
+
+require_relative "test_helper"
+
+class OpenAI::Test::RubocopTargetCoverageTest < Minitest::Test
+  def test_inspects_ruby_interfaces_and_root_ruby_files
+    output, errors, status = Open3.capture3(
+      "rubocop",
+      "--list-target-files",
+      ".",
+      "--force-exclusion",
+      chdir: File.expand_path("../..", __dir__)
+    )
+
+    assert_predicate(status, :success?, errors)
+
+    targets = output.lines(chomp: true)
+    required_targets = %w[rbi/openai/client.rbi rbi/openai/models.rbi Rakefile openai.gemspec]
+
+    assert_empty(required_targets - targets, "RuboCop skipped required first-party targets")
+  end
+end


### PR DESCRIPTION
## Summary

- Restore RuboCop inspection of every first-party RBI by adding `**/*.rbi` to `AllCops/Include` and merging RuboCop's default include patterns instead of replacing them.
- Simplify `lint:rubocop` to discover all Ruby and RBI targets from the repository root while preserving `--parallel`, `--force-exclusion`, existing exclusions, and every enabled cop.
- Add an integration regression test that checks RuboCop's actual target list for representative generated RBIs, `Rakefile`, and `openai.gemspec`.

`--force-exclusion` filters even explicitly supplied files through RuboCop's recognized `AllCops/Include` patterns. Since `.rbi` was missing from those patterns, the previous explicit RBI glob silently inspected none of the repository's 1,224 RBI files. Target coverage now increases from **1,389 Ruby files and 0 RBIs** to **2,614 files, including all 1,224 RBIs**.

## Castiron ownership: no upstream change required

I inspected Castiron's authoritative `docs/stainless-sdk-json-fixtures/release-primary/generated-file-excludes.yaml` and its actual Ruby renderer at `crates/castiron-render-ruby/src/output.rs` before publishing:

- `.rubocop.yml` and `Rakefile` are explicitly excluded by exact path as SDK-owned Ruby package/tooling metadata.
- The broader `test/` tree is excluded from generator ownership; only `test/openai/resources/` and `test/openai/resource_namespaces.rb` are re-included. The new `test/openai/rubocop_target_coverage_test.rb` is therefore SDK-owned.
- Castiron's Ruby renderer emits generated RBI/resource files and generated resource tests, but none of the three modified files.

No generator/template/schema change, companion regeneration, or upstream Castiron change is required.

## Verification

- Regression demonstrated before the fix: the new test failed because `rbi/openai/client.rbi` was absent from `rubocop --list-target-files . --force-exclusion`.
- `TEST=test/openai/rubocop_target_coverage_test.rb bundle exec rake test` — 1 test, 3 assertions, passing.
- `bundle exec rake test` — 627 tests, 2,538 assertions, no failures/errors/skips.
- `bundle exec rake lint` — 2,614 files inspected, no offenses; Sorbet reports no errors; all 1,212 RBS files validate.
- `bundle exec rubocop --list-target-files . --force-exclusion` — 2,614 targets, all 1,224 RBIs included; `Rakefile`, `Steepfile`, and `openai.gemspec` included; vendor/generated-dependency targets excluded.
- Required thermo-nuclear code-quality review completed before push; no structural findings.
