### PR TITLE
fix(webhooks): support Rack and case-insensitive HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,11 @@ Note that the `body` parameter must be the raw JSON string sent from the server 
 require 'sinatra'
 require 'openai'
 
-# Set up the client with webhook secret from environment variable
-client = OpenAI::Client.new(webhook_secret: ENV['OPENAI_WEBHOOK_SECRET'])
+# Set up the client with API credentials and the webhook secret
+client = OpenAI::Client.new(
+  api_key: ENV.fetch('OPENAI_API_KEY'),
+  webhook_secret: ENV.fetch('OPENAI_WEBHOOK_SECRET')
+)
 
 post '/webhook' do
   request_body = request.body.read
@@ -462,8 +465,11 @@ require 'sinatra'
 require 'json'
 require 'openai'
 
-# Set up the client with webhook secret from environment variable
-client = OpenAI::Client.new(webhook_secret: ENV['OPENAI_WEBHOOK_SECRET'])
+# Set up the client with API credentials and the webhook secret
+client = OpenAI::Client.new(
+  api_key: ENV.fetch('OPENAI_API_KEY'),
+  webhook_secret: ENV.fetch('OPENAI_WEBHOOK_SECRET')
+)
 
 post '/webhook' do
   request_body = request.body.read

--- a/lib/openai/resources/webhooks.rb
+++ b/lib/openai/resources/webhooks.rb
@@ -43,10 +43,20 @@ module OpenAI
                 "or passed to this function"
         end
 
-        # Extract required headers
-        signature_header = headers["webhook-signature"] || headers[:webhook_signature]
-        timestamp_header = headers["webhook-timestamp"] || headers[:webhook_timestamp]
-        webhook_id = headers["webhook-id"] || headers[:webhook_id]
+        header_names = %w[webhook-signature webhook-timestamp webhook-id]
+        normalized_headers = {}
+        headers.each do |name, value|
+          name = name.to_s.downcase.delete_prefix("http_").tr("_", "-")
+          next unless header_names.include?(name)
+
+          if normalized_headers.key?(name) && normalized_headers[name] != value
+            raise ArgumentError, "Conflicting values for #{name} header"
+          end
+
+          normalized_headers[name] = value
+        end
+
+        signature_header, timestamp_header, webhook_id = normalized_headers.values_at(*header_names)
 
         if signature_header.nil?
           raise ArgumentError, "Missing required webhook-signature header"

--- a/test/openai/resources/webhooks_test.rb
+++ b/test/openai/resources/webhooks_test.rb
@@ -3,6 +3,7 @@
 require_relative "../test_helper"
 require "base64"
 require "openssl"
+require "stringio"
 
 class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
   def setup
@@ -77,6 +78,85 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     assert_kind_of(OpenAI::Models::Webhooks::ResponseCompletedWebhookEvent, event)
     assert_equal("evt_685c059ae3a481909bdc86819b066fb6", event.id)
     assert_equal("resp_123", event.data.id)
+  end
+
+  def test_unwrap_with_rack_request_environment
+    request_environment = {
+      "REQUEST_METHOD" => "POST",
+      "PATH_INFO" => "/webhook",
+      "CONTENT_TYPE" => "application/json",
+      "rack.input" => StringIO.new(@test_payload),
+      "HTTP_WEBHOOK_SIGNATURE" => @webhook_signature,
+      "HTTP_WEBHOOK_TIMESTAMP" => @fixed_timestamp,
+      "HTTP_WEBHOOK_ID" => @webhook_id
+    }
+
+    assert_nil(@webhook_service.verify_signature(@test_payload, request_environment))
+
+    event = @webhook_service.unwrap(request_environment.fetch("rack.input").read, request_environment)
+
+    assert_kind_of(OpenAI::Models::Webhooks::ResponseCompletedWebhookEvent, event)
+    assert_equal("evt_685c059ae3a481909bdc86819b066fb6", event.id)
+  end
+
+  def test_verify_signature_with_title_case_headers
+    headers = {
+      "Webhook-Signature" => @webhook_signature,
+      "Webhook-Timestamp" => @fixed_timestamp,
+      "Webhook-Id" => @webhook_id
+    }
+
+    assert_nil(@webhook_service.verify_signature(@test_payload, headers))
+  end
+
+  def test_verify_signature_with_snake_case_symbol_headers
+    headers = {
+      webhook_signature: @webhook_signature,
+      webhook_timestamp: @fixed_timestamp,
+      webhook_id: @webhook_id
+    }
+
+    assert_nil(@webhook_service.verify_signature(@test_payload, headers))
+  end
+
+  def test_verify_signature_rejects_conflicting_header_aliases
+    headers = {
+      "webhook-signature" => @webhook_signature,
+      "HTTP_WEBHOOK_SIGNATURE" => "v1,attacker-controlled-signature",
+      "webhook-timestamp" => @fixed_timestamp,
+      "webhook-id" => @webhook_id
+    }
+
+    error = assert_raises(ArgumentError) do
+      @webhook_service.verify_signature(@test_payload, headers)
+    end
+
+    assert_match(/conflicting.*webhook-signature/i, error.message)
+  end
+
+  def test_verify_signature_accepts_matching_header_aliases
+    headers = {
+      "webhook-signature" => @webhook_signature,
+      "HTTP_WEBHOOK_SIGNATURE" => @webhook_signature,
+      "webhook-timestamp" => @fixed_timestamp,
+      "webhook-id" => @webhook_id
+    }
+
+    assert_nil(@webhook_service.verify_signature(@test_payload, headers))
+  end
+
+  def test_readme_webhook_examples_configure_required_api_credentials
+    readme = File.read(File.expand_path("../../../README.md", __dir__))
+    webhook_section = readme.split("## Webhook Verification\n", 2).fetch(1)
+    webhook_section = webhook_section.split("\n### [Structured outputs]", 2).first
+    examples = webhook_section.scan(/```ruby\n(.*?)\n```/m).flatten
+
+    assert_equal(2, examples.length)
+    examples.each do |example|
+      assert_match(/api_key:\s*ENV\.fetch\(['"]OPENAI_API_KEY['"]\)/, example)
+      assert_match(/webhook_secret:\s*ENV\.fetch\(['"]OPENAI_WEBHOOK_SECRET['"]\)/, example)
+      assert_includes(example, "request.env")
+    end
   end
 
   def test_verify_signature_with_custom_tolerance


### PR DESCRIPTION
## Summary

- Accept Rack/Sinatra HTTP_WEBHOOK_* environment keys, conventional title-case HTTP headers, and existing lowercase or symbol webhook headers.
- Reject conflicting aliases for the same signed header while accepting equivalent aliases with matching values.
- Correct both Sinatra README examples to explicitly fetch their API key and webhook secret, preserving the existing requirement for API credentials.
- Add genuine signed Rack request-environment coverage, title-case and symbol compatibility checks, duplicate-header security regressions, and README example assertions.

## Generator ownership

The webhook resource and original README examples were generated by Stainless. The required upstream Castiron Ruby-renderer companion is https://github.com/openai/openai/pull/1290513. It emits matching normalization and signed-request regression coverage only for the production OpenAI codegen profile while preserving existing Stainless-parity fixtures.

## Validation

- Full Ruby 4.0 SDK suite after rebasing onto current main: 646 tests, 2,590 assertions, zero failures.
- Complete RuboCop, Sorbet, and RBS validation: 2,615 Ruby/RBI files and 1,212 RBS files passed.
- Focused webhook regressions: 14 tests and 32 assertions passed on Ruby 3.3, 3.4, and 4.0.
- Gem packaging completed successfully.
- Companion Castiron Ruby renderer suite: 573 tests passed.
- Regression tests were observed failing before each implementation change and passing afterward.