### PR TITLE
fix: strip credential headers on cross-origin redirects

### DIFF
--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -267,15 +267,18 @@ module OpenAI
           value.to_s.dump.delete_prefix('"').delete_suffix('"')
         end
 
+        # @api private
+        def sensitive_header?(name)
+          normalized_name = name.to_s.downcase
+          REDACTED_HEADERS.include?(normalized_name) || SENSITIVE_QUERY_KEY.match?(normalized_name)
+        end
+
         def format_headers(headers)
           redacted =
             headers.sort.to_h do |name, value|
               normalized_name = name.to_s.downcase
-              sensitive =
-                REDACTED_HEADERS.include?(normalized_name) ||
-                SENSITIVE_QUERY_KEY.match?(normalized_name)
               rendered =
-                if sensitive
+                if sensitive_header?(normalized_name)
                   "[REDACTED]"
                 elsif URL_HEADER_KEY.match?(normalized_name)
                   sanitized_header_url(value)

--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -273,6 +273,12 @@ module OpenAI
           REDACTED_HEADERS.include?(normalized_name) || SENSITIVE_QUERY_KEY.match?(normalized_name)
         end
 
+        # @api private
+        def credential_header?(name)
+          normalized_name = name.to_s.downcase
+          normalized_name != "idempotency-key" && sensitive_header?(normalized_name)
+        end
+
         def format_headers(headers)
           redacted =
             headers.sort.to_h do |name, value|

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -167,8 +167,10 @@ module OpenAI
 
             # from undici
             if OpenAI::Internal::Util.uri_origin(url) != OpenAI::Internal::Util.uri_origin(location)
-              drop = [*OpenAI::Internal::Logging::REDACTED_HEADERS, "host"]
-              request = {**request, headers: request.fetch(:headers).except(*drop)}
+              headers = request.fetch(:headers).reject do |name, _|
+                name == "host" || OpenAI::Internal::Logging.sensitive_header?(name)
+              end
+              request = {**request, headers: headers}
             end
 
             unless request_body_replayable?(request[:body])

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -167,7 +167,7 @@ module OpenAI
 
             # from undici
             if OpenAI::Internal::Util.uri_origin(url) != OpenAI::Internal::Util.uri_origin(location)
-              drop = %w[authorization cookie host proxy-authorization]
+              drop = [*OpenAI::Internal::Logging::REDACTED_HEADERS, "host"]
               request = {**request, headers: request.fetch(:headers).except(*drop)}
             end
 

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -168,7 +168,7 @@ module OpenAI
             # from undici
             if OpenAI::Internal::Util.uri_origin(url) != OpenAI::Internal::Util.uri_origin(location)
               headers = request.fetch(:headers).reject do |name, _|
-                name == "host" || OpenAI::Internal::Logging.sensitive_header?(name)
+                name == "host" || OpenAI::Internal::Logging.credential_header?(name)
               end
               request = {**request, headers: headers}
             end

--- a/rbi/openai/internal/logging.rbi
+++ b/rbi/openai/internal/logging.rbi
@@ -156,6 +156,10 @@ module OpenAI
         def sensitive_header?(name)
         end
 
+        sig { params(name: T.any(String, Symbol)).returns(T::Boolean) }
+        def credential_header?(name)
+        end
+
         sig { params(headers: T::Hash[String, String]).returns(String) }
         def format_headers(headers)
         end

--- a/rbi/openai/internal/logging.rbi
+++ b/rbi/openai/internal/logging.rbi
@@ -152,6 +152,10 @@ module OpenAI
         def safe_field(value)
         end
 
+        sig { params(name: T.any(String, Symbol)).returns(T::Boolean) }
+        def sensitive_header?(name)
+        end
+
         sig { params(headers: T::Hash[String, String]).returns(String) }
         def format_headers(headers)
         end

--- a/sig/openai/internal/logging.rbs
+++ b/sig/openai/internal/logging.rbs
@@ -69,6 +69,7 @@ module OpenAI
       def self.safe_path: (URI::Generic url) -> String
       def self.safe_url: (URI::Generic url) -> String
       def self.safe_field: (top? value) -> String
+      def self.sensitive_header?: (String | Symbol name) -> bool
       def self.format_headers: (::Hash[String, String] headers) -> String
       def self.format_body: (
         top body,

--- a/sig/openai/internal/logging.rbs
+++ b/sig/openai/internal/logging.rbs
@@ -70,6 +70,7 @@ module OpenAI
       def self.safe_url: (URI::Generic url) -> String
       def self.safe_field: (top? value) -> String
       def self.sensitive_header?: (String | Symbol name) -> bool
+      def self.credential_header?: (String | Symbol name) -> bool
       def self.format_headers: (::Hash[String, String] headers) -> String
       def self.format_body: (
         top body,

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -886,6 +886,11 @@ class OpenAITest < Minitest::Test
         "Api-Key" => "custom-api-key",
         :"X-API-Key" => "custom-x-api-key",
         "X-Amz-Security-Token" => "custom-session-token",
+        :"X-Auth-Token" => "custom-auth-token",
+        "X-Goog-API-Key" => "custom-google-key",
+        :"X-Client-Secret" => "custom-client-secret",
+        api_key: "custom-underscore-key",
+        "X-Password" => "custom-password",
         Cookie: "session=private",
         "Proxy-Authorization": "Basic proxy-secret",
         "Set-Cookie" => "session=private-response",
@@ -902,10 +907,27 @@ class OpenAITest < Minitest::Test
     assert_equal("custom-api-key", first_headers.fetch("api-key"))
     assert_equal("custom-x-api-key", first_headers.fetch("x-api-key"))
     assert_equal("custom-session-token", first_headers.fetch("x-amz-security-token"))
+    assert_equal("custom-auth-token", first_headers.fetch("x-auth-token"))
+    assert_equal("custom-google-key", first_headers.fetch("x-goog-api-key"))
+    assert_equal("custom-client-secret", first_headers.fetch("x-client-secret"))
+    assert_equal("custom-underscore-key", first_headers.fetch("api_key"))
+    assert_equal("custom-password", first_headers.fetch("x-password"))
 
     redirected_headers = requests.fetch(1).headers
     sensitive_headers = %w[
-      api-key authorization cookie host proxy-authorization set-cookie x-amz-security-token x-api-key
+      api-key
+      api_key
+      authorization
+      cookie
+      host
+      proxy-authorization
+      set-cookie
+      x-amz-security-token
+      x-api-key
+      x-auth-token
+      x-client-secret
+      x-goog-api-key
+      x-password
     ]
     sensitive_headers.each do |header|
       refute_includes(redirected_headers, header)

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -895,6 +895,7 @@ class OpenAITest < Minitest::Test
         "Proxy-Authorization": "Basic proxy-secret",
         "Set-Cookie" => "session=private-response",
         Host: "trusted.example",
+        "Idempotency-Key" => "retry-safe-id",
         "X-Trace-Id" => "safe-trace"
       }
     )
@@ -932,6 +933,7 @@ class OpenAITest < Minitest::Test
     sensitive_headers.each do |header|
       refute_includes(redirected_headers, header)
     end
+    assert_equal("retry-safe-id", redirected_headers.fetch("idempotency-key"))
     assert_equal("safe-trace", redirected_headers.fetch("x-trace-id"))
   end
 

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -762,7 +762,12 @@ class OpenAITest < Minitest::Test
       OpenAI::Client.new(
         base_url: "http://localhost",
         api_key: "My API Key",
-        admin_api_key: "My Admin API Key"
+        admin_api_key: "My Admin API Key",
+        default_headers: {
+          "api-key" => "custom-api-key",
+          :"X-API-Key" => "custom-x-api-key",
+          "X-Amz-Security-Token" => "custom-session-token"
+        }
       )
 
     assert_raises(OpenAI::Errors::APIConnectionError) do
@@ -778,8 +783,11 @@ class OpenAITest < Minitest::Test
 
     assert_equal("Bearer xyz", auth_header)
     assert_requested(:any, "http://localhost/redirected", times: OpenAI::Client::MAX_REDIRECTS) do
-      auth_header = _1.headers.transform_keys(&:downcase).fetch("authorization")
-      assert_equal("Bearer xyz", auth_header)
+      headers = _1.headers.transform_keys(&:downcase)
+      assert_equal("Bearer xyz", headers.fetch("authorization"))
+      assert_equal("custom-api-key", headers.fetch("api-key"))
+      assert_equal("custom-x-api-key", headers.fetch("x-api-key"))
+      assert_equal("custom-session-token", headers.fetch("x-amz-security-token"))
     end
   end
 
@@ -846,6 +854,63 @@ class OpenAITest < Minitest::Test
       %w[authorization cookie proxy-authorization].each { refute_includes(headers, _1) }
       assert_equal("example.com", headers["host"])
     end
+  end
+
+  def test_client_redirect_strips_credential_default_headers_with_custom_transport
+    source = "https://trusted.example/v1/models"
+    destination = "https://attacker.example/redirected"
+    requests = []
+    http_client = Minitest::Mock.new(OpenAI::HTTPClient.new)
+    redirect = OpenAI::HTTPClient::Response.new(
+      status: 302,
+      headers: {"location" => destination},
+      body: ""
+    )
+    success = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: "{}"
+    )
+    [redirect, success].each do |response|
+      http_client.expect(:execute, response) do |request|
+        requests << request
+        true
+      end
+    end
+
+    client = OpenAI::Client.new(
+      api_key: "standard-client-key",
+      base_url: "https://trusted.example/v1",
+      http_client: http_client,
+      default_headers: {
+        "Api-Key" => "custom-api-key",
+        :"X-API-Key" => "custom-x-api-key",
+        "X-Amz-Security-Token" => "custom-session-token",
+        Cookie: "session=private",
+        "Proxy-Authorization": "Basic proxy-secret",
+        "Set-Cookie" => "session=private-response",
+        Host: "trusted.example",
+        "X-Trace-Id" => "safe-trace"
+      }
+    )
+    client.request(method: :get, path: "models", security: {bearer_auth: true})
+
+    http_client.verify
+    assert_equal([source, destination], requests.map { _1.url.to_s })
+    first_headers = requests.fetch(0).headers
+    assert_equal("Bearer standard-client-key", first_headers.fetch("authorization"))
+    assert_equal("custom-api-key", first_headers.fetch("api-key"))
+    assert_equal("custom-x-api-key", first_headers.fetch("x-api-key"))
+    assert_equal("custom-session-token", first_headers.fetch("x-amz-security-token"))
+
+    redirected_headers = requests.fetch(1).headers
+    sensitive_headers = %w[
+      api-key authorization cookie host proxy-authorization set-cookie x-amz-security-token x-api-key
+    ]
+    sensitive_headers.each do |header|
+      refute_includes(redirected_headers, header)
+    end
+    assert_equal("safe-trace", redirected_headers.fetch("x-trace-id"))
   end
 
   def test_default_headers

--- a/test/openai/logging_test.rb
+++ b/test/openai/logging_test.rb
@@ -301,6 +301,7 @@ class LoggingTest < Minitest::Test
       "Authorization" => "authorization-secret",
       "X-Amz-Security-Token" => "aws-secret",
       "X-Client-Secret" => "client-header-secret",
+      "Idempotency-Key" => "private-idempotency-key",
       "Safe-Header" => "visible"
     )
     url = OpenAI::Internal::Logging.safe_url(
@@ -316,6 +317,7 @@ class LoggingTest < Minitest::Test
     refute_includes(headers, "authorization-secret")
     refute_includes(headers, "aws-secret")
     refute_includes(headers, "client-header-secret")
+    refute_includes(headers, "private-idempotency-key")
     assert_includes(url, "safe=visible")
     assert_includes(url, "%5BREDACTED%5D")
     refute_includes(url, "query-secret")


### PR DESCRIPTION
## Summary

- Stop forwarding credential-bearing default headers to a different origin when the standard client follows a redirect.
- Share the SDK's complete sensitive-header classification between logging and redirect filtering, including fixed names and credential-like token/key/secret/password suffixes, while preserving `Host` stripping, same-origin credentials, and `Idempotency-Key` request semantics.
- Keep idempotency values redacted in logs even though their non-credential protocol header must survive redirected mutating requests.
- Reproduce a trusted-to-attacker `302` with a custom HTTP transport and cover mixed string/symbol header names, `api-key`, `x-api-key`, `x-amz-security-token`, `x-auth-token`, `x-goog-api-key`, `x-client-secret`, `api_key`, `x-password`, authorization, cookies, proxy credentials, and harmless header retention.
- Preserve Azure and Bedrock's existing, independent origin and redirect protections; this change does not claim those providers were exposed.

## Castiron / generator ownership

**No upstream Castiron/compiler/template/schema change or companion regeneration is required.**

- `CONTRIBUTING.md` states SDK-local modifications persist across generations.
- Merged PR #345 explicitly identifies this exact `lib/openai/internal/transport/base_client.rb` path as SDK-owned runtime, distinguishes it from Castiron-owned root/client files, and states it will not be overwritten by regeneration.
- Merged PR #384 explicitly establishes that Castiron's Ruby renderer does not emit the SDK-owned logging Ruby, RBI, or RBS files used for the shared internal predicate.
- Merged PR #383 independently verified Castiron preserves SDK-local changes through its three-way overlay.
- Actual generation PR #386 updated `.castiron.stats.yml`, the transformed OpenAPI specification, and generated resources without touching this runtime or its tests.
- This PR modifies only SDK-owned transport/logging runtime, its SDK-owned logging RBI/RBS declarations, and SDK regression tests; generated API sources, schemas, templates, generated signatures, and generation metadata remain unchanged.

## Verification

- Confirmed the custom-transport regression **fails before the fix** because `api-key`, `x-api-key`, and `x-amz-security-token` reach the attacker origin.
- Separately reproduced the reviewer-reported token/key/secret/password suffix and underscore variants failing before extracting the shared full predicate.
- Ruby 4.0 full suite after rebasing onto the latest `main`: **641 tests, 2,611 assertions, zero failures/errors/skips**.
- Ruby 3.4 full suite after rebasing onto the latest `main`: **641 tests, 2,611 assertions, zero failures/errors/skips**.
- Ruby 3.3 full suite after rebasing onto the latest `main`: **641 tests, 2,611 assertions, zero failures/errors/skips**.
- Focused redirect coverage: **6 tests, 66 assertions**.
- Logging suite: **35 tests, 360 assertions**.
- Azure provider suite: **13 tests, 94 assertions**.
- Bedrock provider suite: **25 tests, 163 assertions**.
- Full RuboCop, including all SDK-owned/generated RBI files: **2,615 files, zero offenses**.
- Sorbet typecheck: **zero errors**.
- RBS validation: **1,212 files, zero errors**.
- `bundle exec rake build:gem`: succeeds.
- Required thermo-nuclear code-quality review before every push: no findings; one canonical internal credential classifier is shared by both call sites, with matching direct-dispatch RBI/RBS declarations, no generated changes, and no files over 1,000 lines.
