### PR TITLE
chore: enforce line length lint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,8 +59,7 @@ RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.patterns = ["."]
   task.formatters = %w[github] if ENV.key?("CI")
 
-  # some lines cannot be shortened
-  task.options = %w[--parallel --force-exclusion --except Layout/LineLength]
+  task.options = %w[--parallel --force-exclusion]
 end
 
 norm_lines = %w[tr -- \n \0].shelljoin

--- a/lib/openai/auth/workload_identity.rb
+++ b/lib/openai/auth/workload_identity.rb
@@ -14,7 +14,8 @@ module OpenAI
       )
         if identity_provider_id.to_s.strip.empty?
           raise ArgumentError,
-                "identity_provider_id must not be blank; pass identity_provider_id: or set IDENTITY_PROVIDER_ID"
+                "identity_provider_id must not be blank; pass identity_provider_id: " \
+                "or set IDENTITY_PROVIDER_ID"
         end
 
         if service_account_id.to_s.strip.empty?

--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -87,7 +87,8 @@ module OpenAI
         token_type = @config.provider.token_type
         subject_token_type = SUBJECT_TOKEN_TYPES.fetch(token_type) do
           raise ArgumentError,
-                "Unsupported token type: #{token_type.inspect}. Supported types: #{SUBJECT_TOKEN_TYPES.keys.join(', ')}"
+                "Unsupported token type: #{token_type.inspect}. " \
+                "Supported types: #{SUBJECT_TOKEN_TYPES.keys.join(', ')}"
         end
 
         request = Net::HTTP::Post.new(@token_exchange_url)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -315,7 +315,9 @@ module OpenAI
 
       if provider_runtime.nil? && api_key.nil? && admin_api_key.nil? && workload_identity.nil?
         raise ArgumentError,
-              "Missing credentials. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable."
+              "Missing credentials. Please pass an `api_key`, `workload_identity`, " \
+              "`admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` " \
+              "environment variable."
       end
 
       headers = {

--- a/lib/openai/helpers/structured_output/base_model.rb
+++ b/lib/openai/helpers/structured_output/base_model.rb
@@ -60,7 +60,9 @@ module OpenAI
 
         class << self
           def optional(...)
-            message = "`optional` is not supported for structured output APIs, use `#required` with `nil?: true` instead"
+            message =
+              "`optional` is not supported for structured output APIs, " \
+              "use `#required` with `nil?: true` instead"
             raise message
           end
         end

--- a/lib/openai/helpers/structured_output/json_schema_converter.rb
+++ b/lib/openai/helpers/structured_output/json_schema_converter.rb
@@ -196,7 +196,10 @@ module OpenAI
               OpenAI::UnionOf
               OpenAI::BaseModel
             ]
-            message = "#{type} does not implement the #{OpenAI::Helpers::StructuredOutput::JsonSchemaConverter} interface. Please use one of the supported types: #{models}"
+            message =
+              "#{type} does not implement the " \
+              "#{OpenAI::Helpers::StructuredOutput::JsonSchemaConverter} interface. " \
+              "Please use one of the supported types: #{models}"
             raise ArgumentError.new(message)
           end
         end

--- a/lib/openai/internal/conversation_cursor_page.rb
+++ b/lib/openai/internal/conversation_cursor_page.rb
@@ -83,7 +83,8 @@ module OpenAI
       def inspect
         model = OpenAI::Internal::Type::Converter.inspect(@model, depth: 1)
 
-        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} has_more=#{has_more.inspect} last_id=#{last_id.inspect}>"
+        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} " \
+          "has_more=#{has_more.inspect} last_id=#{last_id.inspect}>"
       end
     end
   end

--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -20,8 +20,20 @@ module OpenAI
       MAX_ARRAY_ITEMS = 100
       OPAQUE_STRING_BYTES = 1_024
       SENSITIVE_BODY_KEY = /(?:api[-_]?key|authorization|credential|password|secret|signature|token)/i
-      SENSITIVE_QUERY_KEY =
-        /(?:(?:\A|[-_\[])(?:key|sig)|(?-i:K)ey|api[-_]?key|authorization|credentials?|password|secret|signature|token)(?:\[|\]|\z)/i
+      SENSITIVE_QUERY_KEY = /
+        (?:
+          (?:\A|[-_\[])(?:key|sig)
+          | (?-i:K)ey
+          | api[-_]?key
+          | authorization
+          | credentials?
+          | password
+          | secret
+          | signature
+          | token
+        )
+        (?:\[|\]|\z)
+      /ix
       URL_HEADER_KEY = /(?:\A|[-_])(?:location|url|uri)\z|\A(?:link|refresh)\z/i
 
       class Context

--- a/lib/openai/internal/next_cursor_page.rb
+++ b/lib/openai/internal/next_cursor_page.rb
@@ -83,7 +83,8 @@ module OpenAI
       def inspect
         model = OpenAI::Internal::Type::Converter.inspect(@model, depth: 1)
 
-        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} has_more=#{has_more.inspect} next_=#{next_.inspect}>"
+        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} " \
+          "has_more=#{has_more.inspect} next_=#{next_.inspect}>"
       end
     end
   end

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -748,7 +748,8 @@ module OpenAI
         #
         # @return [String]
         def inspect
-          "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{@base_url} max_retries=#{@max_retries} timeout=#{@timeout}>"
+          "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{@base_url} " \
+            "max_retries=#{@max_retries} timeout=#{@timeout}>"
         end
 
         define_sorbet_constant!(:RequestComponents) do

--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -46,7 +46,9 @@ module OpenAI
         #
         # @return [Boolean]
         def ==(other)
-          other.is_a?(OpenAI::Internal::Type::ArrayOf) && other.nilable? == nilable? && other.item_type == item_type
+          other.is_a?(OpenAI::Internal::Type::ArrayOf) &&
+            other.nilable? == nilable? &&
+            other.item_type == item_type
         end
 
         # @api public

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -61,7 +61,9 @@ module OpenAI
         #
         # @return [Boolean]
         def ==(other)
-          other.is_a?(OpenAI::Internal::Type::HashOf) && other.nilable? == nilable? && other.item_type == item_type
+          other.is_a?(OpenAI::Internal::Type::HashOf) &&
+            other.nilable? == nilable? &&
+            other.item_type == item_type
         end
 
         # @api public

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -551,7 +551,13 @@ module OpenAI
           case val
           in Hash
             val.each do |name, value|
-              write_multipart_value(y, boundary: boundary, key: "#{key}[#{name}]", val: value, closing: closing)
+              write_multipart_value(
+                y,
+                boundary: boundary,
+                key: "#{key}[#{name}]",
+                val: value,
+                closing: closing
+              )
             end
           in Array
             val.each do |value|
@@ -602,7 +608,10 @@ module OpenAI
           case [content_type, body]
           in [OpenAI::Internal::Util::JSON_CONTENT, Hash | Array | -> { primitive?(_1) }]
             [headers, JSON.generate(body)]
-          in [OpenAI::Internal::Util::JSONL_CONTENT, Enumerable] unless OpenAI::Internal::Type::FileInput === body
+          in [
+            OpenAI::Internal::Util::JSONL_CONTENT,
+            Enumerable
+          ] unless OpenAI::Internal::Type::FileInput === body
             [headers, body.lazy.map { JSON.generate(_1) }]
           in [%r{^multipart/form-data}, Hash | OpenAI::Internal::Type::FileInput]
             boundary, strio = encode_multipart_streaming(body)

--- a/test/openai/logging_test.rb
+++ b/test/openai/logging_test.rb
@@ -469,7 +469,14 @@ class LoggingTest < Minitest::Test
     assert_equal(0.0, event.delay)
     assert_equal(429, event.status)
     assert_equal("req_1", event.request_id)
-    assert_equal({"content-type" => "application/json", "retry-after" => "0", "x-request-id" => "req_1"}, event.response.headers)
+    assert_equal(
+      {
+        "content-type" => "application/json",
+        "retry-after" => "0",
+        "x-request-id" => "req_1"
+      },
+      event.response.headers
+    )
     assert_nil(event.error)
     assert_predicate(event, :frozen?)
   end

--- a/test/openai/resources/admin/organization/groups/roles_test.rb
+++ b/test/openai/resources/admin/organization/groups/roles_test.rb
@@ -29,7 +29,12 @@ class OpenAI::Test::Resources::Admin::Organization::Groups::RolesTest < OpenAI::
     assert_pattern do
       response => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -61,7 +66,12 @@ class OpenAI::Test::Resources::Admin::Organization::Groups::RolesTest < OpenAI::
     assert_pattern do
       row => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/admin/organization/projects/groups/roles_test.rb
+++ b/test/openai/resources/admin/organization/projects/groups/roles_test.rb
@@ -39,7 +39,12 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Groups::RolesTest 
     assert_pattern do
       response => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -71,7 +76,12 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Groups::RolesTest 
     assert_pattern do
       row => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/admin/organization/projects/users/roles_test.rb
+++ b/test/openai/resources/admin/organization/projects/users/roles_test.rb
@@ -39,7 +39,12 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Users::RolesTest <
     assert_pattern do
       response => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -71,7 +76,12 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Users::RolesTest <
     assert_pattern do
       row => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/admin/organization/usage_test.rb
+++ b/test/openai/resources/admin/organization/usage_test.rb
@@ -12,7 +12,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageAudioSpeechesResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageAudioSpeechesResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -29,7 +34,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageAudioTranscriptionsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageAudioTranscriptionsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -46,7 +56,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageCodeInterpreterSessionsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageCodeInterpreterSessionsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -63,7 +78,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageCompletionsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageCompletionsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -80,7 +100,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageCostsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageCostsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -97,7 +122,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageEmbeddingsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageEmbeddingsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -114,7 +144,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageFileSearchCallsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageFileSearchCallsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -131,7 +166,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageImagesResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageImagesResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -148,7 +188,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageModerationsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageModerationsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -165,7 +210,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageVectorStoresResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageVectorStoresResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -182,7 +232,12 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageWebSearchCallsResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::UsageWebSearchCallsResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol

--- a/test/openai/resources/admin/organization/users/roles_test.rb
+++ b/test/openai/resources/admin/organization/users/roles_test.rb
@@ -29,7 +29,12 @@ class OpenAI::Test::Resources::Admin::Organization::Users::RolesTest < OpenAI::T
     assert_pattern do
       response => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -61,7 +66,12 @@ class OpenAI::Test::Resources::Admin::Organization::Users::RolesTest < OpenAI::T
     assert_pattern do
       row => {
         id: String,
-        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource]) | nil,
+        assignment_sources:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource
+            ]
+          ) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/beta/chatkit/threads_test.rb
+++ b/test/openai/resources/beta/chatkit/threads_test.rb
@@ -95,7 +95,12 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
         type: :"chatkit.user_message",
         id: String,
         attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content]),
+        content:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content
+            ]
+          ),
         created_at: Integer,
         inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
         object: Symbol,
@@ -109,7 +114,14 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
         object: Symbol,
         thread_id: String
       }
-      in {type: :"chatkit.widget", id: String, created_at: Integer, object: Symbol, thread_id: String, widget: String}
+      in {
+        type: :"chatkit.widget",
+        id: String,
+        created_at: Integer,
+        object: Symbol,
+        thread_id: String,
+        widget: String
+      }
       in {
         type: :"chatkit.client_tool_call",
         id: String,
@@ -137,7 +149,12 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
         id: String,
         created_at: Integer,
         object: Symbol,
-        tasks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task]),
+        tasks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task
+            ]
+          ),
         thread_id: String
       }
       end

--- a/test/openai/resources/beta/responses/input_items_test.rb
+++ b/test/openai/resources/beta/responses/input_items_test.rb
@@ -79,13 +79,23 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
         queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
         status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
         agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
-        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFileSearchToolCall::Result]) | nil
+        results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Beta::BetaResponseFileSearchToolCall::Result
+            ]
+          ) | nil
       }
       in {
         type: :computer_call,
         id: String,
         call_id: String,
-        pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck]),
+        pending_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck
+            ]
+          ),
         status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
         action: OpenAI::Beta::BetaComputerAction | nil,
         actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
@@ -97,7 +107,12 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
         call_id: String,
         output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
         status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
+        acknowledged_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+            ]
+          ) | nil,
         agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
         created_by: String | nil
       }
@@ -124,7 +139,12 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
         type: :agent_message,
         id: String,
         author: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content]),
+        content:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content
+            ]
+          ),
         recipient: String,
         agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
       }
@@ -215,7 +235,12 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
         id: String,
         code: String | nil,
         container_id: String,
-        outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output]) | nil,
+        outputs:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output
+            ]
+          ) | nil,
         status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
         agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
       }
@@ -250,7 +275,12 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
         id: String,
         call_id: String,
         max_output_length: Integer | nil,
-        output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output]),
+        output:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output
+            ]
+          ),
         status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
         agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
         caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,

--- a/test/openai/resources/conversations/items_test.rb
+++ b/test/openai/resources/conversations/items_test.rb
@@ -91,7 +91,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         id: String,
         queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
         status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
+        results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseFileSearchToolCall::Result
+            ]
+          ) | nil
       }
       in {
         type: :web_search_call,
@@ -109,7 +114,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         type: :computer_call,
         id: String,
         call_id: String,
-        pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
+        pending_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+            ]
+          ),
         status: OpenAI::Responses::ResponseComputerToolCall::Status,
         action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
         actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
@@ -120,7 +130,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         call_id: String,
         output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
         status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
+        acknowledged_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+            ]
+          ) | nil,
         created_by: String | nil
       }
       in {
@@ -169,7 +184,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         id: String,
         code: String | nil,
         container_id: String,
-        outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
+        outputs:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+            ]
+          ) | nil,
         status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
       }
       in {
@@ -200,7 +220,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         id: String,
         call_id: String,
         max_output_length: Integer | nil,
-        output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
+        output:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+            ]
+          ),
         status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
         caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
         created_by: String | nil
@@ -227,7 +252,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         type: :mcp_list_tools,
         id: String,
         server_label: String,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]),
+        tools:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Conversations::ConversationItem::McpListTools::Tool
+            ]
+          ),
         error: String | nil
       }
       in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
@@ -342,7 +372,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         id: String,
         queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
         status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
+        results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseFileSearchToolCall::Result
+            ]
+          ) | nil
       }
       in {
         type: :web_search_call,
@@ -360,7 +395,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         type: :computer_call,
         id: String,
         call_id: String,
-        pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
+        pending_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+            ]
+          ),
         status: OpenAI::Responses::ResponseComputerToolCall::Status,
         action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
         actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
@@ -371,7 +411,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         call_id: String,
         output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
         status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
+        acknowledged_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+            ]
+          ) | nil,
         created_by: String | nil
       }
       in {
@@ -420,7 +465,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         id: String,
         code: String | nil,
         container_id: String,
-        outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
+        outputs:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+            ]
+          ) | nil,
         status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
       }
       in {
@@ -451,7 +501,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         id: String,
         call_id: String,
         max_output_length: Integer | nil,
-        output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
+        output:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+            ]
+          ),
         status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
         caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
         created_by: String | nil
@@ -478,7 +533,12 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
         type: :mcp_list_tools,
         id: String,
         server_label: String,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]),
+        tools:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Conversations::ConversationItem::McpListTools::Tool
+            ]
+          ),
         error: String | nil
       }
       in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}

--- a/test/openai/resources/evals/runs/output_items_test.rb
+++ b/test/openai/resources/evals/runs/output_items_test.rb
@@ -19,7 +19,12 @@ class OpenAI::Test::Resources::Evals::Runs::OutputItemsTest < OpenAI::Test::Reso
         datasource_item_id: Integer,
         eval_id: String,
         object: Symbol,
-        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::Runs::OutputItemRetrieveResponse::Result]),
+        results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::Runs::OutputItemRetrieveResponse::Result
+            ]
+          ),
         run_id: String,
         sample: OpenAI::Models::Evals::Runs::OutputItemRetrieveResponse::Sample,
         status: String
@@ -49,7 +54,12 @@ class OpenAI::Test::Resources::Evals::Runs::OutputItemsTest < OpenAI::Test::Reso
         datasource_item_id: Integer,
         eval_id: String,
         object: Symbol,
-        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::Runs::OutputItemListResponse::Result]),
+        results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::Runs::OutputItemListResponse::Result
+            ]
+          ),
         run_id: String,
         sample: OpenAI::Models::Evals::Runs::OutputItemListResponse::Sample,
         status: String

--- a/test/openai/resources/evals/runs_test.rb
+++ b/test/openai/resources/evals/runs_test.rb
@@ -25,8 +25,18 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCreateResponse::PerModelUsage]),
-        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCreateResponse::PerTestingCriteriaResult]),
+        per_model_usage:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunCreateResponse::PerModelUsage
+            ]
+          ),
+        per_testing_criteria_results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunCreateResponse::PerTestingCriteriaResult
+            ]
+          ),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunCreateResponse::ResultCounts,
         status: String
@@ -52,8 +62,18 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunRetrieveResponse::PerModelUsage]),
-        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunRetrieveResponse::PerTestingCriteriaResult]),
+        per_model_usage:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunRetrieveResponse::PerModelUsage
+            ]
+          ),
+        per_testing_criteria_results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunRetrieveResponse::PerTestingCriteriaResult
+            ]
+          ),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunRetrieveResponse::ResultCounts,
         status: String
@@ -86,8 +106,18 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunListResponse::PerModelUsage]),
-        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunListResponse::PerTestingCriteriaResult]),
+        per_model_usage:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunListResponse::PerModelUsage
+            ]
+          ),
+        per_testing_criteria_results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunListResponse::PerTestingCriteriaResult
+            ]
+          ),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunListResponse::ResultCounts,
         status: String
@@ -129,8 +159,18 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCancelResponse::PerModelUsage]),
-        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCancelResponse::PerTestingCriteriaResult]),
+        per_model_usage:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunCancelResponse::PerModelUsage
+            ]
+          ),
+        per_testing_criteria_results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::Evals::RunCancelResponse::PerTestingCriteriaResult
+            ]
+          ),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunCancelResponse::ResultCounts,
         status: String

--- a/test/openai/resources/evals_test.rb
+++ b/test/openai/resources/evals_test.rb
@@ -31,7 +31,12 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalCreateResponse::TestingCriterion])
+        testing_criteria:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Models::EvalCreateResponse::TestingCriterion
+            ]
+          )
       }
     end
   end
@@ -51,7 +56,12 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalRetrieveResponse::TestingCriterion])
+        testing_criteria:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Models::EvalRetrieveResponse::TestingCriterion
+            ]
+          )
       }
     end
   end
@@ -71,7 +81,12 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalUpdateResponse::TestingCriterion])
+        testing_criteria:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Models::EvalUpdateResponse::TestingCriterion
+            ]
+          )
       }
     end
   end
@@ -98,7 +113,12 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalListResponse::TestingCriterion])
+        testing_criteria:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Models::EvalListResponse::TestingCriterion
+            ]
+          )
       }
     end
   end

--- a/test/openai/resources/fine_tuning/alpha/graders_test.rb
+++ b/test/openai/resources/fine_tuning/alpha/graders_test.rb
@@ -17,7 +17,12 @@ class OpenAI::Test::Resources::FineTuning::Alpha::GradersTest < OpenAI::Test::Re
     assert_pattern do
       response => {
         metadata: OpenAI::Models::FineTuning::Alpha::GraderRunResponse::Metadata,
-        model_grader_token_usage_per_model: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]),
+        model_grader_token_usage_per_model:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              OpenAI::Internal::Type::Unknown
+            ]
+          ),
         reward: Float,
         sub_rewards: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown])
       }

--- a/test/openai/resources/fine_tuning/checkpoints/permissions_test.rb
+++ b/test/openai/resources/fine_tuning/checkpoints/permissions_test.rb
@@ -40,7 +40,12 @@ class OpenAI::Test::Resources::FineTuning::Checkpoints::PermissionsTest < OpenAI
 
     assert_pattern do
       response => {
-        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::FineTuning::Checkpoints::PermissionRetrieveResponse::Data]),
+        data:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Models::FineTuning::Checkpoints::PermissionRetrieveResponse::Data
+            ]
+          ),
         has_more: OpenAI::Internal::Type::Boolean,
         object: Symbol,
         first_id: String | nil,

--- a/test/openai/resources/fine_tuning/jobs_test.rb
+++ b/test/openai/resources/fine_tuning/jobs_test.rb
@@ -28,7 +28,12 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
+        integrations:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
+            ]
+          ) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -60,7 +65,12 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
+        integrations:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
+            ]
+          ) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -99,7 +109,12 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
+        integrations:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
+            ]
+          ) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -131,7 +146,12 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
+        integrations:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
+            ]
+          ) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -190,7 +210,12 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
+        integrations:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
+            ]
+          ) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -222,7 +247,12 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
+        integrations:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
+            ]
+          ) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }

--- a/test/openai/resources/responses/input_items_test.rb
+++ b/test/openai/resources/responses/input_items_test.rb
@@ -73,13 +73,23 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
         id: String,
         queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
         status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
+        results:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseFileSearchToolCall::Result
+            ]
+          ) | nil
       }
       in {
         type: :computer_call,
         id: String,
         call_id: String,
-        pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
+        pending_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+            ]
+          ),
         status: OpenAI::Responses::ResponseComputerToolCall::Status,
         action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
         actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
@@ -90,7 +100,12 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
         call_id: String,
         output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
         status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
+        acknowledged_safety_checks:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+            ]
+          ) | nil,
         created_by: String | nil
       }
       in {
@@ -162,7 +177,12 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
         id: String,
         code: String | nil,
         container_id: String,
-        outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
+        outputs:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+            ]
+          ) | nil,
         status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
       }
       in {
@@ -193,7 +213,12 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
         id: String,
         call_id: String,
         max_output_length: Integer | nil,
-        output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
+        output:
+          ^(
+            OpenAI::Internal::Type::ArrayOf[
+              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+            ]
+          ),
         status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
         caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
         created_by: String | nil

--- a/test/openai/resources/vector_stores/file_batches_test.rb
+++ b/test/openai/resources/vector_stores/file_batches_test.rb
@@ -83,7 +83,12 @@ class OpenAI::Test::Resources::VectorStores::FileBatchesTest < OpenAI::Test::Res
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
+        attributes:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              union: OpenAI::VectorStores::VectorStoreFile::Attribute
+            ]
+          ) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end

--- a/test/openai/resources/vector_stores/files_test.rb
+++ b/test/openai/resources/vector_stores/files_test.rb
@@ -19,7 +19,12 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
+        attributes:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              union: OpenAI::VectorStores::VectorStoreFile::Attribute
+            ]
+          ) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end
@@ -41,7 +46,12 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
+        attributes:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              union: OpenAI::VectorStores::VectorStoreFile::Attribute
+            ]
+          ) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end
@@ -68,7 +78,12 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
+        attributes:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              union: OpenAI::VectorStores::VectorStoreFile::Attribute
+            ]
+          ) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end
@@ -97,7 +112,12 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
+        attributes:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              union: OpenAI::VectorStores::VectorStoreFile::Attribute
+            ]
+          ) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end

--- a/test/openai/resources/vector_stores_test.rb
+++ b/test/openai/resources/vector_stores_test.rb
@@ -138,7 +138,12 @@ class OpenAI::Test::Resources::VectorStoresTest < OpenAI::Test::ResourceTest
 
     assert_pattern do
       row => {
-        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::Models::VectorStoreSearchResponse::Attribute]) | nil,
+        attributes:
+          ^(
+            OpenAI::Internal::Type::HashOf[
+              union: OpenAI::Models::VectorStoreSearchResponse::Attribute
+            ]
+          ) | nil,
         content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::VectorStoreSearchResponse::Content]),
         file_id: String,
         filename: String,

--- a/test/openai/resources/webhooks_test.rb
+++ b/test/openai/resources/webhooks_test.rb
@@ -15,7 +15,10 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     @webhook_service = @client.webhooks
 
     # Standardized test data matching TypeScript
-    @test_payload = '{"id": "evt_685c059ae3a481909bdc86819b066fb6", "object": "event", "created_at": 1750861210, "type": "response.completed", "data": {"id": "resp_123"}}'
+    @test_payload =
+      '{"id": "evt_685c059ae3a481909bdc86819b066fb6", "object": "event", ' \
+      '"created_at": 1750861210, "type": "response.completed", ' \
+      '"data": {"id": "resp_123"}}'
     @test_secret = "whsec_RdvaYFYUXuIFuEbvZHwMfYFhUf7aMYjYcmM24+Aj40c="
 
     @fixed_timestamp = "1750861210"
@@ -200,7 +203,8 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     old_timestamp = (1_750_861_210 - 400).to_s
 
     headers = {
-      "webhook-signature" => @webhook_signature, # This won't match old timestamp but we're testing time validation
+      # This won't match the old timestamp, but this test exercises time validation.
+      "webhook-signature" => @webhook_signature,
       "webhook-timestamp" => old_timestamp,
       "webhook-id" => @webhook_id
     }


### PR DESCRIPTION
## Summary

- remove the required lint task's `--except Layout/LineLength` escape hatch
- fix all 40 currently enforced offenses across 21 files without suppressions
- wrap generated resource-test patterns in the same shape emitted by Castiron
- preserve exception messages, regex behavior, inspection output, and test assertions while making their layout compliant

## Ratchet evidence

- **Rule:** `Layout/LineLength`
- **Threshold:** 110 columns, unchanged
- **Baseline:** 40 offenses across 21 files
- **Final:** 0 offenses across 2,619 Ruby/RBI files
- **Suppressions added:** none
- **Remaining policy debt:** removing the existing `AllowedPatterns` all at once exposes 6,104 offenses across 833 files, so those patterns remain explicit follow-up ratchets rather than being mixed into this enforcement PR

## Castiron impact

Generated resource tests are affected, so this rollout has a required companion generator PR: openai/openai#1291077. Castiron owns `test/openai/resources/**`; the companion updates the canonical renderer and adds focused max-width coverage. Handwritten auth, helper, internal, logging, and legacy webhook-test lines are SDK-owned or preserved overlay code.

## Validation

- `mise x ruby@4.0.6 -- bundle exec rake lint`
- 2,619 Ruby/RBI files lint-clean
- Sorbet clean
- 1,212 RBS files valid
- focused auth, structured-output, logging, internal utility, retry, and client tests: 170 runs / 1,268 assertions

Depends on openai/openai#1291077.
