### PR TITLE
chore: enforce missing super lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,10 +82,6 @@ Lint/EmptyInPattern:
   Exclude:
     - "test/**/*"
 
-Lint/MissingSuper:
-  Exclude:
-    - "**/*.rbi"
-
 # Disabled for safety reasons, this option changes code semantics.
 Lint/UnusedMethodArgument:
   AutoCorrect: false

--- a/rbi/openai/internal/type/base_model.rbi
+++ b/rbi/openai/internal/type/base_model.rbi
@@ -29,7 +29,7 @@ module OpenAI
           # Assumes superclass fields are totally defined before fields are accessed /
           # defined on subclasses.
           sig { params(child: OpenAI::Internal::Type::BaseModel).void }
-          def inherited(child)
+          def inherited(child) # rubocop:disable Lint/MissingSuper -- RBI declarations cannot contain executable bodies.
           end
 
           # @api private


### PR DESCRIPTION
## Summary
- Remove the RBI exclusion for Lint/MissingSuper.
- Enforce the rule across every repository-owned Ruby and RBI file.

## Validation
- Targeted RuboCop: 1,389 files, zero offenses.
- Full-stack validation passes on the final stacked branch.

## Stack
1 of 5. Base: main.

## Generator impact
No Castiron change is needed. The RuboCop config and RBI paths involved here are generator-excluded.