### PR TITLE
fix: validate and bound retry delays

### DIFF
--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -432,23 +432,22 @@ module OpenAI
         #
         # @return [Float]
         private def retry_delay(headers, retry_count:)
-          # Non-standard extension
-          span = Float(headers["retry-after-ms"], exception: false)&.then { _1 / 1000 }
-          return span if span
-
           retry_header = headers["retry-after"]
-          return span if (span = Float(retry_header, exception: false))
+          delays = [
+            Float(headers["retry-after-ms"], exception: false)&.then { _1 / 1000 },
+            Float(retry_header, exception: false),
+            retry_header&.then do
+              Time.httpdate(_1) - Time.now
+            rescue ArgumentError
+              nil
+            end
+          ]
+          server_delay = delays.find { _1&.finite? && !_1.negative? }
+          return [server_delay, @max_retry_delay].min if server_delay
 
-          span = retry_header&.then do
-            Time.httpdate(_1) - Time.now
-          rescue ArgumentError
-            nil
-          end
-          return span if span
-
-          scale = retry_count**2
+          delay = (@initial_retry_delay * (2**retry_count)).clamp(0, @max_retry_delay)
           jitter = 1 - (0.25 * rand)
-          (@initial_retry_delay * scale * jitter).clamp(0, @max_retry_delay)
+          delay * jitter
         end
 
         # @api private

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -587,7 +587,7 @@ class OpenAITest < Minitest::Test
     end
 
     assert_requested(:any, /./, times: 2)
-    assert_equal(10, Thread.current.thread_variable_get(:mock_sleep).last)
+    assert_equal(8.0, Thread.current.thread_variable_get(:mock_sleep).last)
   end
 
   def test_client_retry_after_ms

--- a/test/openai/internal/transport/base_client_retry_test.rb
+++ b/test/openai/internal/transport/base_client_retry_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::BaseClientRetryTest < Minitest::Test
+  class RetryClient < OpenAI::Client
+    def calculated_retry_delay(headers, retry_count: 0)
+      retry_delay(headers, retry_count: retry_count)
+    end
+  end
+
+  def setup
+    super
+    @client = RetryClient.new(api_key: "test-key")
+  end
+
+  def test_first_retry_uses_configured_initial_delay
+    @client.stub(:rand, 0.0) do
+      assert_equal(0.5, @client.calculated_retry_delay({}))
+    end
+  end
+
+  def test_backoff_grows_exponentially_and_respects_configured_maximum
+    client = RetryClient.new(api_key: "test-key", initial_retry_delay: 1.25, max_retry_delay: 3.0)
+
+    client.stub(:rand, 0.0) do
+      assert_equal(1.25, client.calculated_retry_delay({}, retry_count: 0))
+      assert_equal(2.5, client.calculated_retry_delay({}, retry_count: 1))
+      assert_equal(3.0, client.calculated_retry_delay({}, retry_count: 2))
+      assert_equal(3.0, client.calculated_retry_delay({}, retry_count: 10))
+    end
+  end
+
+  def test_jitter_is_applied_after_capping_exponential_backoff
+    @client.stub(:rand, 1.0) do
+      assert_equal(0.375, @client.calculated_retry_delay({}, retry_count: 0))
+      assert_equal(6.0, @client.calculated_retry_delay({}, retry_count: 10))
+    end
+  end
+
+  def test_zero_configured_backoff_remains_supported
+    client = RetryClient.new(api_key: "test-key", initial_retry_delay: 0, max_retry_delay: 0)
+
+    assert_equal(0, client.calculated_retry_delay({}))
+    assert_equal(0, client.calculated_retry_delay({"retry-after" => "5"}))
+  end
+
+  def test_negative_retry_after_values_fall_back_to_initial_delay
+    @client.stub(:rand, 0.0) do
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after" => "-1"}))
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after-ms" => "-1000"}))
+    end
+  end
+
+  def test_non_finite_retry_after_values_fall_back_to_initial_delay
+    @client.stub(:rand, 0.0) do
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after" => "1e999"}))
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after-ms" => "1e999"}))
+    end
+  end
+
+  def test_malformed_retry_after_values_fall_back_to_initial_delay
+    @client.stub(:rand, 0.0) do
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after" => "not a date"}))
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after-ms" => "not a number"}))
+    end
+  end
+
+  def test_expired_retry_after_date_falls_back_to_initial_delay
+    expired = (Time.now - 60).httpdate
+
+    @client.stub(:rand, 0.0) do
+      assert_equal(0.5, @client.calculated_retry_delay({"retry-after" => expired}))
+    end
+  end
+
+  def test_retry_after_values_are_capped_at_configured_maximum
+    client = RetryClient.new(api_key: "test-key", max_retry_delay: 2.5)
+
+    assert_equal(2.5, client.calculated_retry_delay({"retry-after" => "1000000000"}))
+    assert_equal(2.5, client.calculated_retry_delay({"retry-after-ms" => "1000000000000"}))
+    assert_equal(2.5, client.calculated_retry_delay({"retry-after" => (Time.now + 60).httpdate}))
+  end
+
+  def test_valid_millisecond_header_takes_precedence_over_retry_after
+    assert_equal(
+      1.25,
+      @client.calculated_retry_delay({"retry-after-ms" => "1250", "retry-after" => "3"})
+    )
+  end
+
+  def test_invalid_millisecond_header_falls_back_to_valid_retry_after
+    assert_equal(
+      3.0,
+      @client.calculated_retry_delay({"retry-after-ms" => "-1000", "retry-after" => "3"})
+    )
+    assert_equal(
+      3.0,
+      @client.calculated_retry_delay({"retry-after-ms" => "1e999", "retry-after" => "3"})
+    )
+  end
+
+  def test_zero_retry_after_remains_immediate
+    assert_equal(0.0, @client.calculated_retry_delay({"retry-after" => "0"}))
+    assert_equal(0.0, @client.calculated_retry_delay({"retry-after-ms" => "0"}))
+  end
+
+  def test_negative_retry_after_retries_and_reports_actual_delay
+    rate_limited = OpenAI::HTTPClient::Response.new(
+      status: 429,
+      headers: {"content-type" => "application/json", "retry-after" => "-1"},
+      body: '{"error":"rate limited"}'
+    )
+    successful = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: '{"ok":true}'
+    )
+    http_client = Minitest::Mock.new(OpenAI::HTTPClient.new)
+    http_client.expect(:execute, rate_limited, [OpenAI::HTTPClient::Request])
+    http_client.expect(:execute, successful, [OpenAI::HTTPClient::Request])
+    retry_events = []
+    slept = []
+    client = RetryClient.new(
+      api_key: "test-key",
+      http_client: http_client,
+      max_retries: 1,
+      on_retry: ->(event) { retry_events << event }
+    )
+
+    client.stub(:rand, 0.0) do
+      client.stub(:sleep, ->(delay) { slept << delay }) do
+        assert_equal(true, client.request(method: :get, path: "probe")[:ok])
+      end
+    end
+
+    assert_mock(http_client)
+    assert_equal([0.5], slept)
+    assert_equal(1, retry_events.length)
+    assert_equal(0.5, retry_events.fetch(0).delay)
+    assert_equal(429, retry_events.fetch(0).status)
+  end
+end


### PR DESCRIPTION
## Summary

- reject negative, expired, malformed, and non-finite retry-after hints; preserve valid retry-after-ms precedence and explicit zero-delay hints
- cap server-requested delays at the configured maximum and use jittered exponential backoff starting at the configured initial delay
- add focused direct-policy and end-to-end HTTP 429 regression coverage, including custom retry settings, real SDK HTTP transport mocks, and retry callback events

## Castiron ownership

No upstream Castiron, generator, schema, template, or regeneration change is required. The canonical Ruby generation ownership policy excludes the entire `lib/openai/internal/` runtime and non-resource `test/` trees; its `ruby_policy_keeps_generated_api_surface_and_preserves_sdk_documentation` regression test explicitly asserts that `lib/openai/internal/transport/base_client.rb` is excluded. The Ruby renderer does not emit this transport file, and the Castiron SDK preparation overlay restores handwritten paths from the integrated SDK tree. Both modified runtime logic and new internal tests are therefore SDK-owned and preserved across regeneration.

## Validation

- Ruby 3.3.12: 639 tests, 2,565 assertions, no failures
- Ruby 3.4.10: 639 tests, 2,565 assertions, no failures
- Ruby 4.0.6: 639 tests, 2,565 assertions, no failures
- full RuboCop: 1,390 files, no offenses
- Sorbet: no errors
- RBS validation: 1,212 files, no errors
- independently reproduced `429 retry-after: -1` raising `ArgumentError` before the fix and confirmed successful retry afterward
- required thermo-nuclear code-quality review completed with no structural findings