### PR TITLE
chore: enforce nonempty pattern branches

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,11 +74,6 @@ Layout/SpaceInsideHashLiteralBraces:
   Exclude:
     - "**/*.rbi"
 
-# Fairly useful in tests for pattern assertions.
-Lint/EmptyInPattern:
-  Exclude:
-    - "test/**/*"
-
 # Disabled for safety reasons, this option changes code semantics.
 Lint/UnusedMethodArgument:
   AutoCorrect: false

--- a/test/openai/resources/audio/transcriptions_test.rb
+++ b/test/openai/resources/audio/transcriptions_test.rb
@@ -13,9 +13,12 @@ class OpenAI::Test::Resources::Audio::TranscriptionsTest < OpenAI::Test::Resourc
 
     assert_pattern do
       case response
-      in OpenAI::Audio::Transcription
-      in OpenAI::Audio::TranscriptionDiarized
-      in OpenAI::Audio::TranscriptionVerbose
+      in (
+        OpenAI::Audio::Transcription |
+        OpenAI::Audio::TranscriptionDiarized |
+        OpenAI::Audio::TranscriptionVerbose
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/audio/translations_test.rb
+++ b/test/openai/resources/audio/translations_test.rb
@@ -12,8 +12,11 @@ class OpenAI::Test::Resources::Audio::TranslationsTest < OpenAI::Test::ResourceT
 
     assert_pattern do
       case response
-      in OpenAI::Audio::Translation
-      in OpenAI::Audio::TranslationVerbose
+      in (
+        OpenAI::Audio::Translation |
+        OpenAI::Audio::TranslationVerbose
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/beta/chatkit/threads_test.rb
+++ b/test/openai/resources/beta/chatkit/threads_test.rb
@@ -80,83 +80,89 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
 
     assert_pattern do
       case row
-      in OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem
-      in OpenAI::Beta::ChatKit::ChatKitThreadAssistantMessageItem
-      in OpenAI::Beta::ChatKit::ChatKitWidgetItem
-      in OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall
-      in OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask
-      in OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup
+      in (
+        OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem |
+        OpenAI::Beta::ChatKit::ChatKitThreadAssistantMessageItem |
+        OpenAI::Beta::ChatKit::ChatKitWidgetItem |
+        OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall |
+        OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask |
+        OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :"chatkit.user_message",
-        id: String,
-        attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
-        content:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content
-            ]
-          ),
-        created_at: Integer,
-        inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
-        object: Symbol,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.assistant_message",
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitResponseOutputText]),
-        created_at: Integer,
-        object: Symbol,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.widget",
-        id: String,
-        created_at: Integer,
-        object: Symbol,
-        thread_id: String,
-        widget: String
-      }
-      in {
-        type: :"chatkit.client_tool_call",
-        id: String,
-        arguments: String,
-        call_id: String,
-        created_at: Integer,
-        name: String,
-        object: Symbol,
-        output: String | nil,
-        status: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall::Status,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.task",
-        id: String,
-        created_at: Integer,
-        heading: String | nil,
-        object: Symbol,
-        summary: String | nil,
-        task_type: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask::TaskType,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.task_group",
-        id: String,
-        created_at: Integer,
-        object: Symbol,
-        tasks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task
-            ]
-          ),
-        thread_id: String
-      }
+      in (
+        {
+          type: :"chatkit.user_message",
+          id: String,
+          attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content
+              ]
+            ),
+          created_at: Integer,
+          inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
+          object: Symbol,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.assistant_message",
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitResponseOutputText]),
+          created_at: Integer,
+          object: Symbol,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.widget",
+          id: String,
+          created_at: Integer,
+          object: Symbol,
+          thread_id: String,
+          widget: String
+        } |
+        {
+          type: :"chatkit.client_tool_call",
+          id: String,
+          arguments: String,
+          call_id: String,
+          created_at: Integer,
+          name: String,
+          object: Symbol,
+          output: String | nil,
+          status: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall::Status,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.task",
+          id: String,
+          created_at: Integer,
+          heading: String | nil,
+          object: Symbol,
+          summary: String | nil,
+          task_type: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask::TaskType,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.task_group",
+          id: String,
+          created_at: Integer,
+          object: Symbol,
+          tasks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task
+              ]
+            ),
+          thread_id: String
+        }
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/beta/responses/input_items_test.rb
+++ b/test/openai/resources/beta/responses/input_items_test.rb
@@ -19,329 +19,335 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
 
     assert_pattern do
       case row
-      in OpenAI::Beta::BetaResponseInputMessageItem
-      in OpenAI::Beta::BetaResponseOutputMessage
-      in OpenAI::Beta::BetaResponseFileSearchToolCall
-      in OpenAI::Beta::BetaResponseComputerToolCall
-      in OpenAI::Beta::BetaResponseComputerToolCallOutputItem
-      in OpenAI::Beta::BetaResponseFunctionWebSearch
-      in OpenAI::Beta::BetaResponseFunctionToolCallItem
-      in OpenAI::Beta::BetaResponseFunctionToolCallOutputItem
-      in OpenAI::Beta::BetaResponseItem::AgentMessage
-      in OpenAI::Beta::BetaResponseItem::MultiAgentCall
-      in OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput
-      in OpenAI::Beta::BetaResponseToolSearchCall
-      in OpenAI::Beta::BetaResponseToolSearchOutputItem
-      in OpenAI::Beta::BetaResponseItem::AdditionalTools
-      in OpenAI::Beta::BetaResponseReasoningItem
-      in OpenAI::Beta::BetaResponseItem::Program
-      in OpenAI::Beta::BetaResponseItem::ProgramOutput
-      in OpenAI::Beta::BetaResponseCompactionItem
-      in OpenAI::Beta::BetaResponseItem::ImageGenerationCall
-      in OpenAI::Beta::BetaResponseCodeInterpreterToolCall
-      in OpenAI::Beta::BetaResponseItem::LocalShellCall
-      in OpenAI::Beta::BetaResponseItem::LocalShellCallOutput
-      in OpenAI::Beta::BetaResponseFunctionShellToolCall
-      in OpenAI::Beta::BetaResponseFunctionShellToolCallOutput
-      in OpenAI::Beta::BetaResponseApplyPatchToolCall
-      in OpenAI::Beta::BetaResponseApplyPatchToolCallOutput
-      in OpenAI::Beta::BetaResponseItem::McpListTools
-      in OpenAI::Beta::BetaResponseItem::McpApprovalRequest
-      in OpenAI::Beta::BetaResponseItem::McpApprovalResponse
-      in OpenAI::Beta::BetaResponseItem::McpCall
-      in OpenAI::Beta::BetaResponseCustomToolCallItem
-      in OpenAI::Beta::BetaResponseCustomToolCallOutputItem
+      in (
+        OpenAI::Beta::BetaResponseInputMessageItem |
+        OpenAI::Beta::BetaResponseOutputMessage |
+        OpenAI::Beta::BetaResponseFileSearchToolCall |
+        OpenAI::Beta::BetaResponseComputerToolCall |
+        OpenAI::Beta::BetaResponseComputerToolCallOutputItem |
+        OpenAI::Beta::BetaResponseFunctionWebSearch |
+        OpenAI::Beta::BetaResponseFunctionToolCallItem |
+        OpenAI::Beta::BetaResponseFunctionToolCallOutputItem |
+        OpenAI::Beta::BetaResponseItem::AgentMessage |
+        OpenAI::Beta::BetaResponseItem::MultiAgentCall |
+        OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput |
+        OpenAI::Beta::BetaResponseToolSearchCall |
+        OpenAI::Beta::BetaResponseToolSearchOutputItem |
+        OpenAI::Beta::BetaResponseItem::AdditionalTools |
+        OpenAI::Beta::BetaResponseReasoningItem |
+        OpenAI::Beta::BetaResponseItem::Program |
+        OpenAI::Beta::BetaResponseItem::ProgramOutput |
+        OpenAI::Beta::BetaResponseCompactionItem |
+        OpenAI::Beta::BetaResponseItem::ImageGenerationCall |
+        OpenAI::Beta::BetaResponseCodeInterpreterToolCall |
+        OpenAI::Beta::BetaResponseItem::LocalShellCall |
+        OpenAI::Beta::BetaResponseItem::LocalShellCallOutput |
+        OpenAI::Beta::BetaResponseFunctionShellToolCall |
+        OpenAI::Beta::BetaResponseFunctionShellToolCallOutput |
+        OpenAI::Beta::BetaResponseApplyPatchToolCall |
+        OpenAI::Beta::BetaResponseApplyPatchToolCallOutput |
+        OpenAI::Beta::BetaResponseItem::McpListTools |
+        OpenAI::Beta::BetaResponseItem::McpApprovalRequest |
+        OpenAI::Beta::BetaResponseItem::McpApprovalResponse |
+        OpenAI::Beta::BetaResponseItem::McpCall |
+        OpenAI::Beta::BetaResponseCustomToolCallItem |
+        OpenAI::Beta::BetaResponseCustomToolCallOutputItem
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseInputContent]),
-        role: OpenAI::Beta::BetaResponseInputMessageItem::Role,
-        agent: OpenAI::Beta::BetaResponseInputMessageItem::Agent | nil,
-        status: OpenAI::Beta::BetaResponseInputMessageItem::Status | nil
-      }
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseOutputMessage::Content]),
-        role: Symbol,
-        status: OpenAI::Beta::BetaResponseOutputMessage::Status,
-        agent: OpenAI::Beta::BetaResponseOutputMessage::Agent | nil,
-        phase: OpenAI::Beta::BetaResponseOutputMessage::Phase | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
-        action: OpenAI::Beta::BetaComputerAction | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
-        agent: OpenAI::Beta::BetaResponseComputerToolCall::Agent | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseFunctionWebSearch::Action,
-        status: OpenAI::Beta::BetaResponseFunctionWebSearch::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionWebSearch::Agent | nil
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :agent_message,
-        id: String,
-        author: String,
-        content:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content
-            ]
-          ),
-        recipient: String,
-        agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
-      }
-      in {
-        type: :multi_agent_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Action,
-        arguments: String,
-        call_id: String,
-        agent: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Agent | nil
-      }
-      in {
-        type: :multi_agent_call_output,
-        id: String,
-        action: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Action,
-        call_id: String,
-        output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseOutputText]),
-        agent: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Agent | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Beta::BetaResponseToolSearchCall::Execution,
-        status: OpenAI::Beta::BetaResponseToolSearchCall::Status,
-        agent: OpenAI::Beta::BetaResponseToolSearchCall::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Beta::BetaResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Beta::BetaResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
-        agent: OpenAI::Beta::BetaResponseToolSearchOutputItem::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Beta::BetaResponseItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
-        agent: OpenAI::Beta::BetaResponseItem::AdditionalTools::Agent | nil
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Summary]),
-        agent: OpenAI::Beta::BetaResponseReasoningItem::Agent | nil,
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Beta::BetaResponseReasoningItem::Status | nil
-      }
-      in {
-        type: :program,
-        id: String,
-        call_id: String,
-        code: String,
-        fingerprint: String,
-        agent: OpenAI::Beta::BetaResponseItem::Program::Agent | nil
-      }
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Beta::BetaResponseItem::ProgramOutput::Status,
-        agent: OpenAI::Beta::BetaResponseItem::ProgramOutput::Agent | nil
-      }
-      in {
-        type: :compaction,
-        id: String,
-        encrypted_content: String,
-        agent: OpenAI::Beta::BetaResponseCompactionItem::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Status,
-        agent: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Agent | nil
-      }
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Beta::BetaResponseItem::LocalShellCall::Status,
-        agent: OpenAI::Beta::BetaResponseItem::LocalShellCall::Agent | nil
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        agent: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Agent | nil,
-        status: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Beta::BetaResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Beta::BetaResponseFunctionShellToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionShellToolCall::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Beta::BetaResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Beta::BetaResponseApplyPatchToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseApplyPatchToolCall::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Status,
-        agent: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseItem::McpListTools::Tool]),
-        agent: OpenAI::Beta::BetaResponseItem::McpListTools::Agent | nil,
-        error: String | nil
-      }
-      in {
-        type: :mcp_approval_request,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        agent: OpenAI::Beta::BetaResponseItem::McpApprovalRequest::Agent | nil
-      }
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        agent: OpenAI::Beta::BetaResponseItem::McpApprovalResponse::Agent | nil,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        agent: OpenAI::Beta::BetaResponseItem::McpCall::Agent | nil,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Beta::BetaResponseItem::McpCall::Status | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseInputContent]),
+          role: OpenAI::Beta::BetaResponseInputMessageItem::Role,
+          agent: OpenAI::Beta::BetaResponseInputMessageItem::Agent | nil,
+          status: OpenAI::Beta::BetaResponseInputMessageItem::Status | nil
+        } |
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseOutputMessage::Content]),
+          role: Symbol,
+          status: OpenAI::Beta::BetaResponseOutputMessage::Status,
+          agent: OpenAI::Beta::BetaResponseOutputMessage::Agent | nil,
+          phase: OpenAI::Beta::BetaResponseOutputMessage::Phase | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
+          action: OpenAI::Beta::BetaComputerAction | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
+          agent: OpenAI::Beta::BetaResponseComputerToolCall::Agent | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseFunctionWebSearch::Action,
+          status: OpenAI::Beta::BetaResponseFunctionWebSearch::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionWebSearch::Agent | nil
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :agent_message,
+          id: String,
+          author: String,
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content
+              ]
+            ),
+          recipient: String,
+          agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
+        } |
+        {
+          type: :multi_agent_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Action,
+          arguments: String,
+          call_id: String,
+          agent: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Agent | nil
+        } |
+        {
+          type: :multi_agent_call_output,
+          id: String,
+          action: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Action,
+          call_id: String,
+          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseOutputText]),
+          agent: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Agent | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Beta::BetaResponseToolSearchCall::Execution,
+          status: OpenAI::Beta::BetaResponseToolSearchCall::Status,
+          agent: OpenAI::Beta::BetaResponseToolSearchCall::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Beta::BetaResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Beta::BetaResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
+          agent: OpenAI::Beta::BetaResponseToolSearchOutputItem::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Beta::BetaResponseItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
+          agent: OpenAI::Beta::BetaResponseItem::AdditionalTools::Agent | nil
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Summary]),
+          agent: OpenAI::Beta::BetaResponseReasoningItem::Agent | nil,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Content]) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Beta::BetaResponseReasoningItem::Status | nil
+        } |
+        {
+          type: :program,
+          id: String,
+          call_id: String,
+          code: String,
+          fingerprint: String,
+          agent: OpenAI::Beta::BetaResponseItem::Program::Agent | nil
+        } |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Beta::BetaResponseItem::ProgramOutput::Status,
+          agent: OpenAI::Beta::BetaResponseItem::ProgramOutput::Agent | nil
+        } |
+        {
+          type: :compaction,
+          id: String,
+          encrypted_content: String,
+          agent: OpenAI::Beta::BetaResponseCompactionItem::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Status,
+          agent: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Agent | nil
+        } |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Beta::BetaResponseItem::LocalShellCall::Status,
+          agent: OpenAI::Beta::BetaResponseItem::LocalShellCall::Agent | nil
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          agent: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Agent | nil,
+          status: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Beta::BetaResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Beta::BetaResponseFunctionShellToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionShellToolCall::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Beta::BetaResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Beta::BetaResponseApplyPatchToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseApplyPatchToolCall::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Status,
+          agent: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseItem::McpListTools::Tool]),
+          agent: OpenAI::Beta::BetaResponseItem::McpListTools::Agent | nil,
+          error: String | nil
+        } |
+        {
+          type: :mcp_approval_request,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          agent: OpenAI::Beta::BetaResponseItem::McpApprovalRequest::Agent | nil
+        } |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          agent: OpenAI::Beta::BetaResponseItem::McpApprovalResponse::Agent | nil,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          agent: OpenAI::Beta::BetaResponseItem::McpCall::Agent | nil,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Beta::BetaResponseItem::McpCall::Status | nil
+        }
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/conversations/items_test.rb
+++ b/test/openai/resources/conversations/items_test.rb
@@ -34,267 +34,278 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
 
     assert_pattern do
       case response
-      in OpenAI::Conversations::Message
-      in OpenAI::Responses::ResponseFunctionToolCallItem
-      in OpenAI::Responses::ResponseFunctionToolCallOutputItem
-      in OpenAI::Responses::ResponseFileSearchToolCall
-      in OpenAI::Responses::ResponseFunctionWebSearch
-      in OpenAI::Conversations::ConversationItem::ImageGenerationCall
-      in OpenAI::Responses::ResponseComputerToolCall
-      in OpenAI::Responses::ResponseComputerToolCallOutputItem
-      in OpenAI::Responses::ResponseToolSearchCall
-      in OpenAI::Responses::ResponseToolSearchOutputItem
-      in OpenAI::Conversations::ConversationItem::AdditionalTools
-      in OpenAI::Responses::ResponseReasoningItem
-      in OpenAI::Conversations::ConversationItem::Program
-      in OpenAI::Conversations::ConversationItem::ProgramOutput
-      in OpenAI::Responses::ResponseCompactionItem
-      in OpenAI::Responses::ResponseCodeInterpreterToolCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCallOutput
-      in OpenAI::Responses::ResponseFunctionShellToolCall
-      in OpenAI::Responses::ResponseFunctionShellToolCallOutput
-      in OpenAI::Responses::ResponseApplyPatchToolCall
-      in OpenAI::Responses::ResponseApplyPatchToolCallOutput
-      in OpenAI::Conversations::ConversationItem::McpListTools
-      in OpenAI::Conversations::ConversationItem::McpApprovalRequest
-      in OpenAI::Conversations::ConversationItem::McpApprovalResponse
-      in OpenAI::Conversations::ConversationItem::McpCall
-      in OpenAI::Responses::ResponseCustomToolCall
-      in OpenAI::Responses::ResponseCustomToolCallOutput
+      in (
+        OpenAI::Conversations::Message |
+        OpenAI::Responses::ResponseFunctionToolCallItem |
+        OpenAI::Responses::ResponseFunctionToolCallOutputItem |
+        OpenAI::Responses::ResponseFileSearchToolCall |
+        OpenAI::Responses::ResponseFunctionWebSearch |
+        OpenAI::Conversations::ConversationItem::ImageGenerationCall |
+        OpenAI::Responses::ResponseComputerToolCall |
+        OpenAI::Responses::ResponseComputerToolCallOutputItem |
+        OpenAI::Responses::ResponseToolSearchCall |
+        OpenAI::Responses::ResponseToolSearchOutputItem |
+        OpenAI::Conversations::ConversationItem::AdditionalTools |
+        OpenAI::Responses::ResponseReasoningItem |
+        OpenAI::Conversations::ConversationItem::Program |
+        OpenAI::Conversations::ConversationItem::ProgramOutput |
+        OpenAI::Responses::ResponseCompactionItem |
+        OpenAI::Responses::ResponseCodeInterpreterToolCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCallOutput |
+        OpenAI::Responses::ResponseFunctionShellToolCall |
+        OpenAI::Responses::ResponseFunctionShellToolCallOutput |
+        OpenAI::Responses::ResponseApplyPatchToolCall |
+        OpenAI::Responses::ResponseApplyPatchToolCallOutput |
+        OpenAI::Conversations::ConversationItem::McpListTools |
+        OpenAI::Conversations::ConversationItem::McpApprovalRequest |
+        OpenAI::Conversations::ConversationItem::McpApprovalResponse |
+        OpenAI::Conversations::ConversationItem::McpCall |
+        OpenAI::Responses::ResponseCustomToolCall |
+        OpenAI::Responses::ResponseCustomToolCallOutput
+      )
+        nil
       end
     end
 
     assert_pattern do
       case response
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
-        role: OpenAI::Conversations::Message::Role,
-        status: OpenAI::Conversations::Message::Status,
-        phase: OpenAI::Conversations::Message::Phase | nil
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-        caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-        status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-      }
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Responses::ResponseComputerToolCall::Status,
-        action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-        status: OpenAI::Responses::ResponseToolSearchCall::Status,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-      }
-      in {type: :program, id: String, call_id: String, code: String, fingerprint: String}
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
-      }
-      in {type: :compaction, id: String, encrypted_content: String, created_by: String | nil}
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Conversations::ConversationItem::McpListTools::Tool
-            ]
-          ),
-        error: String | nil
-      }
-      in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
-      }
-      in {
-        type: :custom_tool_call,
-        call_id: String,
-        input: String,
-        name: String,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :custom_tool_call_output,
-        call_id: String,
-        output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
+          role: OpenAI::Conversations::Message::Role,
+          status: OpenAI::Conversations::Message::Status,
+          phase: OpenAI::Conversations::Message::Phase | nil
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
+          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
+          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
+        } |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Responses::ResponseComputerToolCall::Status,
+          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
+          status: OpenAI::Responses::ResponseToolSearchCall::Status,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseReasoningItem::Content
+              ]
+            ) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
+        } |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
+        } |
+        {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Conversations::ConversationItem::McpListTools::Tool
+              ]
+            ),
+          error: String | nil
+        } |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
+        } |
+        {
+          type: :custom_tool_call,
+          call_id: String,
+          input: String,
+          name: String,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :custom_tool_call_output,
+          call_id: String,
+          output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
+        }
+      )
+        nil
       end
     end
   end
@@ -315,267 +326,278 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
 
     assert_pattern do
       case row
-      in OpenAI::Conversations::Message
-      in OpenAI::Responses::ResponseFunctionToolCallItem
-      in OpenAI::Responses::ResponseFunctionToolCallOutputItem
-      in OpenAI::Responses::ResponseFileSearchToolCall
-      in OpenAI::Responses::ResponseFunctionWebSearch
-      in OpenAI::Conversations::ConversationItem::ImageGenerationCall
-      in OpenAI::Responses::ResponseComputerToolCall
-      in OpenAI::Responses::ResponseComputerToolCallOutputItem
-      in OpenAI::Responses::ResponseToolSearchCall
-      in OpenAI::Responses::ResponseToolSearchOutputItem
-      in OpenAI::Conversations::ConversationItem::AdditionalTools
-      in OpenAI::Responses::ResponseReasoningItem
-      in OpenAI::Conversations::ConversationItem::Program
-      in OpenAI::Conversations::ConversationItem::ProgramOutput
-      in OpenAI::Responses::ResponseCompactionItem
-      in OpenAI::Responses::ResponseCodeInterpreterToolCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCallOutput
-      in OpenAI::Responses::ResponseFunctionShellToolCall
-      in OpenAI::Responses::ResponseFunctionShellToolCallOutput
-      in OpenAI::Responses::ResponseApplyPatchToolCall
-      in OpenAI::Responses::ResponseApplyPatchToolCallOutput
-      in OpenAI::Conversations::ConversationItem::McpListTools
-      in OpenAI::Conversations::ConversationItem::McpApprovalRequest
-      in OpenAI::Conversations::ConversationItem::McpApprovalResponse
-      in OpenAI::Conversations::ConversationItem::McpCall
-      in OpenAI::Responses::ResponseCustomToolCall
-      in OpenAI::Responses::ResponseCustomToolCallOutput
+      in (
+        OpenAI::Conversations::Message |
+        OpenAI::Responses::ResponseFunctionToolCallItem |
+        OpenAI::Responses::ResponseFunctionToolCallOutputItem |
+        OpenAI::Responses::ResponseFileSearchToolCall |
+        OpenAI::Responses::ResponseFunctionWebSearch |
+        OpenAI::Conversations::ConversationItem::ImageGenerationCall |
+        OpenAI::Responses::ResponseComputerToolCall |
+        OpenAI::Responses::ResponseComputerToolCallOutputItem |
+        OpenAI::Responses::ResponseToolSearchCall |
+        OpenAI::Responses::ResponseToolSearchOutputItem |
+        OpenAI::Conversations::ConversationItem::AdditionalTools |
+        OpenAI::Responses::ResponseReasoningItem |
+        OpenAI::Conversations::ConversationItem::Program |
+        OpenAI::Conversations::ConversationItem::ProgramOutput |
+        OpenAI::Responses::ResponseCompactionItem |
+        OpenAI::Responses::ResponseCodeInterpreterToolCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCallOutput |
+        OpenAI::Responses::ResponseFunctionShellToolCall |
+        OpenAI::Responses::ResponseFunctionShellToolCallOutput |
+        OpenAI::Responses::ResponseApplyPatchToolCall |
+        OpenAI::Responses::ResponseApplyPatchToolCallOutput |
+        OpenAI::Conversations::ConversationItem::McpListTools |
+        OpenAI::Conversations::ConversationItem::McpApprovalRequest |
+        OpenAI::Conversations::ConversationItem::McpApprovalResponse |
+        OpenAI::Conversations::ConversationItem::McpCall |
+        OpenAI::Responses::ResponseCustomToolCall |
+        OpenAI::Responses::ResponseCustomToolCallOutput
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
-        role: OpenAI::Conversations::Message::Role,
-        status: OpenAI::Conversations::Message::Status,
-        phase: OpenAI::Conversations::Message::Phase | nil
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-        caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-        status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-      }
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Responses::ResponseComputerToolCall::Status,
-        action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-        status: OpenAI::Responses::ResponseToolSearchCall::Status,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-      }
-      in {type: :program, id: String, call_id: String, code: String, fingerprint: String}
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
-      }
-      in {type: :compaction, id: String, encrypted_content: String, created_by: String | nil}
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Conversations::ConversationItem::McpListTools::Tool
-            ]
-          ),
-        error: String | nil
-      }
-      in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
-      }
-      in {
-        type: :custom_tool_call,
-        call_id: String,
-        input: String,
-        name: String,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :custom_tool_call_output,
-        call_id: String,
-        output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
+          role: OpenAI::Conversations::Message::Role,
+          status: OpenAI::Conversations::Message::Status,
+          phase: OpenAI::Conversations::Message::Phase | nil
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
+          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
+          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
+        } |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Responses::ResponseComputerToolCall::Status,
+          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
+          status: OpenAI::Responses::ResponseToolSearchCall::Status,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseReasoningItem::Content
+              ]
+            ) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
+        } |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
+        } |
+        {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Conversations::ConversationItem::McpListTools::Tool
+              ]
+            ),
+          error: String | nil
+        } |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
+        } |
+        {
+          type: :custom_tool_call,
+          call_id: String,
+          input: String,
+          name: String,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :custom_tool_call_output,
+          call_id: String,
+          output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
+        }
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/responses/input_items_test.rb
+++ b/test/openai/resources/responses/input_items_test.rb
@@ -19,254 +19,265 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
 
     assert_pattern do
       case row
-      in OpenAI::Responses::ResponseInputMessageItem
-      in OpenAI::Responses::ResponseOutputMessage
-      in OpenAI::Responses::ResponseFileSearchToolCall
-      in OpenAI::Responses::ResponseComputerToolCall
-      in OpenAI::Responses::ResponseComputerToolCallOutputItem
-      in OpenAI::Responses::ResponseFunctionWebSearch
-      in OpenAI::Responses::ResponseFunctionToolCallItem
-      in OpenAI::Responses::ResponseFunctionToolCallOutputItem
-      in OpenAI::Responses::ResponseToolSearchCall
-      in OpenAI::Responses::ResponseToolSearchOutputItem
-      in OpenAI::Responses::ResponseItem::AdditionalTools
-      in OpenAI::Responses::ResponseReasoningItem
-      in OpenAI::Responses::ResponseItem::Program
-      in OpenAI::Responses::ResponseItem::ProgramOutput
-      in OpenAI::Responses::ResponseCompactionItem
-      in OpenAI::Responses::ResponseItem::ImageGenerationCall
-      in OpenAI::Responses::ResponseCodeInterpreterToolCall
-      in OpenAI::Responses::ResponseItem::LocalShellCall
-      in OpenAI::Responses::ResponseItem::LocalShellCallOutput
-      in OpenAI::Responses::ResponseFunctionShellToolCall
-      in OpenAI::Responses::ResponseFunctionShellToolCallOutput
-      in OpenAI::Responses::ResponseApplyPatchToolCall
-      in OpenAI::Responses::ResponseApplyPatchToolCallOutput
-      in OpenAI::Responses::ResponseItem::McpListTools
-      in OpenAI::Responses::ResponseItem::McpApprovalRequest
-      in OpenAI::Responses::ResponseItem::McpApprovalResponse
-      in OpenAI::Responses::ResponseItem::McpCall
-      in OpenAI::Responses::ResponseCustomToolCallItem
-      in OpenAI::Responses::ResponseCustomToolCallOutputItem
+      in (
+        OpenAI::Responses::ResponseInputMessageItem |
+        OpenAI::Responses::ResponseOutputMessage |
+        OpenAI::Responses::ResponseFileSearchToolCall |
+        OpenAI::Responses::ResponseComputerToolCall |
+        OpenAI::Responses::ResponseComputerToolCallOutputItem |
+        OpenAI::Responses::ResponseFunctionWebSearch |
+        OpenAI::Responses::ResponseFunctionToolCallItem |
+        OpenAI::Responses::ResponseFunctionToolCallOutputItem |
+        OpenAI::Responses::ResponseToolSearchCall |
+        OpenAI::Responses::ResponseToolSearchOutputItem |
+        OpenAI::Responses::ResponseItem::AdditionalTools |
+        OpenAI::Responses::ResponseReasoningItem |
+        OpenAI::Responses::ResponseItem::Program |
+        OpenAI::Responses::ResponseItem::ProgramOutput |
+        OpenAI::Responses::ResponseCompactionItem |
+        OpenAI::Responses::ResponseItem::ImageGenerationCall |
+        OpenAI::Responses::ResponseCodeInterpreterToolCall |
+        OpenAI::Responses::ResponseItem::LocalShellCall |
+        OpenAI::Responses::ResponseItem::LocalShellCallOutput |
+        OpenAI::Responses::ResponseFunctionShellToolCall |
+        OpenAI::Responses::ResponseFunctionShellToolCallOutput |
+        OpenAI::Responses::ResponseApplyPatchToolCall |
+        OpenAI::Responses::ResponseApplyPatchToolCallOutput |
+        OpenAI::Responses::ResponseItem::McpListTools |
+        OpenAI::Responses::ResponseItem::McpApprovalRequest |
+        OpenAI::Responses::ResponseItem::McpApprovalResponse |
+        OpenAI::Responses::ResponseItem::McpCall |
+        OpenAI::Responses::ResponseCustomToolCallItem |
+        OpenAI::Responses::ResponseCustomToolCallOutputItem
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseInputContent]),
-        role: OpenAI::Responses::ResponseInputMessageItem::Role,
-        status: OpenAI::Responses::ResponseInputMessageItem::Status | nil
-      }
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseOutputMessage::Content]),
-        role: Symbol,
-        status: OpenAI::Responses::ResponseOutputMessage::Status,
-        phase: OpenAI::Responses::ResponseOutputMessage::Phase | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Responses::ResponseComputerToolCall::Status,
-        action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-        status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-        caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-        status: OpenAI::Responses::ResponseToolSearchCall::Status,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Responses::ResponseItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-      }
-      in {type: :program, id: String, call_id: String, code: String, fingerprint: String}
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Responses::ResponseItem::ProgramOutput::Status
-      }
-      in {type: :compaction, id: String, encrypted_content: String, created_by: String | nil}
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Responses::ResponseItem::ImageGenerationCall::Status
-      }
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Responses::ResponseItem::LocalShellCall::Status
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        status: OpenAI::Responses::ResponseItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseItem::McpListTools::Tool]),
-        error: String | nil
-      }
-      in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Responses::ResponseItem::McpCall::Status | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseInputContent]),
+          role: OpenAI::Responses::ResponseInputMessageItem::Role,
+          status: OpenAI::Responses::ResponseInputMessageItem::Status | nil
+        } |
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseOutputMessage::Content]),
+          role: Symbol,
+          status: OpenAI::Responses::ResponseOutputMessage::Status,
+          phase: OpenAI::Responses::ResponseOutputMessage::Phase | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Responses::ResponseComputerToolCall::Status,
+          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
+          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
+          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
+          status: OpenAI::Responses::ResponseToolSearchCall::Status,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Responses::ResponseItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseReasoningItem::Content
+              ]
+            ) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
+        } |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Responses::ResponseItem::ProgramOutput::Status
+        } |
+        {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Responses::ResponseItem::ImageGenerationCall::Status
+        } |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Responses::ResponseItem::LocalShellCall::Status
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          status: OpenAI::Responses::ResponseItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseItem::McpListTools::Tool]),
+          error: String | nil
+        } |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Responses::ResponseItem::McpCall::Status | nil
+        }
+      )
+        nil
       end
     end
   end


### PR DESCRIPTION
## Summary

- remove the generated-test exclusion for `Lint/EmptyInPattern`
- combine response type and hash alternatives into one parenthesized pattern with one explicit body
- preserve the preceding 110-column line-length ratchet
- avoid introducing duplicate branch bodies or suppressions

## Ratchet evidence

- **Rule:** `Lint/EmptyInPattern`
- **Baseline:** 243 offenses in 6 generated resource-test files
- **Naive replacement rejected:** one `nil` per branch introduced 231 `Lint/DuplicateBranch` offenses
- **Final:** 0 `Lint/EmptyInPattern` and 0 `Lint/DuplicateBranch` offenses
- **Suppressions added:** none

## Castiron impact

All affected files are under generator-owned `test/openai/resources/**`. The canonical renderer fix is openai/openai#1291082, stacked on the line-length renderer change in openai/openai#1291077.

## Validation

- `mise x ruby@4.0.6 -- bundle exec rake lint`
- 2,619 Ruby/RBI files lint-clean
- Sorbet clean
- 1,212 RBS files valid
- GitHub CI will provide the authoritative Prism-backed generated resource-test run

Depends on openai/openai-ruby#406 and openai/openai#1291082.
