### PR TITLE
fix: redact sensitive query and form logging

### DIFF
--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -21,7 +21,7 @@ module OpenAI
       OPAQUE_STRING_BYTES = 1_024
       SENSITIVE_BODY_KEY = /(?:api[-_]?key|authorization|credential|password|secret|signature|token)/i
       SENSITIVE_QUERY_KEY =
-        /(?:(?:\A|[-_\[])(?:key|sig)|api[-_]?key|authorization|credential|password|secret|signature|token)(?:\[|\]|\z)/i
+        /(?:(?:\A|[-_\[])(?:key|sig)|(?-i:K)ey|api[-_]?key|authorization|credentials?|password|secret|signature|token)(?:\[|\]|\z)/i
       URL_HEADER_KEY = /(?:\A|[-_])(?:location|url|uri)\z|\A(?:link|refresh)\z/i
 
       class Context

--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -21,7 +21,7 @@ module OpenAI
       OPAQUE_STRING_BYTES = 1_024
       SENSITIVE_BODY_KEY = /(?:api[-_]?key|authorization|credential|password|secret|signature|token)/i
       SENSITIVE_QUERY_KEY =
-        /(?:\A|[-_])(?:api[-_]?key|authorization|credential|key|password|secret|sig|signature|token)\z/i
+        /(?:(?:\A|[-_\[])(?:key|sig)|api[-_]?key|authorization|credential|password|secret|signature|token)(?:\]|\z)/i
       URL_HEADER_KEY = /(?:\A|[-_])(?:location|url|uri)\z|\A(?:link|refresh)\z/i
 
       class Context
@@ -357,11 +357,13 @@ module OpenAI
             return JSON.generate(scrub_value(parsed))
           end
 
-          text = body.byteslice(0, MAX_BODY_BYTES).to_s
-          text = text.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-          return text.inspect if total_bytes <= MAX_BODY_BYTES
+          unless content_type.match?(%r{\Aapplication/x-www-form-urlencoded(?:;|\z)}i)
+            return "[TEXT BODY OMITTED] bytes=#{total_bytes}"
+          end
+          return "[FORM BODY OMITTED] bytes=#{total_bytes} reason=too_large" if total_bytes > MAX_BODY_BYTES
 
-          "#{text.inspect} [TRUNCATED bytes=#{total_bytes}]"
+          sanitized = sanitized_query(body)
+          sanitized.nil? ? "[INVALID FORM BODY OMITTED] bytes=#{total_bytes}" : sanitized.inspect
         rescue JSON::ParserError
           "[INVALID JSON BODY OMITTED] bytes=#{total_bytes}"
         end

--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -21,7 +21,7 @@ module OpenAI
       OPAQUE_STRING_BYTES = 1_024
       SENSITIVE_BODY_KEY = /(?:api[-_]?key|authorization|credential|password|secret|signature|token)/i
       SENSITIVE_QUERY_KEY =
-        /(?:(?:\A|[-_\[])(?:key|sig)|api[-_]?key|authorization|credential|password|secret|signature|token)(?:\]|\z)/i
+        /(?:(?:\A|[-_\[])(?:key|sig)|api[-_]?key|authorization|credential|password|secret|signature|token)(?:\[|\]|\z)/i
       URL_HEADER_KEY = /(?:\A|[-_])(?:location|url|uri)\z|\A(?:link|refresh)\z/i
 
       class Context

--- a/test/openai/logging_security_test.rb
+++ b/test/openai/logging_security_test.rb
@@ -7,6 +7,7 @@ class LoggingSecurityTest < Minitest::Test
   def test_info_and_debug_logs_redact_camel_case_and_nested_query_credentials
     credentials = {
       "accessToken" => "camel-access-secret",
+      "accessKey" => "camel-access-key-secret",
       "clientSecret" => "camel-client-secret",
       "sessionToken" => "camel-session-secret",
       "bearerToken" => "camel-bearer-secret",
@@ -14,7 +15,8 @@ class LoggingSecurityTest < Minitest::Test
       "clientSecret[]" => "array-client-secret",
       "credentials[accessToken]" => "nested-access-secret",
       "credentials[client_secret]" => "nested-client-secret",
-      "credentials[access_token][]" => "nested-array-secret"
+      "credentials[access_token][]" => "nested-array-secret",
+      "credentials[value]" => "nested-credential-secret"
     }
 
     [:info, :debug].each do |level|
@@ -41,8 +43,10 @@ class LoggingSecurityTest < Minitest::Test
     url = URI(
       "https://user:password@example.com/probe?" \
       "access%54oken=encoded-access-secret&" \
+      "access%4Bey=encoded-access-key-secret&" \
       "credentials%5Bclient%53ecret%5D=encoded-client-secret&" \
       "access_token%5B%5D=encoded-array-secret&" \
+      "credentials%5Bvalue%5D=encoded-credential-secret&" \
       "safe=visible"
     )
 
@@ -50,8 +54,10 @@ class LoggingSecurityTest < Minitest::Test
       assert_includes(formatted, "safe=visible")
       assert_includes(formatted, "%5BREDACTED%5D")
       refute_includes(formatted, "encoded-access-secret")
+      refute_includes(formatted, "encoded-access-key-secret")
       refute_includes(formatted, "encoded-client-secret")
       refute_includes(formatted, "encoded-array-secret")
+      refute_includes(formatted, "encoded-credential-secret")
       refute_includes(formatted, "user:password@")
     end
   end
@@ -59,6 +65,7 @@ class LoggingSecurityTest < Minitest::Test
   def test_debug_logs_structurally_redact_form_urlencoded_request_bodies
     body =
       "client_secret=client-form-secret&access_token=access-form-secret&" \
+      "accessKey=access-key-form-secret&credentials%5Bvalue%5D=credential-form-secret&" \
       "access_token%5B%5D=array-form-secret&" \
       "credentials%5BsessionToken%5D=nested-form-secret&" \
       "safe=hello+world&repeat=one&repeat=two"
@@ -72,12 +79,16 @@ class LoggingSecurityTest < Minitest::Test
     assert_includes(output, "request started")
     assert_includes(output, "client_secret=%5BREDACTED%5D")
     assert_includes(output, "access_token=%5BREDACTED%5D")
+    assert_includes(output, "accessKey=%5BREDACTED%5D")
+    assert_includes(output, "credentials%5Bvalue%5D=%5BREDACTED%5D")
     assert_includes(output, "access_token%5B%5D=%5BREDACTED%5D")
     assert_includes(output, "credentials%5BsessionToken%5D=%5BREDACTED%5D")
     assert_includes(output, "safe=hello+world")
     assert_includes(output, "repeat=one&repeat=two")
     refute_includes(output, "client-form-secret")
     refute_includes(output, "access-form-secret")
+    refute_includes(output, "access-key-form-secret")
+    refute_includes(output, "credential-form-secret")
     refute_includes(output, "array-form-secret")
     refute_includes(output, "nested-form-secret")
   end
@@ -85,6 +96,7 @@ class LoggingSecurityTest < Minitest::Test
   def test_debug_logs_structurally_redact_form_urlencoded_response_bodies
     body =
       "accessToken=response-access-secret&access_token%5B%5D=response-array-secret&" \
+      "accessKey=response-access-key-secret&credentials%5Bvalue%5D=response-credential-secret&" \
       "credentials%5Bclient_secret%5D=response-client-secret&safe=visible"
     formatted = OpenAI::Internal::Logging.format_observed_body(
       body,
@@ -94,10 +106,14 @@ class LoggingSecurityTest < Minitest::Test
     )
 
     assert_includes(formatted, "accessToken=%5BREDACTED%5D")
+    assert_includes(formatted, "accessKey=%5BREDACTED%5D")
+    assert_includes(formatted, "credentials%5Bvalue%5D=%5BREDACTED%5D")
     assert_includes(formatted, "access_token%5B%5D=%5BREDACTED%5D")
     assert_includes(formatted, "credentials%5Bclient_secret%5D=%5BREDACTED%5D")
     assert_includes(formatted, "safe=visible")
     refute_includes(formatted, "response-access-secret")
+    refute_includes(formatted, "response-access-key-secret")
+    refute_includes(formatted, "response-credential-secret")
     refute_includes(formatted, "response-array-secret")
     refute_includes(formatted, "response-client-secret")
   end

--- a/test/openai/logging_security_test.rb
+++ b/test/openai/logging_security_test.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "minitest/mock"
+require_relative "test_helper"
+
+class LoggingSecurityTest < Minitest::Test
+  def test_info_and_debug_logs_redact_camel_case_and_nested_query_credentials
+    credentials = {
+      "accessToken" => "camel-access-secret",
+      "clientSecret" => "camel-client-secret",
+      "sessionToken" => "camel-session-secret",
+      "bearerToken" => "camel-bearer-secret",
+      "credentials[accessToken]" => "nested-access-secret",
+      "credentials[client_secret]" => "nested-client-secret"
+    }
+
+    [:info, :debug].each do |level|
+      output, request = logged_request(
+        log_level: level,
+        query: {**credentials, "safe" => "visible", "monkey" => "still-visible"}
+      )
+
+      assert_includes(output, "request complete")
+      assert_includes(output, "safe=visible")
+      assert_includes(output, "monkey=still-visible")
+      assert_includes(output, "%5BREDACTED%5D")
+
+      credentials.each_value do |secret|
+        assert_includes(request.url.to_s, secret)
+        refute_includes(output, secret)
+      end
+
+      assert_equal(level == :debug, output.include?("request started"))
+    end
+  end
+
+  def test_url_sanitization_redacts_percent_encoded_and_nested_credential_keys
+    url = URI(
+      "https://user:password@example.com/probe?" \
+      "access%54oken=encoded-access-secret&" \
+      "credentials%5Bclient%53ecret%5D=encoded-client-secret&" \
+      "safe=visible"
+    )
+
+    [OpenAI::Internal::Logging.safe_url(url), OpenAI::Internal::Logging.safe_path(url)].each do |formatted|
+      assert_includes(formatted, "safe=visible")
+      assert_includes(formatted, "%5BREDACTED%5D")
+      refute_includes(formatted, "encoded-access-secret")
+      refute_includes(formatted, "encoded-client-secret")
+      refute_includes(formatted, "user:password@")
+    end
+  end
+
+  def test_debug_logs_structurally_redact_form_urlencoded_request_bodies
+    body =
+      "client_secret=client-form-secret&access_token=access-form-secret&" \
+      "credentials%5BsessionToken%5D=nested-form-secret&" \
+      "safe=hello+world&repeat=one&repeat=two"
+    output, request = logged_request(
+      log_level: :debug,
+      headers: {"content-type" => "application/x-www-form-urlencoded; charset=utf-8"},
+      body: body
+    )
+
+    assert_equal(body, request.body)
+    assert_includes(output, "request started")
+    assert_includes(output, "client_secret=%5BREDACTED%5D")
+    assert_includes(output, "access_token=%5BREDACTED%5D")
+    assert_includes(output, "credentials%5BsessionToken%5D=%5BREDACTED%5D")
+    assert_includes(output, "safe=hello+world")
+    assert_includes(output, "repeat=one&repeat=two")
+    refute_includes(output, "client-form-secret")
+    refute_includes(output, "access-form-secret")
+    refute_includes(output, "nested-form-secret")
+  end
+
+  def test_debug_logs_structurally_redact_form_urlencoded_response_bodies
+    body = "accessToken=response-access-secret&credentials%5Bclient_secret%5D=response-client-secret&safe=visible"
+    formatted = OpenAI::Internal::Logging.format_observed_body(
+      body,
+      headers: {"content-type" => "application/x-www-form-urlencoded"},
+      complete: true,
+      total_bytes: body.bytesize
+    )
+
+    assert_includes(formatted, "accessToken=%5BREDACTED%5D")
+    assert_includes(formatted, "credentials%5Bclient_secret%5D=%5BREDACTED%5D")
+    assert_includes(formatted, "safe=visible")
+    refute_includes(formatted, "response-access-secret")
+    refute_includes(formatted, "response-client-secret")
+  end
+
+  def test_debug_logs_omit_malformed_or_oversized_form_bodies
+    headers = {"content-type" => "application/x-www-form-urlencoded"}
+    malformed = "access_token=malformed-secret&invalid=\xFF".b
+    oversized = "access_token=oversized-secret&padding=#{'x' * OpenAI::Internal::Logging::MAX_BODY_BYTES}"
+
+    [malformed, oversized].each do |body|
+      formatted = OpenAI::Internal::Logging.format_body(body, headers: headers)
+
+      assert_includes(formatted, "BODY OMITTED]")
+      assert_includes(formatted, "bytes=#{body.bytesize}")
+      refute_includes(formatted, "malformed-secret")
+      refute_includes(formatted, "oversized-secret")
+    end
+  end
+
+  def test_debug_logs_omit_unsupported_textual_request_and_response_bodies
+    content_types = [
+      "application/xml",
+      "application/vnd.example+xml; charset=utf-8",
+      "text/xml",
+      "text/plain",
+      "text/html",
+      "text/csv",
+      ""
+    ]
+
+    content_types.each do |content_type|
+      body = "<access_token>unsupported-text-secret</access_token>"
+      headers = {"content-type" => content_type}
+      request_body = OpenAI::Internal::Logging.format_body(body, headers: headers)
+      response_body = OpenAI::Internal::Logging.format_observed_body(
+        body,
+        headers: headers,
+        complete: true,
+        total_bytes: body.bytesize
+      )
+
+      [request_body, response_body].each do |formatted|
+        assert_includes(formatted, "BODY OMITTED]")
+        assert_includes(formatted, "bytes=#{body.bytesize}")
+        refute_includes(formatted, "unsupported-text-secret")
+      end
+    end
+  end
+
+  private def logged_request(log_level:, query: nil, headers: nil, body: nil)
+    output = StringIO.new
+    logger = Logger.new(output)
+    response = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json", "x-request-id" => "req_security"},
+      body: '{"ok":true}'
+    )
+    request = nil
+    transport = Minitest::Mock.new(Object.new)
+    transport.expect(:execute, response) do |value|
+      request = value
+      value.is_a?(OpenAI::HTTPClient::Request)
+    end
+    client = OpenAI::Client.new(
+      api_key: "test-key",
+      base_url: "https://example.com/v1",
+      http_client: transport,
+      logger: logger,
+      log_level: log_level
+    )
+
+    assert_equal(
+      true,
+      client.request(
+        method: body.nil? ? :get : :post,
+        path: "probe",
+        query: query,
+        headers: headers,
+        body: body
+      )[:ok]
+    )
+    assert_mock(transport)
+
+    [output.string, request]
+  end
+end

--- a/test/openai/logging_security_test.rb
+++ b/test/openai/logging_security_test.rb
@@ -10,8 +10,11 @@ class LoggingSecurityTest < Minitest::Test
       "clientSecret" => "camel-client-secret",
       "sessionToken" => "camel-session-secret",
       "bearerToken" => "camel-bearer-secret",
+      "access_token[]" => "array-access-secret",
+      "clientSecret[]" => "array-client-secret",
       "credentials[accessToken]" => "nested-access-secret",
-      "credentials[client_secret]" => "nested-client-secret"
+      "credentials[client_secret]" => "nested-client-secret",
+      "credentials[access_token][]" => "nested-array-secret"
     }
 
     [:info, :debug].each do |level|
@@ -39,6 +42,7 @@ class LoggingSecurityTest < Minitest::Test
       "https://user:password@example.com/probe?" \
       "access%54oken=encoded-access-secret&" \
       "credentials%5Bclient%53ecret%5D=encoded-client-secret&" \
+      "access_token%5B%5D=encoded-array-secret&" \
       "safe=visible"
     )
 
@@ -47,6 +51,7 @@ class LoggingSecurityTest < Minitest::Test
       assert_includes(formatted, "%5BREDACTED%5D")
       refute_includes(formatted, "encoded-access-secret")
       refute_includes(formatted, "encoded-client-secret")
+      refute_includes(formatted, "encoded-array-secret")
       refute_includes(formatted, "user:password@")
     end
   end
@@ -54,6 +59,7 @@ class LoggingSecurityTest < Minitest::Test
   def test_debug_logs_structurally_redact_form_urlencoded_request_bodies
     body =
       "client_secret=client-form-secret&access_token=access-form-secret&" \
+      "access_token%5B%5D=array-form-secret&" \
       "credentials%5BsessionToken%5D=nested-form-secret&" \
       "safe=hello+world&repeat=one&repeat=two"
     output, request = logged_request(
@@ -66,16 +72,20 @@ class LoggingSecurityTest < Minitest::Test
     assert_includes(output, "request started")
     assert_includes(output, "client_secret=%5BREDACTED%5D")
     assert_includes(output, "access_token=%5BREDACTED%5D")
+    assert_includes(output, "access_token%5B%5D=%5BREDACTED%5D")
     assert_includes(output, "credentials%5BsessionToken%5D=%5BREDACTED%5D")
     assert_includes(output, "safe=hello+world")
     assert_includes(output, "repeat=one&repeat=two")
     refute_includes(output, "client-form-secret")
     refute_includes(output, "access-form-secret")
+    refute_includes(output, "array-form-secret")
     refute_includes(output, "nested-form-secret")
   end
 
   def test_debug_logs_structurally_redact_form_urlencoded_response_bodies
-    body = "accessToken=response-access-secret&credentials%5Bclient_secret%5D=response-client-secret&safe=visible"
+    body =
+      "accessToken=response-access-secret&access_token%5B%5D=response-array-secret&" \
+      "credentials%5Bclient_secret%5D=response-client-secret&safe=visible"
     formatted = OpenAI::Internal::Logging.format_observed_body(
       body,
       headers: {"content-type" => "application/x-www-form-urlencoded"},
@@ -84,9 +94,11 @@ class LoggingSecurityTest < Minitest::Test
     )
 
     assert_includes(formatted, "accessToken=%5BREDACTED%5D")
+    assert_includes(formatted, "access_token%5B%5D=%5BREDACTED%5D")
     assert_includes(formatted, "credentials%5Bclient_secret%5D=%5BREDACTED%5D")
     assert_includes(formatted, "safe=visible")
     refute_includes(formatted, "response-access-secret")
+    refute_includes(formatted, "response-array-secret")
     refute_includes(formatted, "response-client-secret")
   end
 


### PR DESCRIPTION
## Summary

- Redact camelCase token/key names, singular/plural credential containers, nested, array-style, and percent-encoded credential query parameters from both INFO request-completion logs and DEBUG request-start logs while preserving safe parameters and the original request URL.
- Structurally redact `application/x-www-form-urlencoded` request and response bodies with the existing URL-query sanitizer, preserving safe fields, duplicate parameters, and the original request body.
- Omit malformed or oversized form payloads and unsupported textual payloads, including XML, instead of logging secrets from formats that cannot be safely scrubbed.
- Add a separate focused security regression matrix using a real `Logger`/`StringIO` and a framework-provided delegated `Minitest::Mock`; keep the existing 943-line logging test file below the 1,000-line maintainability boundary.

## Castiron impact

No upstream Castiron/compiler, template, OpenAPI schema, regeneration, or companion source change is required.

I inspected Castiron's actual Ruby `render_tree_from_views` implementation in `api/castiron/crates/castiron-render-ruby/src/output.rs`: it emits package roots/indexes, generated clients, resources, models, and resource tests, but does not emit `lib/openai/internal/logging.rb`. Its `resource_test_path` emits `test/pkgxyz/resources/<resource>_test.rb`, not the SDK-owned `test/openai/logging_security_test.rb` added here. The only generator-owned observability boundary is the client constructor, and its upstream companion [openai/openai#1277393](https://github.com/openai/openai/pull/1277393) is already merged. The later generated SDK update changed `.castiron.stats.yml` while preserving this logging overlay; merged [#384](https://github.com/openai/openai-ruby/pull/384) independently records the same ownership analysis. This PR changes neither generated constructor signatures nor RBI/RBS declarations.

## Verification

- Reproduced the vulnerability before the fix: all six new security regression tests failed on the unmodified implementation.
- Ruby 4.0.6 full suite: **632 tests, 2,832 assertions**, zero failures.
- Ruby 3.3.12 full suite: **632 tests, 2,832 assertions**, zero failures.
- Dedicated logging security matrix: **6 tests, 297 assertions** on both Ruby versions, including array-style parameters, camelCase `accessKey`, and plural `credentials[value]` review feedback.
- Existing logging/stream regression suite: **35 tests, 358 assertions**.
- Full RuboCop: **1,390 files**, no offenses.
- Sorbet: `bundle exec rake typecheck:sorbet`, no errors.
- RBS validation: **1,212 files**, no errors.
- Package build: `bundle exec rake build:gem`.
- Explicit thermo-nuclear maintainability review completed before pushing; simplified the credential matcher and reused the existing canonical query sanitizer.
