### PR TITLE
fix: honor workload identity environment defaults

### DIFF
--- a/lib/openai/auth/workload_identity.rb
+++ b/lib/openai/auth/workload_identity.rb
@@ -6,12 +6,22 @@ module OpenAI
       attr_reader :client_id, :identity_provider_id, :service_account_id, :provider, :refresh_buffer_seconds
 
       def initialize(
-        identity_provider_id:,
-        service_account_id:,
         provider:,
+        identity_provider_id: ENV["IDENTITY_PROVIDER_ID"],
+        service_account_id: ENV["SERVICE_ACCOUNT_ID"],
         client_id: nil,
         refresh_buffer_seconds: 1200
       )
+        if identity_provider_id.to_s.strip.empty?
+          raise ArgumentError,
+                "identity_provider_id must not be blank; pass identity_provider_id: or set IDENTITY_PROVIDER_ID"
+        end
+
+        if service_account_id.to_s.strip.empty?
+          raise ArgumentError,
+                "service_account_id must not be blank; pass service_account_id: or set SERVICE_ACCOUNT_ID"
+        end
+
         @client_id = client_id&.to_s
         @identity_provider_id = identity_provider_id.to_s
         @service_account_id = service_account_id.to_s

--- a/rbi/openai/auth.rbi
+++ b/rbi/openai/auth.rbi
@@ -35,17 +35,17 @@ module OpenAI
 
       sig do
         params(
-          identity_provider_id: T.any(String, Symbol),
-          service_account_id: T.any(String, Symbol),
           provider: SubjectTokenProvider,
+          identity_provider_id: T.nilable(T.any(String, Symbol)),
+          service_account_id: T.nilable(T.any(String, Symbol)),
           client_id: T.nilable(T.any(String, Symbol)),
           refresh_buffer_seconds: Integer
         ).void
       end
       def initialize(
-        identity_provider_id:,
-        service_account_id:,
         provider:,
+        identity_provider_id: ENV["IDENTITY_PROVIDER_ID"],
+        service_account_id: ENV["SERVICE_ACCOUNT_ID"],
         client_id: nil,
         refresh_buffer_seconds: 1200
       )

--- a/test/openai/auth/workload_identity_test.rb
+++ b/test/openai/auth/workload_identity_test.rb
@@ -14,17 +14,112 @@ class WorkloadIdentityTest < Minitest::Test
   def setup
     super
     @token_path = File.join(Dir.tmpdir, "test_k8s_token_#{SecureRandom.hex}")
+    @environment = %w[IDENTITY_PROVIDER_ID SERVICE_ACCOUNT_ID].to_h { [_1, ENV[_1]] }
+    @environment.each_key { ENV.delete(_1) }
   end
 
   def teardown
     FileUtils.rm_f(@token_path)
     WebMock.reset!
+    @environment.each { |name, value| value.nil? ? ENV.delete(name) : ENV[name] = value }
     super
   end
 
   def after_all
     WebMock.disable!
     super
+  end
+
+  def test_workload_identity_defaults_to_environment_variables
+    ENV["IDENTITY_PROVIDER_ID"] = "environment-provider"
+    ENV["SERVICE_ACCOUNT_ID"] = "environment-account"
+    provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      provider: provider,
+      client_id: :oauth_client,
+      refresh_buffer_seconds: 60
+    )
+
+    assert_equal("environment-provider", config.identity_provider_id)
+    assert_equal("environment-account", config.service_account_id)
+    assert_same(provider, config.provider)
+    assert_equal("oauth_client", config.client_id)
+    assert_equal(60, config.refresh_buffer_seconds)
+  end
+
+  def test_workload_identity_explicit_identifiers_override_environment_variables
+    ENV["IDENTITY_PROVIDER_ID"] = "environment-provider"
+    ENV["SERVICE_ACCOUNT_ID"] = "environment-account"
+
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      identity_provider_id: :explicit_provider,
+      service_account_id: :explicit_account,
+      provider: OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+    )
+
+    assert_equal("explicit_provider", config.identity_provider_id)
+    assert_equal("explicit_account", config.service_account_id)
+  end
+
+  def test_workload_identity_rejects_missing_identity_provider_id
+    ENV["SERVICE_ACCOUNT_ID"] = "environment-account"
+
+    error = assert_raises(ArgumentError) do
+      OpenAI::Auth::WorkloadIdentity.new(
+        provider: OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+      )
+    end
+
+    assert_match(/identity_provider_id/, error.message)
+    assert_match(/IDENTITY_PROVIDER_ID/, error.message)
+  end
+
+  def test_workload_identity_rejects_missing_service_account_id
+    ENV["IDENTITY_PROVIDER_ID"] = "environment-provider"
+
+    error = assert_raises(ArgumentError) do
+      OpenAI::Auth::WorkloadIdentity.new(
+        provider: OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+      )
+    end
+
+    assert_match(/service_account_id/, error.message)
+    assert_match(/SERVICE_ACCOUNT_ID/, error.message)
+  end
+
+  def test_workload_identity_rejects_blank_identity_provider_id
+    ENV["IDENTITY_PROVIDER_ID"] = "environment-provider"
+
+    [nil, "", " \t"].each do |identity_provider_id|
+      error = assert_raises(ArgumentError) do
+        OpenAI::Auth::WorkloadIdentity.new(
+          identity_provider_id: identity_provider_id,
+          service_account_id: "service-account",
+          provider: OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+        )
+      end
+
+      assert_match(/identity_provider_id/, error.message)
+      assert_match(/IDENTITY_PROVIDER_ID/, error.message)
+    end
+  end
+
+  def test_workload_identity_rejects_blank_service_account_id
+    ENV["SERVICE_ACCOUNT_ID"] = "environment-account"
+
+    [nil, "", " \t"].each do |service_account_id|
+      error = assert_raises(ArgumentError) do
+        OpenAI::Auth::WorkloadIdentity.new(
+          identity_provider_id: "identity-provider",
+          service_account_id: service_account_id,
+          provider: OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+        )
+      end
+
+      assert_match(/service_account_id/, error.message)
+      assert_match(/SERVICE_ACCOUNT_ID/, error.message)
+    end
   end
 
   def test_kubernetes_provider_success


### PR DESCRIPTION
## Summary
- Honor the documented IDENTITY_PROVIDER_ID and SERVICE_ACCOUNT_ID environment defaults while keeping explicit identifier precedence.
- Reject missing, nil, empty, and whitespace-only identifiers with actionable setup errors.
- Keep the Sorbet constructor signature aligned and cover isolated environment state, symbols, provider, client_id, and refresh-buffer compatibility.

## Generator ownership
Castiron explicitly excludes lib/openai/auth/, rbi/openai/auth.rbi, and non-resource tests from generated ownership in api/castiron/docs/stainless-sdk-json-fixtures/release-primary/generated-file-excludes/ruby.yaml. These are SDK-authored files preserved across generation; https://github.com/openai/openai/pull/1290530 adds companion regression coverage for the ownership boundary and three-way overlay preservation. No renderer, template, schema, or production generator change is required.

## Verification
- Added regression tests first and observed four failures plus one error on unmodified production code.
- Focused workload-identity suite: 20 tests, 85 assertions.
- Full SDK suite: 632 tests, 2,582 assertions.
- Full RuboCop: 1,389 files, no offenses.
- Sorbet typecheck: clean.
- RBS validation: 1,212 files, no errors.
- Completed the requested thermo-nuclear code-quality review and aligned RBI environment defaults with the existing client signature convention.