### PR TITLE
fix: reject invalid webhook signing secrets

### DIFF
--- a/lib/openai/resources/webhooks.rb
+++ b/lib/openai/resources/webhooks.rb
@@ -37,7 +37,7 @@ module OpenAI
         webhook_secret = @client.webhook_secret || ENV["OPENAI_WEBHOOK_SECRET"],
         tolerance = 300
       )
-        if webhook_secret.nil?
+        if webhook_secret.nil? || webhook_secret.strip.empty?
           raise ArgumentError,
                 "The webhook secret must either be set using the env var, OPENAI_WEBHOOK_SECRET, " \
                 "or passed to this function"
@@ -90,10 +90,12 @@ module OpenAI
 
         # Decode the secret if it starts with whsec_
         decoded_secret = if webhook_secret.start_with?("whsec_")
-          Base64.decode64(webhook_secret[6..])
+          Base64.strict_decode64(webhook_secret[6..])
         else
           webhook_secret
         end
+
+        raise ArgumentError, "The webhook secret must not be empty" if decoded_secret.empty?
 
         # Create the signed payload: {webhook_id}.{timestamp}.{payload}
         signed_payload = "#{webhook_id}.#{timestamp_header}.#{payload}"

--- a/test/openai/resources/webhooks_test.rb
+++ b/test/openai/resources/webhooks_test.rb
@@ -43,6 +43,42 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     end
   end
 
+  def test_unwrap_rejects_forged_signatures_for_invalid_secrets
+    invalid_secrets = {
+      "" => "",
+      " \t\n" => " \t\n",
+      "whsec_" => "",
+      "whsec_!!!!" => "",
+      "whsec_====" => "",
+      "whsec_Zm9v!!!!" => "foo"
+    }
+
+    invalid_secrets.each do |webhook_secret, signing_key|
+      headers = signed_headers(signing_key)
+
+      assert_raises(ArgumentError, "expected #{webhook_secret.inspect} to be rejected") do
+        @webhook_service.unwrap(@test_payload, headers, webhook_secret)
+      end
+    end
+  end
+
+  def test_unwrap_accepts_raw_webhook_secrets
+    webhook_secret = "raw webhook secret"
+
+    event = @webhook_service.unwrap(@test_payload, signed_headers(webhook_secret), webhook_secret)
+
+    assert_equal("evt_685c059ae3a481909bdc86819b066fb6", event.id)
+  end
+
+  def test_unwrap_accepts_base64_encoded_webhook_secrets
+    signing_key = "binary\x00webhook secret"
+    webhook_secret = "whsec_#{Base64.strict_encode64(signing_key)}"
+
+    event = @webhook_service.unwrap(@test_payload, signed_headers(signing_key), webhook_secret)
+
+    assert_equal("evt_685c059ae3a481909bdc86819b066fb6", event.id)
+  end
+
   def test_verify_signature_with_missing_headers
     headers = {}
 
@@ -139,5 +175,18 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     assert_raises(OpenAI::Errors::InvalidWebhookSignatureError) do
       @webhook_service.verify_signature(@test_payload, headers, @test_secret)
     end
+  end
+
+  private
+
+  def signed_headers(signing_key)
+    signed_payload = "#{@webhook_id}.#{@fixed_timestamp}.#{@test_payload}"
+    signature = Base64.strict_encode64(OpenSSL::HMAC.digest("sha256", signing_key, signed_payload))
+
+    {
+      "webhook-signature" => "v1,#{signature}",
+      "webhook-timestamp" => @fixed_timestamp,
+      "webhook-id" => @webhook_id
+    }
   end
 end


### PR DESCRIPTION
## Summary

- Reject empty and whitespace-only webhook signing secrets while preserving the existing documented missing-secret `ArgumentError`.
- Decode `whsec_` secrets with `Base64.strict_decode64`, reject empty decoded keys, and preserve valid raw and binary Base64-encoded secrets.
- Add end-to-end forged-signature regressions proving that `""`, whitespace, `"whsec_"`, `"whsec_!!!!"`, invalid padding, and malformed suffixes cannot authenticate attacker-controlled webhook events.

### Generator ownership

`lib/openai/resources/webhooks.rb` and its resource tests were originally generated by `stainless-app[bot]`; they are outside the documented generator-safe directories. The required upstream Castiron companion fixes the canonical Ruby webhook renderer under the OpenAI code-generation profile while preserving Stainless-parity fixtures: https://github.com/openai/openai/pull/1290580.

## Test plan

- `bundle exec ruby -Itest test/openai/resources/webhooks_test.rb` — 11 tests, 18 assertions.
- `TEST_API_BASE_URL=http://127.0.0.1:4023 bundle exec rake test` — 659 tests, 2,689 assertions.
- `bundle exec rake lint` — 2,616 Ruby/RBI files with no RuboCop offenses; Sorbet succeeds; all 1,212 RBS files validate.
- Upstream Castiron companion: all 573 Ruby-renderer tests pass, including explicit `StainlessParity` versus `OpenAI` profile coverage.
