### PR TITLE
fix: reject dot-only identifiers in API paths

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -261,9 +261,13 @@ module OpenAI
         #
         # @param path [String, Integer]
         #
+        # @raise [ArgumentError]
         # @return [String]
         def encode_path(path)
-          path.to_s.gsub(OpenAI::Internal::Util::RFC_3986_NOT_PCHARS) { ERB::Util.url_encode(_1) }
+          path = path.to_s
+          raise ArgumentError, "path segment cannot be '.' or '..'" if path == "." || path == ".."
+
+          path.gsub(OpenAI::Internal::Util::RFC_3986_NOT_PCHARS) { ERB::Util.url_encode(_1) }
         end
 
         # @api private

--- a/test/openai/internal/path_encoding_test.rb
+++ b/test/openai/internal/path_encoding_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::PathEncodingTest < Minitest::Test
+  def test_encode_path_rejects_dot_only_segments
+    %w[. ..].each do |segment|
+      error = assert_raises(ArgumentError) { OpenAI::Internal::Util.encode_path(segment) }
+
+      assert_match(/path segment/, error.message)
+    end
+  end
+
+  def test_encode_path_preserves_identifiers_and_escapes_slashes
+    {
+      "group_123" => "group_123",
+      "group.id" => "group.id",
+      ".group" => ".group",
+      "group." => "group.",
+      "..." => "...",
+      "group/../role" => "group%2F..%2Frole",
+      "../role" => "..%2Frole",
+      "%2e" => "%252e",
+      "%2e%2e" => "%252e%252e",
+      123 => "123"
+    }.each do |segment, expected|
+      assert_equal(expected, OpenAI::Internal::Util.encode_path(segment))
+    end
+  end
+
+  def test_interpolate_path_rejects_dot_segments_in_every_position
+    %w[. ..].each do |segment|
+      [
+        [segment, "group_123", "role_123"],
+        ["proj_123", segment, "role_123"],
+        ["proj_123", "group_123", segment]
+      ].each do |identifiers|
+        assert_raises(ArgumentError) do
+          OpenAI::Internal::Util.interpolate_path(
+            ["projects/%1$s/groups/%2$s/roles/%3$s", *identifiers]
+          )
+        end
+      end
+    end
+  end
+
+  def test_nested_admin_deletes_reject_dot_segments_before_transport
+    transport = OpenAI::HTTPClient.new
+    unexpected_request = lambda do |request|
+      flunk("Unexpected #{request.method.to_s.upcase} #{request.url.path}")
+    end
+
+    transport.stub(:execute, unexpected_request) do
+      client = OpenAI::Client.new(
+        admin_api_key: "test-admin-key",
+        base_url: "https://example.com/v1",
+        http_client: transport
+      )
+      resources = [
+        [client.admin.organization.projects.groups.roles, :group_id],
+        [client.admin.organization.projects.users.roles, :user_id]
+      ]
+
+      %w[.. .].each do |segment|
+        resources.each do |resource, scoped_identifier|
+          [
+            ["proj_123", segment, "role_123"],
+            [segment, "scoped_123", "role_123"],
+            ["proj_123", "scoped_123", segment]
+          ].each do |project_id, scoped_id, role_id|
+            assert_raises(ArgumentError) do
+              resource.delete(role_id, project_id: project_id, scoped_identifier => scoped_id)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_nested_admin_deletes_preserve_endpoint_and_escape_slashes
+    transport = Minitest::Mock.new(OpenAI::HTTPClient.new)
+    [
+      "/v1/projects/proj.123/groups/group%2F123/roles/role%2F123",
+      "/v1/projects/proj.123/users/user%2F123/roles/role%2F123"
+    ].each do |expected_path|
+      response = OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: ['{"deleted":true,"object":"role.deleted"}']
+      )
+      transport.expect(:execute, response) do |request|
+        assert_equal(:delete, request.method)
+        assert_equal(expected_path, request.url.path)
+        assert_equal("Bearer test-admin-key", request.headers.fetch("authorization"))
+
+        true
+      end
+    end
+
+    client = OpenAI::Client.new(
+      admin_api_key: "test-admin-key",
+      base_url: "https://example.com/v1",
+      http_client: transport
+    )
+    client.admin.organization.projects.groups.roles.delete(
+      "role/123",
+      project_id: "proj.123",
+      group_id: "group/123"
+    )
+    client.admin.organization.projects.users.roles.delete(
+      "role/123",
+      project_id: "proj.123",
+      user_id: "user/123"
+    )
+
+    assert_mock(transport)
+  end
+end


### PR DESCRIPTION
## Summary
- Reject standalone `.` and `..` identifiers in the shared path encoder before URI joining can normalize an authenticated request onto another endpoint.
- Add red-to-green coverage for every path-argument position, nested group/user admin role deletes, dotted and numeric identifiers, percent-looking strings, and escaped slashes.
- Ownership: active Castiron excludes `lib/openai/internal/**` from generated output and preserves this SDK-owned runtime through its bootstrap overlay. A companion Castiron PR will add explicit generator ownership/preservation regression coverage and will be linked here.

## Security reproduction
Before this change, `client.admin.organization.projects.groups.roles.delete("role_123", project_id: "proj_123", group_id: "..")` sends `DELETE /v1/projects/proj_123/roles/role_123`, the distinct project-role delete endpoint. Both standalone dot identifiers now raise `ArgumentError` before transport execution.

## Verification
- Ruby 3.3, 3.4, and 4.0 focused path-security regressions: 5 tests / 41 assertions each.
- Full Ruby 4.0 suite: 631 tests / 2,576 assertions.
- RuboCop: 1,390 files, no offenses.
- Sorbet: no errors.
- RBS validation: 1,212 files, no errors.
- Gem packaging: succeeds.
- Thermo-nuclear code-quality review completed before pushing; no findings.