### PR TITLE
chore: enforce useless assignment lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,10 +82,6 @@ Lint/EmptyInPattern:
   Exclude:
     - "test/**/*"
 
-Lint/MissingSuper:
-  Exclude:
-    - "**/*.rbi"
-
 # Disabled for safety reasons, this option changes code semantics.
 Lint/UnusedMethodArgument:
   AutoCorrect: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,8 +89,6 @@ Lint/UnusedMethodArgument:
 # This option is prone to causing accidental bugs.
 Lint/UselessAssignment:
   AutoCorrect: false
-  Exclude:
-    - "examples/**/*.rb"
 
 Metrics/AbcSize:
   Enabled: false

--- a/examples/demo_sorbet.rb
+++ b/examples/demo_sorbet.rb
@@ -27,7 +27,7 @@ end
 begin
   pp("----- trying to use params class in sorbet -----")
 
-  params = OpenAI::Models::Chat::CompletionCreateParams.new(
+  _params = OpenAI::Models::Chat::CompletionCreateParams.new(
     # You can still use raw `Hash`es where sorbet expects `Class`es,
     #   but there is currently no way for the typechecker to verify the `Hash` contents
     messages: [{role: :user, content: "Say this is a test again"}],
@@ -35,11 +35,11 @@ begin
   )
 
   # if you have sorbet LSP enabled, and uncomment the two lines below
-  #   you will see a red squiggly line on `params` due to a quirk of the sorbet type system.
+  #   you will see a red squiggly line on `_params` due to a quirk of the sorbet type system.
   #
   # this file will still, in fact, run correctly as uncommented.
 
-  # completion = client.chat.completions.create(params)
+  # completion = client.chat.completions.create(_params)
   # pp(completion.choices.first&.message&.content)
 end
 

--- a/rbi/openai/internal/type/base_model.rbi
+++ b/rbi/openai/internal/type/base_model.rbi
@@ -29,7 +29,7 @@ module OpenAI
           # Assumes superclass fields are totally defined before fields are accessed /
           # defined on subclasses.
           sig { params(child: OpenAI::Internal::Type::BaseModel).void }
-          def inherited(child)
+          def inherited(child) # rubocop:disable Lint/MissingSuper -- RBI declarations cannot contain executable bodies.
           end
 
           # @api private


### PR DESCRIPTION
## Summary
- Remove the examples exclusion for Lint/UselessAssignment while keeping unsafe autocorrection disabled.
- Mark the intentionally unused Sorbet demonstration value explicitly and keep its commented example consistent.

## Validation
- Targeted RuboCop: 1,389 files, zero offenses.
- Sorbet typecheck for the example passes.
- Full-stack validation passes on the final stacked branch.

## Stack
2 of 5. Depends on the missing-super lint PR.

## Generator impact
No Castiron change is needed. The RuboCop config and examples directory are generator-excluded.