### PR TITLE
fix: keep required path parameters out of resource query strings

### DIFF
--- a/lib/openai/resources/admin/organization/projects/groups.rb
+++ b/lib/openai/resources/admin/organization/projects/groups.rb
@@ -53,11 +53,11 @@ module OpenAI
             # @see OpenAI::Models::Admin::Organization::Projects::GroupRetrieveParams
             def retrieve(group_id, params)
               parsed, options = OpenAI::Admin::Organization::Projects::GroupRetrieveParams.dump_request(params)
-              query = OpenAI::Internal::Util.encode_query_params(parsed)
               project_id =
                 parsed.delete(:project_id) do
                   raise ArgumentError.new("missing required path argument #{_1}")
                 end
+              query = OpenAI::Internal::Util.encode_query_params(parsed)
               @client.request(
                 method: :get,
                 path: ["organization/projects/%1$s/groups/%2$s", project_id, group_id],

--- a/lib/openai/resources/admin/organization/projects/groups/roles.rb
+++ b/lib/openai/resources/admin/organization/projects/groups/roles.rb
@@ -97,11 +97,11 @@ module OpenAI
               # @see OpenAI::Models::Admin::Organization::Projects::Groups::RoleListParams
               def list(group_id, params)
                 parsed, options = OpenAI::Admin::Organization::Projects::Groups::RoleListParams.dump_request(params)
-                query = OpenAI::Internal::Util.encode_query_params(parsed)
                 project_id =
                   parsed.delete(:project_id) do
                     raise ArgumentError.new("missing required path argument #{_1}")
                   end
+                query = OpenAI::Internal::Util.encode_query_params(parsed)
                 @client.request(
                   method: :get,
                   path: ["projects/%1$s/groups/%2$s/roles", project_id, group_id],

--- a/lib/openai/resources/admin/organization/projects/users/roles.rb
+++ b/lib/openai/resources/admin/organization/projects/users/roles.rb
@@ -97,11 +97,11 @@ module OpenAI
               # @see OpenAI::Models::Admin::Organization::Projects::Users::RoleListParams
               def list(user_id, params)
                 parsed, options = OpenAI::Admin::Organization::Projects::Users::RoleListParams.dump_request(params)
-                query = OpenAI::Internal::Util.encode_query_params(parsed)
                 project_id =
                   parsed.delete(:project_id) do
                     raise ArgumentError.new("missing required path argument #{_1}")
                   end
+                query = OpenAI::Internal::Util.encode_query_params(parsed)
                 @client.request(
                   method: :get,
                   path: ["projects/%1$s/users/%2$s/roles", project_id, user_id],

--- a/lib/openai/resources/beta/threads/runs/steps.rb
+++ b/lib/openai/resources/beta/threads/runs/steps.rb
@@ -33,7 +33,6 @@ module OpenAI
             # @see OpenAI::Models::Beta::Threads::Runs::StepRetrieveParams
             def retrieve(step_id, params)
               parsed, options = OpenAI::Beta::Threads::Runs::StepRetrieveParams.dump_request(params)
-              query = OpenAI::Internal::Util.encode_query_params(parsed)
               thread_id =
                 parsed.delete(:thread_id) do
                   raise ArgumentError.new("missing required path argument #{_1}")
@@ -42,6 +41,7 @@ module OpenAI
                 parsed.delete(:run_id) do
                   raise ArgumentError.new("missing required path argument #{_1}")
                 end
+              query = OpenAI::Internal::Util.encode_query_params(parsed)
               @client.request(
                 method: :get,
                 path: ["threads/%1$s/runs/%2$s/steps/%3$s", thread_id, run_id, step_id],
@@ -82,11 +82,11 @@ module OpenAI
             # @see OpenAI::Models::Beta::Threads::Runs::StepListParams
             def list(run_id, params)
               parsed, options = OpenAI::Beta::Threads::Runs::StepListParams.dump_request(params)
-              query = OpenAI::Internal::Util.encode_query_params(parsed)
               thread_id =
                 parsed.delete(:thread_id) do
                   raise ArgumentError.new("missing required path argument #{_1}")
                 end
+              query = OpenAI::Internal::Util.encode_query_params(parsed)
               @client.request(
                 method: :get,
                 path: ["threads/%1$s/runs/%2$s/steps", thread_id, run_id],

--- a/lib/openai/resources/conversations/items.rb
+++ b/lib/openai/resources/conversations/items.rb
@@ -58,11 +58,11 @@ module OpenAI
         # @see OpenAI::Models::Conversations::ItemRetrieveParams
         def retrieve(item_id, params)
           parsed, options = OpenAI::Conversations::ItemRetrieveParams.dump_request(params)
-          query = OpenAI::Internal::Util.encode_query_params(parsed)
           conversation_id =
             parsed.delete(:conversation_id) do
               raise ArgumentError.new("missing required path argument #{_1}")
             end
+          query = OpenAI::Internal::Util.encode_query_params(parsed)
           @client.request(
             method: :get,
             path: ["conversations/%1$s/items/%2$s", conversation_id, item_id],

--- a/lib/openai/resources/evals/runs/output_items.rb
+++ b/lib/openai/resources/evals/runs/output_items.rb
@@ -66,11 +66,11 @@ module OpenAI
           # @see OpenAI::Models::Evals::Runs::OutputItemListParams
           def list(run_id, params)
             parsed, options = OpenAI::Evals::Runs::OutputItemListParams.dump_request(params)
-            query = OpenAI::Internal::Util.encode_query_params(parsed)
             eval_id =
               parsed.delete(:eval_id) do
                 raise ArgumentError.new("missing required path argument #{_1}")
               end
+            query = OpenAI::Internal::Util.encode_query_params(parsed)
             @client.request(
               method: :get,
               path: ["evals/%1$s/runs/%2$s/output_items", eval_id, run_id],

--- a/lib/openai/resources/vector_stores/file_batches.rb
+++ b/lib/openai/resources/vector_stores/file_batches.rb
@@ -123,11 +123,11 @@ module OpenAI
         # @see OpenAI::Models::VectorStores::FileBatchListFilesParams
         def list_files(batch_id, params)
           parsed, options = OpenAI::VectorStores::FileBatchListFilesParams.dump_request(params)
-          query = OpenAI::Internal::Util.encode_query_params(parsed)
           vector_store_id =
             parsed.delete(:vector_store_id) do
               raise ArgumentError.new("missing required path argument #{_1}")
             end
+          query = OpenAI::Internal::Util.encode_query_params(parsed)
           @client.request(
             method: :get,
             path: ["vector_stores/%1$s/file_batches/%2$s/files", vector_store_id, batch_id],

--- a/test/openai/path_parameter_query_test.rb
+++ b/test/openai/path_parameter_query_test.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::PathParameterQueryTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "test-api-key",
+      admin_api_key: "test-admin-api-key"
+    )
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def test_conversation_item_retrieve_excludes_conversation_id
+    request = stub_get(
+      "/conversations/conv_123/items/msg_123",
+      query: {"include" => ["file_search_call.results"]},
+      body: {id: "msg_123", type: "message", role: "user", content: [], status: "completed"}
+    )
+
+    response = @client.conversations.items.retrieve(
+      "msg_123",
+      conversation_id: "conv_123",
+      include: [:"file_search_call.results"]
+    )
+
+    assert_instance_of(OpenAI::Conversations::Message, response)
+    assert_requested(request)
+  end
+
+  def test_eval_output_items_list_excludes_eval_id
+    request = stub_get(
+      "/evals/eval_123/runs/run_123/output_items",
+      query: {"after" => "item_123", "limit" => "25", "status" => "pass"}
+    )
+
+    response = @client.evals.runs.output_items.list(
+      "run_123",
+      eval_id: "eval_123",
+      after: "item_123",
+      limit: 25,
+      status: :pass
+    )
+
+    assert_instance_of(OpenAI::Internal::CursorPage, response)
+    assert_requested(request)
+  end
+
+  def test_vector_store_batch_files_list_excludes_vector_store_id
+    request = stub_get(
+      "/vector_stores/vs_123/file_batches/batch_123/files",
+      query: {"after" => "file_123", "filter" => "completed", "limit" => "10"}
+    )
+
+    response = @client.vector_stores.file_batches.list_files(
+      "batch_123",
+      vector_store_id: "vs_123",
+      after: "file_123",
+      filter: :completed,
+      limit: 10
+    )
+
+    assert_instance_of(OpenAI::Internal::CursorPage, response)
+    assert_requested(request)
+  end
+
+  def test_run_step_retrieve_excludes_all_path_parameters
+    include_value = "step_details.tool_calls[*].file_search.results[*].content"
+    request = stub_get(
+      "/threads/thread_123/runs/run_123/steps/step_123",
+      query: {"include" => [include_value]}
+    )
+
+    response = @client.beta.threads.runs.steps.retrieve(
+      "step_123",
+      thread_id: "thread_123",
+      run_id: "run_123",
+      include: [include_value.to_sym]
+    )
+
+    assert_instance_of(OpenAI::Beta::Threads::Runs::RunStep, response)
+    assert_requested(request)
+  end
+
+  def test_run_steps_list_excludes_thread_id
+    request = stub_get(
+      "/threads/thread_123/runs/run_123/steps",
+      query: {"after" => "step_123", "limit" => "5", "order" => "asc"}
+    )
+
+    response = @client.beta.threads.runs.steps.list(
+      "run_123",
+      thread_id: "thread_123",
+      after: "step_123",
+      limit: 5,
+      order: :asc
+    )
+
+    assert_instance_of(OpenAI::Internal::CursorPage, response)
+    assert_requested(request)
+  end
+
+  def test_project_group_retrieve_excludes_project_id
+    request = stub_get(
+      "/organization/projects/proj_123/groups/group_123",
+      query: {"group_type" => "tenant_group"}
+    )
+
+    response = @client.admin.organization.projects.groups.retrieve(
+      "group_123",
+      project_id: "proj_123",
+      group_type: :tenant_group
+    )
+
+    assert_instance_of(OpenAI::Admin::Organization::Projects::ProjectGroup, response)
+    assert_requested(request)
+  end
+
+  def test_project_group_roles_list_excludes_project_id
+    request = stub_get(
+      "/projects/proj_123/groups/group_123/roles",
+      query: {"after" => "role_123", "limit" => "10"}
+    )
+
+    response = @client.admin.organization.projects.groups.roles.list(
+      "group_123",
+      project_id: "proj_123",
+      after: "role_123",
+      limit: 10
+    )
+
+    assert_instance_of(OpenAI::Internal::NextCursorPage, response)
+    assert_requested(request)
+  end
+
+  def test_project_user_roles_list_preserves_pagination_and_extra_query
+    request = stub_get(
+      "/projects/proj_123/users/user_123/roles",
+      query: {"after" => "role_123", "limit" => "20", "order" => "desc", "trace" => "enabled"}
+    )
+
+    response = @client.admin.organization.projects.users.roles.list(
+      "user_123",
+      project_id: "proj_123",
+      after: "role_123",
+      limit: 20,
+      order: :desc,
+      request_options: {extra_query: {"trace" => "enabled"}}
+    )
+
+    assert_instance_of(OpenAI::Internal::NextCursorPage, response)
+    assert_requested(request)
+  end
+
+  def test_project_user_roles_list_omits_query_when_only_path_parameters_are_given
+    request = stub_get("/projects/proj_123/users/user_123/roles", query: {})
+
+    response = @client.admin.organization.projects.users.roles.list("user_123", project_id: "proj_123")
+
+    assert_instance_of(OpenAI::Internal::NextCursorPage, response)
+    assert_requested(request)
+  end
+
+  def test_project_user_roles_pagination_keeps_path_parameters_out_of_follow_up_requests
+    path = "/projects/proj_123/users/user_123/roles"
+    first_request = stub_get(
+      path,
+      query: {"limit" => "1"},
+      body: {data: [], has_more: true, next: "role_123"}
+    )
+    next_request = stub_get(path, query: {"after" => "role_123", "limit" => "1"})
+
+    page = @client.admin.organization.projects.users.roles.list("user_123", project_id: "proj_123", limit: 1)
+
+    assert_instance_of(OpenAI::Internal::NextCursorPage, page.next_page)
+    assert_requested(first_request)
+    assert_requested(next_request)
+  end
+
+  private
+
+  def stub_get(path, query:, body: {data: [], has_more: false})
+    stub_request(:get, "http://localhost#{path}")
+      .with(query: query)
+      .to_return_json(status: 200, body: body)
+  end
+end


### PR DESCRIPTION
## Summary

- remove required path parameters before encoding queries in all eight affected generated Ruby resource methods
- preserve valid filters, array query parameters, request-level extra query options, and pagination follow-up requests
- add ten real HTTP/WebMock regression cases spanning conversations, evals, vector stores, beta thread run steps, and project groups/group roles/user roles

### Generator ownership

These resources are generated by the active Castiron Ruby renderer in `openai/openai` under `api/castiron`, not by the archived standalone `openai/castiron` repository. A companion generator PR fixes the source for `CodegenProfile::OpenAI` while preserving required Stainless-parity fixtures: https://github.com/openai/openai/pull/1290567

## Validation

- Command: `bundle exec ruby -Itest test/openai/path_parameter_query_test.rb` — 10 regression cases passed; the original eight endpoint cases were independently observed failing before the fix.
- Command: `./scripts/test` — 636 tests and 2,545 assertions passed against the Steady OpenAPI mock server.
- Command: `bundle exec rake lint:rubocop` — 1,390 files inspected with no offenses.
- Command: `bundle exec rake typecheck` — Sorbet passed and 1,212 RBS files validated.
- Command: `bundle exec rake build:gem` — the Ruby gem built successfully.
