### PR TITLE
chore: guard RuboCop suppression directives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,11 +74,6 @@ Layout/SpaceInsideHashLiteralBraces:
   Exclude:
     - "**/*.rbi"
 
-# Fairly useful in tests for pattern assertions.
-Lint/EmptyInPattern:
-  Exclude:
-    - "test/**/*"
-
 # Disabled for safety reasons, this option changes code semantics.
 Lint/UnusedMethodArgument:
   AutoCorrect: false

--- a/Rakefile
+++ b/Rakefile
@@ -66,6 +66,7 @@ desc("Validate RuboCop suppression directives")
 multitask(:"lint:rubocop_directives") do
   ruby(*%w[scripts/validate-rubocop-directives])
 end
+Rake::Task[:"lint:rubocop"].enhance([:"lint:rubocop_directives"])
 
 norm_lines = %w[tr -- \n \0].shelljoin
 

--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,11 @@ RuboCop::RakeTask.new(:"lint:rubocop") do |task|
   task.options = %w[--parallel --force-exclusion]
 end
 
+desc("Validate RuboCop suppression directives")
+multitask(:"lint:rubocop_directives") do
+  ruby(*%w[scripts/validate-rubocop-directives])
+end
+
 norm_lines = %w[tr -- \n \0].shelljoin
 
 desc("Format `*.rb`")
@@ -146,7 +151,7 @@ desc("Typecheck and validate everything")
 multitask(typecheck: [:"typecheck:sorbet", :"validate:rbs"])
 
 desc("Lint and typecheck")
-multitask(lint: [:"lint:rubocop", :typecheck])
+multitask(lint: [:"lint:rubocop", :"lint:rubocop_directives", :typecheck])
 
 desc("Build yard docs")
 multitask(:"build:docs") do

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -2,18 +2,10 @@
 
 require "open3"
 require "ripper"
-require "rubocop/directive_comment"
+require "rubocop"
 
 module RuboCopDirectiveGuard
   DirectiveText = Data.define(:text)
-  EXCLUDED_PREFIXES = %w[
-    sorbet/rbi/annotations/
-    sorbet/rbi/gems/
-    sorbet/tapioca/
-    vendor/
-  ].freeze
-  ROOT_RUBY_FILES = %w[Gemfile Rakefile Steepfile].freeze
-  RUBY_EXTENSIONS = %w[.gemspec .rake .rb .rbi].freeze
   TODO_OWNER = /(?:\A|;)\s*owner:\s*[^;\s]+/
   TODO_REMOVAL = %r{
     (?:\A|;)\s*
@@ -22,14 +14,6 @@ module RuboCopDirectiveGuard
   }x
 
   module_function
-
-  def ruby_source_path?(path, source = "")
-    return false if EXCLUDED_PREFIXES.any? { path.start_with?(_1) }
-    return true if ROOT_RUBY_FILES.include?(path)
-    return true if RUBY_EXTENSIONS.include?(File.extname(path))
-
-    path.start_with?("scripts/") && source.start_with?("#!/usr/bin/env ruby")
-  end
 
   def violations_for(path, source)
     violations = []
@@ -42,6 +26,8 @@ module RuboCopDirectiveGuard
       action = directive.mode
       cops = directive.raw_cop_names
       metadata = comment.partition("--").then { |_, marker, text| text if marker == "--" }
+      next if action == "enable"
+
       if cops.any? { _1.casecmp("all").zero? }
         violations << "#{path}:#{line_number}: rubocop:#{action} all is forbidden"
       end
@@ -66,15 +52,21 @@ module RuboCopDirectiveGuard
     paths, status = Open3.capture2("git", "ls-files", "-z")
     raise "git ls-files failed" unless status.success?
 
-    paths.split("\0").filter_map do |path|
-      next unless ROOT_RUBY_FILES.include?(path) ||
-                  RUBY_EXTENSIONS.include?(File.extname(path)) ||
-                  path.start_with?("scripts/")
-      next unless File.file?(path)
+    tracked_paths = paths.split("\0").to_h { [_1, true] }
+    root = File.expand_path(".")
+    root_prefix = "#{root}/"
+    rubocop_target_paths.filter_map do |target|
+      path = File.expand_path(target).delete_prefix(root_prefix)
+      next unless tracked_paths.key?(path)
 
-      source = File.read(path)
-      [path, source] if ruby_source_path?(path, source)
+      [path, File.read(target)]
     end
+  end
+
+  def rubocop_target_paths(root = ".")
+    RuboCop::TargetFinder
+      .new(RuboCop::ConfigStore.new)
+      .find([root], :only_recognized_file_types)
   end
 
   def validate

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -57,8 +57,7 @@ module RuboCopDirectiveGuard
   end
 
   def valid_iso_date?(value)
-    Date.iso8601(value)
-    true
+    Date.iso8601(value) >= Date.today
   rescue Date::Error
     false
   end

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "open3"
+require "ripper"
+
+module RuboCopDirectiveGuard
+  DIRECTIVE = /#\s*rubocop:(disable|todo)\s+(.+?)(?:\s+--\s+(.+))?\s*$/
+  EXCLUDED_PREFIXES = %w[
+    sorbet/rbi/annotations/
+    sorbet/rbi/gems/
+    sorbet/tapioca/
+    vendor/
+  ].freeze
+  ROOT_RUBY_FILES = %w[Gemfile Rakefile].freeze
+  RUBY_EXTENSIONS = %w[.gemspec .rake .rb .rbi].freeze
+  TODO_OWNER = /(?:\A|;)\s*owner:\s*[^;\s]+/
+  TODO_REMOVAL = %r{(?:\A|;)\s*(?:issue:\s*(?:#\d+|https?://[^;\s]+)|remove-by:\s*\d{4}-\d{2}-\d{2})}
+
+  module_function
+
+  def ruby_source_path?(path, source = "")
+    return false if EXCLUDED_PREFIXES.any? { path.start_with?(_1) }
+    return true if ROOT_RUBY_FILES.include?(path)
+    return true if RUBY_EXTENSIONS.include?(File.extname(path))
+
+    path.start_with?("scripts/") && source.start_with?("#!/usr/bin/env ruby")
+  end
+
+  def violations_for(path, source)
+    violations = []
+    Ripper.lex(source).each do |(line_number, _column), token, comment, _state|
+      next unless token == :on_comment
+
+      match = DIRECTIVE.match(comment)
+      next if match.nil?
+
+      action, cop_text, metadata = match.captures
+      cops = cop_text.split(",").map(&:strip)
+      if cops.any? { _1.casecmp("all").zero? }
+        violations << "#{path}:#{line_number}: rubocop:#{action} all is forbidden"
+      end
+      cops.reject { _1.include?("/") }.each do |department|
+        violations <<
+          "#{path}:#{line_number}: department-wide rubocop:#{action} #{department} is forbidden"
+      end
+      next unless action == "todo"
+
+      unless metadata&.match?(TODO_OWNER)
+        violations << "#{path}:#{line_number}: rubocop:todo requires `owner: ...` metadata"
+      end
+      unless metadata&.match?(TODO_REMOVAL)
+        violations <<
+          "#{path}:#{line_number}: rubocop:todo requires `issue: #123` or `remove-by: YYYY-MM-DD` metadata"
+      end
+    end
+    violations
+  end
+
+  def tracked_ruby_sources
+    paths, status = Open3.capture2("git", "ls-files", "-z")
+    raise "git ls-files failed" unless status.success?
+
+    paths.split("\0").filter_map do |path|
+      next unless ROOT_RUBY_FILES.include?(path) ||
+                  RUBY_EXTENSIONS.include?(File.extname(path)) ||
+                  path.start_with?("scripts/")
+
+      source = File.read(path)
+      [path, source] if ruby_source_path?(path, source)
+    end
+  end
+
+  def validate
+    tracked_ruby_sources.flat_map { |path, source| violations_for(path, source) }
+  end
+end

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "open3"
 require "ripper"
 require "rubocop"
@@ -7,11 +8,11 @@ require "rubocop"
 module RuboCopDirectiveGuard
   DirectiveText = Data.define(:text)
   TODO_OWNER = /(?:\A|;)\s*owner:\s*[^;\s]+/
-  TODO_REMOVAL = %r{
-    (?:\A|;)\s*
-    (?:issue:\s*(?:\#\d+|https?://[^;\s]+)|remove-by:\s*\d{4}-\d{2}-\d{2})
+  TODO_ISSUE = %r{
+    (?:\A|;)\s*issue:\s*(?:\#\d+|https?://[^;\s]+)
     (?=\s*(?:;|\z))
   }x
+  TODO_REMOVE_BY = /(?:\A|;)\s*remove-by:\s*(\d{4}-\d{2}-\d{2})(?=\s*(?:;|\z))/
 
   module_function
 
@@ -21,7 +22,7 @@ module RuboCopDirectiveGuard
       next unless token == :on_comment
 
       directive = RuboCop::DirectiveComment.new(DirectiveText.new(comment), nil)
-      next if directive.mode.nil? || directive.malformed?
+      next if directive.mode.nil?
 
       action = directive.mode
       cops = directive.raw_cop_names
@@ -40,12 +41,26 @@ module RuboCopDirectiveGuard
       unless metadata&.match?(TODO_OWNER)
         violations << "#{path}:#{line_number}: rubocop:todo requires `owner: ...` metadata"
       end
-      unless metadata&.match?(TODO_REMOVAL)
+      unless valid_todo_removal?(metadata)
         violations <<
           "#{path}:#{line_number}: rubocop:todo requires `issue: #123` or `remove-by: YYYY-MM-DD` metadata"
       end
     end
     violations
+  end
+
+  def valid_todo_removal?(metadata)
+    return false if metadata.nil?
+    return true if metadata.match?(TODO_ISSUE)
+
+    metadata.scan(TODO_REMOVE_BY).flatten.any? { valid_iso_date?(_1) }
+  end
+
+  def valid_iso_date?(value)
+    Date.iso8601(value)
+    true
+  rescue Date::Error
+    false
   end
 
   def tracked_ruby_sources

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -2,9 +2,10 @@
 
 require "open3"
 require "ripper"
+require "rubocop/directive_comment"
 
 module RuboCopDirectiveGuard
-  DIRECTIVE = /#\s*rubocop:(disable|todo)\s+(.+?)(?:\s+--\s+(.+))?\s*$/
+  DirectiveText = Data.define(:text)
   EXCLUDED_PREFIXES = %w[
     sorbet/rbi/annotations/
     sorbet/rbi/gems/
@@ -35,11 +36,12 @@ module RuboCopDirectiveGuard
     Ripper.lex(source).each do |(line_number, _column), token, comment, _state|
       next unless token == :on_comment
 
-      match = DIRECTIVE.match(comment)
-      next if match.nil?
+      directive = RuboCop::DirectiveComment.new(DirectiveText.new(comment), nil)
+      next if directive.mode.nil? || directive.malformed?
 
-      action, cop_text, metadata = match.captures
-      cops = cop_text.split(",").map(&:strip)
+      action = directive.mode
+      cops = directive.raw_cop_names
+      metadata = comment.partition("--").then { |_, marker, text| text if marker == "--" }
       if cops.any? { _1.casecmp("all").zero? }
         violations << "#{path}:#{line_number}: rubocop:#{action} all is forbidden"
       end
@@ -68,6 +70,7 @@ module RuboCopDirectiveGuard
       next unless ROOT_RUBY_FILES.include?(path) ||
                   RUBY_EXTENSIONS.include?(File.extname(path)) ||
                   path.start_with?("scripts/")
+      next unless File.file?(path)
 
       source = File.read(path)
       [path, source] if ruby_source_path?(path, source)

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -11,10 +11,14 @@ module RuboCopDirectiveGuard
     sorbet/tapioca/
     vendor/
   ].freeze
-  ROOT_RUBY_FILES = %w[Gemfile Rakefile].freeze
+  ROOT_RUBY_FILES = %w[Gemfile Rakefile Steepfile].freeze
   RUBY_EXTENSIONS = %w[.gemspec .rake .rb .rbi].freeze
   TODO_OWNER = /(?:\A|;)\s*owner:\s*[^;\s]+/
-  TODO_REMOVAL = %r{(?:\A|;)\s*(?:issue:\s*(?:#\d+|https?://[^;\s]+)|remove-by:\s*\d{4}-\d{2}-\d{2})}
+  TODO_REMOVAL = %r{
+    (?:\A|;)\s*
+    (?:issue:\s*(?:\#\d+|https?://[^;\s]+)|remove-by:\s*\d{4}-\d{2}-\d{2})
+    (?=\s*(?:;|\z))
+  }x
 
   module_function
 

--- a/scripts/validate-rubocop-directives
+++ b/scripts/validate-rubocop-directives
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "rubocop_directive_guard"
+
+if $PROGRAM_NAME == __FILE__
+  violations = RuboCopDirectiveGuard.validate
+  if violations.empty?
+    puts("Validated RuboCop directives with no errors.")
+  else
+    warn(violations.join("\n"))
+    exit(1)
+  end
+end

--- a/test/openai/resources/audio/transcriptions_test.rb
+++ b/test/openai/resources/audio/transcriptions_test.rb
@@ -13,9 +13,12 @@ class OpenAI::Test::Resources::Audio::TranscriptionsTest < OpenAI::Test::Resourc
 
     assert_pattern do
       case response
-      in OpenAI::Audio::Transcription
-      in OpenAI::Audio::TranscriptionDiarized
-      in OpenAI::Audio::TranscriptionVerbose
+      in (
+        OpenAI::Audio::Transcription |
+        OpenAI::Audio::TranscriptionDiarized |
+        OpenAI::Audio::TranscriptionVerbose
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/audio/translations_test.rb
+++ b/test/openai/resources/audio/translations_test.rb
@@ -12,8 +12,11 @@ class OpenAI::Test::Resources::Audio::TranslationsTest < OpenAI::Test::ResourceT
 
     assert_pattern do
       case response
-      in OpenAI::Audio::Translation
-      in OpenAI::Audio::TranslationVerbose
+      in (
+        OpenAI::Audio::Translation |
+        OpenAI::Audio::TranslationVerbose
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/beta/chatkit/threads_test.rb
+++ b/test/openai/resources/beta/chatkit/threads_test.rb
@@ -80,83 +80,89 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
 
     assert_pattern do
       case row
-      in OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem
-      in OpenAI::Beta::ChatKit::ChatKitThreadAssistantMessageItem
-      in OpenAI::Beta::ChatKit::ChatKitWidgetItem
-      in OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall
-      in OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask
-      in OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup
+      in (
+        OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem |
+        OpenAI::Beta::ChatKit::ChatKitThreadAssistantMessageItem |
+        OpenAI::Beta::ChatKit::ChatKitWidgetItem |
+        OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall |
+        OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask |
+        OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :"chatkit.user_message",
-        id: String,
-        attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
-        content:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content
-            ]
-          ),
-        created_at: Integer,
-        inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
-        object: Symbol,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.assistant_message",
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitResponseOutputText]),
-        created_at: Integer,
-        object: Symbol,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.widget",
-        id: String,
-        created_at: Integer,
-        object: Symbol,
-        thread_id: String,
-        widget: String
-      }
-      in {
-        type: :"chatkit.client_tool_call",
-        id: String,
-        arguments: String,
-        call_id: String,
-        created_at: Integer,
-        name: String,
-        object: Symbol,
-        output: String | nil,
-        status: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall::Status,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.task",
-        id: String,
-        created_at: Integer,
-        heading: String | nil,
-        object: Symbol,
-        summary: String | nil,
-        task_type: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask::TaskType,
-        thread_id: String
-      }
-      in {
-        type: :"chatkit.task_group",
-        id: String,
-        created_at: Integer,
-        object: Symbol,
-        tasks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task
-            ]
-          ),
-        thread_id: String
-      }
+      in (
+        {
+          type: :"chatkit.user_message",
+          id: String,
+          attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content
+              ]
+            ),
+          created_at: Integer,
+          inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
+          object: Symbol,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.assistant_message",
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitResponseOutputText]),
+          created_at: Integer,
+          object: Symbol,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.widget",
+          id: String,
+          created_at: Integer,
+          object: Symbol,
+          thread_id: String,
+          widget: String
+        } |
+        {
+          type: :"chatkit.client_tool_call",
+          id: String,
+          arguments: String,
+          call_id: String,
+          created_at: Integer,
+          name: String,
+          object: Symbol,
+          output: String | nil,
+          status: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall::Status,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.task",
+          id: String,
+          created_at: Integer,
+          heading: String | nil,
+          object: Symbol,
+          summary: String | nil,
+          task_type: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask::TaskType,
+          thread_id: String
+        } |
+        {
+          type: :"chatkit.task_group",
+          id: String,
+          created_at: Integer,
+          object: Symbol,
+          tasks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task
+              ]
+            ),
+          thread_id: String
+        }
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/beta/responses/input_items_test.rb
+++ b/test/openai/resources/beta/responses/input_items_test.rb
@@ -19,329 +19,335 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
 
     assert_pattern do
       case row
-      in OpenAI::Beta::BetaResponseInputMessageItem
-      in OpenAI::Beta::BetaResponseOutputMessage
-      in OpenAI::Beta::BetaResponseFileSearchToolCall
-      in OpenAI::Beta::BetaResponseComputerToolCall
-      in OpenAI::Beta::BetaResponseComputerToolCallOutputItem
-      in OpenAI::Beta::BetaResponseFunctionWebSearch
-      in OpenAI::Beta::BetaResponseFunctionToolCallItem
-      in OpenAI::Beta::BetaResponseFunctionToolCallOutputItem
-      in OpenAI::Beta::BetaResponseItem::AgentMessage
-      in OpenAI::Beta::BetaResponseItem::MultiAgentCall
-      in OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput
-      in OpenAI::Beta::BetaResponseToolSearchCall
-      in OpenAI::Beta::BetaResponseToolSearchOutputItem
-      in OpenAI::Beta::BetaResponseItem::AdditionalTools
-      in OpenAI::Beta::BetaResponseReasoningItem
-      in OpenAI::Beta::BetaResponseItem::Program
-      in OpenAI::Beta::BetaResponseItem::ProgramOutput
-      in OpenAI::Beta::BetaResponseCompactionItem
-      in OpenAI::Beta::BetaResponseItem::ImageGenerationCall
-      in OpenAI::Beta::BetaResponseCodeInterpreterToolCall
-      in OpenAI::Beta::BetaResponseItem::LocalShellCall
-      in OpenAI::Beta::BetaResponseItem::LocalShellCallOutput
-      in OpenAI::Beta::BetaResponseFunctionShellToolCall
-      in OpenAI::Beta::BetaResponseFunctionShellToolCallOutput
-      in OpenAI::Beta::BetaResponseApplyPatchToolCall
-      in OpenAI::Beta::BetaResponseApplyPatchToolCallOutput
-      in OpenAI::Beta::BetaResponseItem::McpListTools
-      in OpenAI::Beta::BetaResponseItem::McpApprovalRequest
-      in OpenAI::Beta::BetaResponseItem::McpApprovalResponse
-      in OpenAI::Beta::BetaResponseItem::McpCall
-      in OpenAI::Beta::BetaResponseCustomToolCallItem
-      in OpenAI::Beta::BetaResponseCustomToolCallOutputItem
+      in (
+        OpenAI::Beta::BetaResponseInputMessageItem |
+        OpenAI::Beta::BetaResponseOutputMessage |
+        OpenAI::Beta::BetaResponseFileSearchToolCall |
+        OpenAI::Beta::BetaResponseComputerToolCall |
+        OpenAI::Beta::BetaResponseComputerToolCallOutputItem |
+        OpenAI::Beta::BetaResponseFunctionWebSearch |
+        OpenAI::Beta::BetaResponseFunctionToolCallItem |
+        OpenAI::Beta::BetaResponseFunctionToolCallOutputItem |
+        OpenAI::Beta::BetaResponseItem::AgentMessage |
+        OpenAI::Beta::BetaResponseItem::MultiAgentCall |
+        OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput |
+        OpenAI::Beta::BetaResponseToolSearchCall |
+        OpenAI::Beta::BetaResponseToolSearchOutputItem |
+        OpenAI::Beta::BetaResponseItem::AdditionalTools |
+        OpenAI::Beta::BetaResponseReasoningItem |
+        OpenAI::Beta::BetaResponseItem::Program |
+        OpenAI::Beta::BetaResponseItem::ProgramOutput |
+        OpenAI::Beta::BetaResponseCompactionItem |
+        OpenAI::Beta::BetaResponseItem::ImageGenerationCall |
+        OpenAI::Beta::BetaResponseCodeInterpreterToolCall |
+        OpenAI::Beta::BetaResponseItem::LocalShellCall |
+        OpenAI::Beta::BetaResponseItem::LocalShellCallOutput |
+        OpenAI::Beta::BetaResponseFunctionShellToolCall |
+        OpenAI::Beta::BetaResponseFunctionShellToolCallOutput |
+        OpenAI::Beta::BetaResponseApplyPatchToolCall |
+        OpenAI::Beta::BetaResponseApplyPatchToolCallOutput |
+        OpenAI::Beta::BetaResponseItem::McpListTools |
+        OpenAI::Beta::BetaResponseItem::McpApprovalRequest |
+        OpenAI::Beta::BetaResponseItem::McpApprovalResponse |
+        OpenAI::Beta::BetaResponseItem::McpCall |
+        OpenAI::Beta::BetaResponseCustomToolCallItem |
+        OpenAI::Beta::BetaResponseCustomToolCallOutputItem
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseInputContent]),
-        role: OpenAI::Beta::BetaResponseInputMessageItem::Role,
-        agent: OpenAI::Beta::BetaResponseInputMessageItem::Agent | nil,
-        status: OpenAI::Beta::BetaResponseInputMessageItem::Status | nil
-      }
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseOutputMessage::Content]),
-        role: Symbol,
-        status: OpenAI::Beta::BetaResponseOutputMessage::Status,
-        agent: OpenAI::Beta::BetaResponseOutputMessage::Agent | nil,
-        phase: OpenAI::Beta::BetaResponseOutputMessage::Phase | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
-        action: OpenAI::Beta::BetaComputerAction | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
-        agent: OpenAI::Beta::BetaResponseComputerToolCall::Agent | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseFunctionWebSearch::Action,
-        status: OpenAI::Beta::BetaResponseFunctionWebSearch::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionWebSearch::Agent | nil
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :agent_message,
-        id: String,
-        author: String,
-        content:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content
-            ]
-          ),
-        recipient: String,
-        agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
-      }
-      in {
-        type: :multi_agent_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Action,
-        arguments: String,
-        call_id: String,
-        agent: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Agent | nil
-      }
-      in {
-        type: :multi_agent_call_output,
-        id: String,
-        action: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Action,
-        call_id: String,
-        output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseOutputText]),
-        agent: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Agent | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Beta::BetaResponseToolSearchCall::Execution,
-        status: OpenAI::Beta::BetaResponseToolSearchCall::Status,
-        agent: OpenAI::Beta::BetaResponseToolSearchCall::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Beta::BetaResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Beta::BetaResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
-        agent: OpenAI::Beta::BetaResponseToolSearchOutputItem::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Beta::BetaResponseItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
-        agent: OpenAI::Beta::BetaResponseItem::AdditionalTools::Agent | nil
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Summary]),
-        agent: OpenAI::Beta::BetaResponseReasoningItem::Agent | nil,
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Beta::BetaResponseReasoningItem::Status | nil
-      }
-      in {
-        type: :program,
-        id: String,
-        call_id: String,
-        code: String,
-        fingerprint: String,
-        agent: OpenAI::Beta::BetaResponseItem::Program::Agent | nil
-      }
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Beta::BetaResponseItem::ProgramOutput::Status,
-        agent: OpenAI::Beta::BetaResponseItem::ProgramOutput::Agent | nil
-      }
-      in {
-        type: :compaction,
-        id: String,
-        encrypted_content: String,
-        agent: OpenAI::Beta::BetaResponseCompactionItem::Agent | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Status,
-        agent: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Agent | nil
-      }
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Beta::BetaResponseItem::LocalShellCall::Status,
-        agent: OpenAI::Beta::BetaResponseItem::LocalShellCall::Agent | nil
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        agent: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Agent | nil,
-        status: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Beta::BetaResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Beta::BetaResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Beta::BetaResponseFunctionShellToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionShellToolCall::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
-        agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Beta::BetaResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Beta::BetaResponseApplyPatchToolCall::Status,
-        agent: OpenAI::Beta::BetaResponseApplyPatchToolCall::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Status,
-        agent: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Agent | nil,
-        caller_: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseItem::McpListTools::Tool]),
-        agent: OpenAI::Beta::BetaResponseItem::McpListTools::Agent | nil,
-        error: String | nil
-      }
-      in {
-        type: :mcp_approval_request,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        agent: OpenAI::Beta::BetaResponseItem::McpApprovalRequest::Agent | nil
-      }
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        agent: OpenAI::Beta::BetaResponseItem::McpApprovalResponse::Agent | nil,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        agent: OpenAI::Beta::BetaResponseItem::McpCall::Agent | nil,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Beta::BetaResponseItem::McpCall::Status | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseInputContent]),
+          role: OpenAI::Beta::BetaResponseInputMessageItem::Role,
+          agent: OpenAI::Beta::BetaResponseInputMessageItem::Agent | nil,
+          status: OpenAI::Beta::BetaResponseInputMessageItem::Status | nil
+        } |
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseOutputMessage::Content]),
+          role: Symbol,
+          status: OpenAI::Beta::BetaResponseOutputMessage::Status,
+          agent: OpenAI::Beta::BetaResponseOutputMessage::Agent | nil,
+          phase: OpenAI::Beta::BetaResponseOutputMessage::Phase | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
+          action: OpenAI::Beta::BetaComputerAction | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
+          agent: OpenAI::Beta::BetaResponseComputerToolCall::Agent | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseFunctionWebSearch::Action,
+          status: OpenAI::Beta::BetaResponseFunctionWebSearch::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionWebSearch::Agent | nil
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :agent_message,
+          id: String,
+          author: String,
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content
+              ]
+            ),
+          recipient: String,
+          agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
+        } |
+        {
+          type: :multi_agent_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Action,
+          arguments: String,
+          call_id: String,
+          agent: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Agent | nil
+        } |
+        {
+          type: :multi_agent_call_output,
+          id: String,
+          action: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Action,
+          call_id: String,
+          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseOutputText]),
+          agent: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Agent | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Beta::BetaResponseToolSearchCall::Execution,
+          status: OpenAI::Beta::BetaResponseToolSearchCall::Status,
+          agent: OpenAI::Beta::BetaResponseToolSearchCall::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Beta::BetaResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Beta::BetaResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
+          agent: OpenAI::Beta::BetaResponseToolSearchOutputItem::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Beta::BetaResponseItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
+          agent: OpenAI::Beta::BetaResponseItem::AdditionalTools::Agent | nil
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Summary]),
+          agent: OpenAI::Beta::BetaResponseReasoningItem::Agent | nil,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Content]) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Beta::BetaResponseReasoningItem::Status | nil
+        } |
+        {
+          type: :program,
+          id: String,
+          call_id: String,
+          code: String,
+          fingerprint: String,
+          agent: OpenAI::Beta::BetaResponseItem::Program::Agent | nil
+        } |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Beta::BetaResponseItem::ProgramOutput::Status,
+          agent: OpenAI::Beta::BetaResponseItem::ProgramOutput::Agent | nil
+        } |
+        {
+          type: :compaction,
+          id: String,
+          encrypted_content: String,
+          agent: OpenAI::Beta::BetaResponseCompactionItem::Agent | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Status,
+          agent: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Agent | nil
+        } |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Beta::BetaResponseItem::LocalShellCall::Status,
+          agent: OpenAI::Beta::BetaResponseItem::LocalShellCall::Agent | nil
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          agent: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Agent | nil,
+          status: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Beta::BetaResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Beta::BetaResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Beta::BetaResponseFunctionShellToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionShellToolCall::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
+          agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Beta::BetaResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Beta::BetaResponseApplyPatchToolCall::Status,
+          agent: OpenAI::Beta::BetaResponseApplyPatchToolCall::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Status,
+          agent: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Agent | nil,
+          caller_: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseItem::McpListTools::Tool]),
+          agent: OpenAI::Beta::BetaResponseItem::McpListTools::Agent | nil,
+          error: String | nil
+        } |
+        {
+          type: :mcp_approval_request,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          agent: OpenAI::Beta::BetaResponseItem::McpApprovalRequest::Agent | nil
+        } |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          agent: OpenAI::Beta::BetaResponseItem::McpApprovalResponse::Agent | nil,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          agent: OpenAI::Beta::BetaResponseItem::McpCall::Agent | nil,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Beta::BetaResponseItem::McpCall::Status | nil
+        }
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/conversations/items_test.rb
+++ b/test/openai/resources/conversations/items_test.rb
@@ -34,267 +34,278 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
 
     assert_pattern do
       case response
-      in OpenAI::Conversations::Message
-      in OpenAI::Responses::ResponseFunctionToolCallItem
-      in OpenAI::Responses::ResponseFunctionToolCallOutputItem
-      in OpenAI::Responses::ResponseFileSearchToolCall
-      in OpenAI::Responses::ResponseFunctionWebSearch
-      in OpenAI::Conversations::ConversationItem::ImageGenerationCall
-      in OpenAI::Responses::ResponseComputerToolCall
-      in OpenAI::Responses::ResponseComputerToolCallOutputItem
-      in OpenAI::Responses::ResponseToolSearchCall
-      in OpenAI::Responses::ResponseToolSearchOutputItem
-      in OpenAI::Conversations::ConversationItem::AdditionalTools
-      in OpenAI::Responses::ResponseReasoningItem
-      in OpenAI::Conversations::ConversationItem::Program
-      in OpenAI::Conversations::ConversationItem::ProgramOutput
-      in OpenAI::Responses::ResponseCompactionItem
-      in OpenAI::Responses::ResponseCodeInterpreterToolCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCallOutput
-      in OpenAI::Responses::ResponseFunctionShellToolCall
-      in OpenAI::Responses::ResponseFunctionShellToolCallOutput
-      in OpenAI::Responses::ResponseApplyPatchToolCall
-      in OpenAI::Responses::ResponseApplyPatchToolCallOutput
-      in OpenAI::Conversations::ConversationItem::McpListTools
-      in OpenAI::Conversations::ConversationItem::McpApprovalRequest
-      in OpenAI::Conversations::ConversationItem::McpApprovalResponse
-      in OpenAI::Conversations::ConversationItem::McpCall
-      in OpenAI::Responses::ResponseCustomToolCall
-      in OpenAI::Responses::ResponseCustomToolCallOutput
+      in (
+        OpenAI::Conversations::Message |
+        OpenAI::Responses::ResponseFunctionToolCallItem |
+        OpenAI::Responses::ResponseFunctionToolCallOutputItem |
+        OpenAI::Responses::ResponseFileSearchToolCall |
+        OpenAI::Responses::ResponseFunctionWebSearch |
+        OpenAI::Conversations::ConversationItem::ImageGenerationCall |
+        OpenAI::Responses::ResponseComputerToolCall |
+        OpenAI::Responses::ResponseComputerToolCallOutputItem |
+        OpenAI::Responses::ResponseToolSearchCall |
+        OpenAI::Responses::ResponseToolSearchOutputItem |
+        OpenAI::Conversations::ConversationItem::AdditionalTools |
+        OpenAI::Responses::ResponseReasoningItem |
+        OpenAI::Conversations::ConversationItem::Program |
+        OpenAI::Conversations::ConversationItem::ProgramOutput |
+        OpenAI::Responses::ResponseCompactionItem |
+        OpenAI::Responses::ResponseCodeInterpreterToolCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCallOutput |
+        OpenAI::Responses::ResponseFunctionShellToolCall |
+        OpenAI::Responses::ResponseFunctionShellToolCallOutput |
+        OpenAI::Responses::ResponseApplyPatchToolCall |
+        OpenAI::Responses::ResponseApplyPatchToolCallOutput |
+        OpenAI::Conversations::ConversationItem::McpListTools |
+        OpenAI::Conversations::ConversationItem::McpApprovalRequest |
+        OpenAI::Conversations::ConversationItem::McpApprovalResponse |
+        OpenAI::Conversations::ConversationItem::McpCall |
+        OpenAI::Responses::ResponseCustomToolCall |
+        OpenAI::Responses::ResponseCustomToolCallOutput
+      )
+        nil
       end
     end
 
     assert_pattern do
       case response
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
-        role: OpenAI::Conversations::Message::Role,
-        status: OpenAI::Conversations::Message::Status,
-        phase: OpenAI::Conversations::Message::Phase | nil
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-        caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-        status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-      }
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Responses::ResponseComputerToolCall::Status,
-        action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-        status: OpenAI::Responses::ResponseToolSearchCall::Status,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-      }
-      in {type: :program, id: String, call_id: String, code: String, fingerprint: String}
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
-      }
-      in {type: :compaction, id: String, encrypted_content: String, created_by: String | nil}
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Conversations::ConversationItem::McpListTools::Tool
-            ]
-          ),
-        error: String | nil
-      }
-      in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
-      }
-      in {
-        type: :custom_tool_call,
-        call_id: String,
-        input: String,
-        name: String,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :custom_tool_call_output,
-        call_id: String,
-        output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
+          role: OpenAI::Conversations::Message::Role,
+          status: OpenAI::Conversations::Message::Status,
+          phase: OpenAI::Conversations::Message::Phase | nil
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
+          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
+          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
+        } |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Responses::ResponseComputerToolCall::Status,
+          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
+          status: OpenAI::Responses::ResponseToolSearchCall::Status,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseReasoningItem::Content
+              ]
+            ) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
+        } |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
+        } |
+        {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Conversations::ConversationItem::McpListTools::Tool
+              ]
+            ),
+          error: String | nil
+        } |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
+        } |
+        {
+          type: :custom_tool_call,
+          call_id: String,
+          input: String,
+          name: String,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :custom_tool_call_output,
+          call_id: String,
+          output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
+        }
+      )
+        nil
       end
     end
   end
@@ -315,267 +326,278 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
 
     assert_pattern do
       case row
-      in OpenAI::Conversations::Message
-      in OpenAI::Responses::ResponseFunctionToolCallItem
-      in OpenAI::Responses::ResponseFunctionToolCallOutputItem
-      in OpenAI::Responses::ResponseFileSearchToolCall
-      in OpenAI::Responses::ResponseFunctionWebSearch
-      in OpenAI::Conversations::ConversationItem::ImageGenerationCall
-      in OpenAI::Responses::ResponseComputerToolCall
-      in OpenAI::Responses::ResponseComputerToolCallOutputItem
-      in OpenAI::Responses::ResponseToolSearchCall
-      in OpenAI::Responses::ResponseToolSearchOutputItem
-      in OpenAI::Conversations::ConversationItem::AdditionalTools
-      in OpenAI::Responses::ResponseReasoningItem
-      in OpenAI::Conversations::ConversationItem::Program
-      in OpenAI::Conversations::ConversationItem::ProgramOutput
-      in OpenAI::Responses::ResponseCompactionItem
-      in OpenAI::Responses::ResponseCodeInterpreterToolCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCall
-      in OpenAI::Conversations::ConversationItem::LocalShellCallOutput
-      in OpenAI::Responses::ResponseFunctionShellToolCall
-      in OpenAI::Responses::ResponseFunctionShellToolCallOutput
-      in OpenAI::Responses::ResponseApplyPatchToolCall
-      in OpenAI::Responses::ResponseApplyPatchToolCallOutput
-      in OpenAI::Conversations::ConversationItem::McpListTools
-      in OpenAI::Conversations::ConversationItem::McpApprovalRequest
-      in OpenAI::Conversations::ConversationItem::McpApprovalResponse
-      in OpenAI::Conversations::ConversationItem::McpCall
-      in OpenAI::Responses::ResponseCustomToolCall
-      in OpenAI::Responses::ResponseCustomToolCallOutput
+      in (
+        OpenAI::Conversations::Message |
+        OpenAI::Responses::ResponseFunctionToolCallItem |
+        OpenAI::Responses::ResponseFunctionToolCallOutputItem |
+        OpenAI::Responses::ResponseFileSearchToolCall |
+        OpenAI::Responses::ResponseFunctionWebSearch |
+        OpenAI::Conversations::ConversationItem::ImageGenerationCall |
+        OpenAI::Responses::ResponseComputerToolCall |
+        OpenAI::Responses::ResponseComputerToolCallOutputItem |
+        OpenAI::Responses::ResponseToolSearchCall |
+        OpenAI::Responses::ResponseToolSearchOutputItem |
+        OpenAI::Conversations::ConversationItem::AdditionalTools |
+        OpenAI::Responses::ResponseReasoningItem |
+        OpenAI::Conversations::ConversationItem::Program |
+        OpenAI::Conversations::ConversationItem::ProgramOutput |
+        OpenAI::Responses::ResponseCompactionItem |
+        OpenAI::Responses::ResponseCodeInterpreterToolCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCall |
+        OpenAI::Conversations::ConversationItem::LocalShellCallOutput |
+        OpenAI::Responses::ResponseFunctionShellToolCall |
+        OpenAI::Responses::ResponseFunctionShellToolCallOutput |
+        OpenAI::Responses::ResponseApplyPatchToolCall |
+        OpenAI::Responses::ResponseApplyPatchToolCallOutput |
+        OpenAI::Conversations::ConversationItem::McpListTools |
+        OpenAI::Conversations::ConversationItem::McpApprovalRequest |
+        OpenAI::Conversations::ConversationItem::McpApprovalResponse |
+        OpenAI::Conversations::ConversationItem::McpCall |
+        OpenAI::Responses::ResponseCustomToolCall |
+        OpenAI::Responses::ResponseCustomToolCallOutput
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
-        role: OpenAI::Conversations::Message::Role,
-        status: OpenAI::Conversations::Message::Status,
-        phase: OpenAI::Conversations::Message::Phase | nil
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-        caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-        status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-      }
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Responses::ResponseComputerToolCall::Status,
-        action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-        status: OpenAI::Responses::ResponseToolSearchCall::Status,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-      }
-      in {type: :program, id: String, call_id: String, code: String, fingerprint: String}
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
-      }
-      in {type: :compaction, id: String, encrypted_content: String, created_by: String | nil}
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Conversations::ConversationItem::McpListTools::Tool
-            ]
-          ),
-        error: String | nil
-      }
-      in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
-      }
-      in {
-        type: :custom_tool_call,
-        call_id: String,
-        input: String,
-        name: String,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :custom_tool_call_output,
-        call_id: String,
-        output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
-        id: String | nil,
-        caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
+          role: OpenAI::Conversations::Message::Role,
+          status: OpenAI::Conversations::Message::Status,
+          phase: OpenAI::Conversations::Message::Phase | nil
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
+          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
+          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
+        } |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Responses::ResponseComputerToolCall::Status,
+          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
+          status: OpenAI::Responses::ResponseToolSearchCall::Status,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseReasoningItem::Content
+              ]
+            ) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
+        } |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
+        } |
+        {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Conversations::ConversationItem::McpListTools::Tool
+              ]
+            ),
+          error: String | nil
+        } |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
+        } |
+        {
+          type: :custom_tool_call,
+          call_id: String,
+          input: String,
+          name: String,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :custom_tool_call_output,
+          call_id: String,
+          output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
+          id: String | nil,
+          caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
+        }
+      )
+        nil
       end
     end
   end

--- a/test/openai/resources/responses/input_items_test.rb
+++ b/test/openai/resources/responses/input_items_test.rb
@@ -19,254 +19,265 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
 
     assert_pattern do
       case row
-      in OpenAI::Responses::ResponseInputMessageItem
-      in OpenAI::Responses::ResponseOutputMessage
-      in OpenAI::Responses::ResponseFileSearchToolCall
-      in OpenAI::Responses::ResponseComputerToolCall
-      in OpenAI::Responses::ResponseComputerToolCallOutputItem
-      in OpenAI::Responses::ResponseFunctionWebSearch
-      in OpenAI::Responses::ResponseFunctionToolCallItem
-      in OpenAI::Responses::ResponseFunctionToolCallOutputItem
-      in OpenAI::Responses::ResponseToolSearchCall
-      in OpenAI::Responses::ResponseToolSearchOutputItem
-      in OpenAI::Responses::ResponseItem::AdditionalTools
-      in OpenAI::Responses::ResponseReasoningItem
-      in OpenAI::Responses::ResponseItem::Program
-      in OpenAI::Responses::ResponseItem::ProgramOutput
-      in OpenAI::Responses::ResponseCompactionItem
-      in OpenAI::Responses::ResponseItem::ImageGenerationCall
-      in OpenAI::Responses::ResponseCodeInterpreterToolCall
-      in OpenAI::Responses::ResponseItem::LocalShellCall
-      in OpenAI::Responses::ResponseItem::LocalShellCallOutput
-      in OpenAI::Responses::ResponseFunctionShellToolCall
-      in OpenAI::Responses::ResponseFunctionShellToolCallOutput
-      in OpenAI::Responses::ResponseApplyPatchToolCall
-      in OpenAI::Responses::ResponseApplyPatchToolCallOutput
-      in OpenAI::Responses::ResponseItem::McpListTools
-      in OpenAI::Responses::ResponseItem::McpApprovalRequest
-      in OpenAI::Responses::ResponseItem::McpApprovalResponse
-      in OpenAI::Responses::ResponseItem::McpCall
-      in OpenAI::Responses::ResponseCustomToolCallItem
-      in OpenAI::Responses::ResponseCustomToolCallOutputItem
+      in (
+        OpenAI::Responses::ResponseInputMessageItem |
+        OpenAI::Responses::ResponseOutputMessage |
+        OpenAI::Responses::ResponseFileSearchToolCall |
+        OpenAI::Responses::ResponseComputerToolCall |
+        OpenAI::Responses::ResponseComputerToolCallOutputItem |
+        OpenAI::Responses::ResponseFunctionWebSearch |
+        OpenAI::Responses::ResponseFunctionToolCallItem |
+        OpenAI::Responses::ResponseFunctionToolCallOutputItem |
+        OpenAI::Responses::ResponseToolSearchCall |
+        OpenAI::Responses::ResponseToolSearchOutputItem |
+        OpenAI::Responses::ResponseItem::AdditionalTools |
+        OpenAI::Responses::ResponseReasoningItem |
+        OpenAI::Responses::ResponseItem::Program |
+        OpenAI::Responses::ResponseItem::ProgramOutput |
+        OpenAI::Responses::ResponseCompactionItem |
+        OpenAI::Responses::ResponseItem::ImageGenerationCall |
+        OpenAI::Responses::ResponseCodeInterpreterToolCall |
+        OpenAI::Responses::ResponseItem::LocalShellCall |
+        OpenAI::Responses::ResponseItem::LocalShellCallOutput |
+        OpenAI::Responses::ResponseFunctionShellToolCall |
+        OpenAI::Responses::ResponseFunctionShellToolCallOutput |
+        OpenAI::Responses::ResponseApplyPatchToolCall |
+        OpenAI::Responses::ResponseApplyPatchToolCallOutput |
+        OpenAI::Responses::ResponseItem::McpListTools |
+        OpenAI::Responses::ResponseItem::McpApprovalRequest |
+        OpenAI::Responses::ResponseItem::McpApprovalResponse |
+        OpenAI::Responses::ResponseItem::McpCall |
+        OpenAI::Responses::ResponseCustomToolCallItem |
+        OpenAI::Responses::ResponseCustomToolCallOutputItem
+      )
+        nil
       end
     end
 
     assert_pattern do
       case row
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseInputContent]),
-        role: OpenAI::Responses::ResponseInputMessageItem::Role,
-        status: OpenAI::Responses::ResponseInputMessageItem::Status | nil
-      }
-      in {
-        type: :message,
-        id: String,
-        content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseOutputMessage::Content]),
-        role: Symbol,
-        status: OpenAI::Responses::ResponseOutputMessage::Status,
-        phase: OpenAI::Responses::ResponseOutputMessage::Phase | nil
-      }
-      in {
-        type: :file_search_call,
-        id: String,
-        queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-        status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFileSearchToolCall::Result
-            ]
-          ) | nil
-      }
-      in {
-        type: :computer_call,
-        id: String,
-        call_id: String,
-        pending_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-            ]
-          ),
-        status: OpenAI::Responses::ResponseComputerToolCall::Status,
-        action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-        actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-      }
-      in {
-        type: :computer_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-        status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-        acknowledged_safety_checks:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-            ]
-          ) | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :web_search_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-        status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-      }
-      in {
-        type: :function_call_output,
-        id: String,
-        call_id: String,
-        output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-        status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-        caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-        created_by: String | nil,
-        name: String | nil,
-        namespace: String | nil
-      }
-      in {
-        type: :tool_search_call,
-        id: String,
-        arguments: OpenAI::Internal::Type::Unknown,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-        status: OpenAI::Responses::ResponseToolSearchCall::Status,
-        created_by: String | nil
-      }
-      in {
-        type: :tool_search_output,
-        id: String,
-        call_id: String | nil,
-        execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-        status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-        created_by: String | nil
-      }
-      in {
-        type: :additional_tools,
-        id: String,
-        role: OpenAI::Responses::ResponseItem::AdditionalTools::Role,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-      }
-      in {
-        type: :reasoning,
-        id: String,
-        summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-        content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-        encrypted_content: String | nil,
-        status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-      }
-      in {type: :program, id: String, call_id: String, code: String, fingerprint: String}
-      in {
-        type: :program_output,
-        id: String,
-        call_id: String,
-        result: String,
-        status: OpenAI::Responses::ResponseItem::ProgramOutput::Status
-      }
-      in {type: :compaction, id: String, encrypted_content: String, created_by: String | nil}
-      in {
-        type: :image_generation_call,
-        id: String,
-        result: String | nil,
-        status: OpenAI::Responses::ResponseItem::ImageGenerationCall::Status
-      }
-      in {
-        type: :code_interpreter_call,
-        id: String,
-        code: String | nil,
-        container_id: String,
-        outputs:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-            ]
-          ) | nil,
-        status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-      }
-      in {
-        type: :local_shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseItem::LocalShellCall::Action,
-        call_id: String,
-        status: OpenAI::Responses::ResponseItem::LocalShellCall::Status
-      }
-      in {
-        type: :local_shell_call_output,
-        id: String,
-        output: String,
-        status: OpenAI::Responses::ResponseItem::LocalShellCallOutput::Status | nil
-      }
-      in {
-        type: :shell_call,
-        id: String,
-        action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-        call_id: String,
-        environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-        status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :shell_call_output,
-        id: String,
-        call_id: String,
-        max_output_length: Integer | nil,
-        output:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-            ]
-          ),
-        status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call,
-        id: String,
-        call_id: String,
-        operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-        status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-        created_by: String | nil
-      }
-      in {
-        type: :apply_patch_call_output,
-        id: String,
-        call_id: String,
-        status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-        caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-        created_by: String | nil,
-        output: String | nil
-      }
-      in {
-        type: :mcp_list_tools,
-        id: String,
-        server_label: String,
-        tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseItem::McpListTools::Tool]),
-        error: String | nil
-      }
-      in {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String}
-      in {
-        type: :mcp_approval_response,
-        id: String,
-        approval_request_id: String,
-        approve: OpenAI::Internal::Type::Boolean,
-        reason: String | nil
-      }
-      in {
-        type: :mcp_call,
-        id: String,
-        arguments: String,
-        name: String,
-        server_label: String,
-        approval_request_id: String | nil,
-        error: String | nil,
-        output: String | nil,
-        status: OpenAI::Responses::ResponseItem::McpCall::Status | nil
-      }
+      in (
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseInputContent]),
+          role: OpenAI::Responses::ResponseInputMessageItem::Role,
+          status: OpenAI::Responses::ResponseInputMessageItem::Status | nil
+        } |
+        {
+          type: :message,
+          id: String,
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseOutputMessage::Content]),
+          role: Symbol,
+          status: OpenAI::Responses::ResponseOutputMessage::Status,
+          phase: OpenAI::Responses::ResponseOutputMessage::Phase | nil
+        } |
+        {
+          type: :file_search_call,
+          id: String,
+          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
+          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
+          results:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFileSearchToolCall::Result
+              ]
+            ) | nil
+        } |
+        {
+          type: :computer_call,
+          id: String,
+          call_id: String,
+          pending_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
+              ]
+            ),
+          status: OpenAI::Responses::ResponseComputerToolCall::Status,
+          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
+          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
+        } |
+        {
+          type: :computer_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
+          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
+          acknowledged_safety_checks:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
+              ]
+            ) | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :web_search_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
+          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
+        } |
+        {
+          type: :function_call_output,
+          id: String,
+          call_id: String,
+          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
+          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
+          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
+          created_by: String | nil,
+          name: String | nil,
+          namespace: String | nil
+        } |
+        {
+          type: :tool_search_call,
+          id: String,
+          arguments: OpenAI::Internal::Type::Unknown,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
+          status: OpenAI::Responses::ResponseToolSearchCall::Status,
+          created_by: String | nil
+        } |
+        {
+          type: :tool_search_output,
+          id: String,
+          call_id: String | nil,
+          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
+          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
+          created_by: String | nil
+        } |
+        {
+          type: :additional_tools,
+          id: String,
+          role: OpenAI::Responses::ResponseItem::AdditionalTools::Role,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
+        } |
+        {
+          type: :reasoning,
+          id: String,
+          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
+          content:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseReasoningItem::Content
+              ]
+            ) | nil,
+          encrypted_content: String | nil,
+          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
+        } |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
+        {
+          type: :program_output,
+          id: String,
+          call_id: String,
+          result: String,
+          status: OpenAI::Responses::ResponseItem::ProgramOutput::Status
+        } |
+        {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
+        {
+          type: :image_generation_call,
+          id: String,
+          result: String | nil,
+          status: OpenAI::Responses::ResponseItem::ImageGenerationCall::Status
+        } |
+        {
+          type: :code_interpreter_call,
+          id: String,
+          code: String | nil,
+          container_id: String,
+          outputs:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
+              ]
+            ) | nil,
+          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
+        } |
+        {
+          type: :local_shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseItem::LocalShellCall::Action,
+          call_id: String,
+          status: OpenAI::Responses::ResponseItem::LocalShellCall::Status
+        } |
+        {
+          type: :local_shell_call_output,
+          id: String,
+          output: String,
+          status: OpenAI::Responses::ResponseItem::LocalShellCallOutput::Status | nil
+        } |
+        {
+          type: :shell_call,
+          id: String,
+          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
+          call_id: String,
+          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
+          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :shell_call_output,
+          id: String,
+          call_id: String,
+          max_output_length: Integer | nil,
+          output:
+            ^(
+              OpenAI::Internal::Type::ArrayOf[
+                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
+              ]
+            ),
+          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call,
+          id: String,
+          call_id: String,
+          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
+          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
+          created_by: String | nil
+        } |
+        {
+          type: :apply_patch_call_output,
+          id: String,
+          call_id: String,
+          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
+          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
+          created_by: String | nil,
+          output: String | nil
+        } |
+        {
+          type: :mcp_list_tools,
+          id: String,
+          server_label: String,
+          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseItem::McpListTools::Tool]),
+          error: String | nil
+        } |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
+        {
+          type: :mcp_approval_response,
+          id: String,
+          approval_request_id: String,
+          approve: OpenAI::Internal::Type::Boolean,
+          reason: String | nil
+        } |
+        {
+          type: :mcp_call,
+          id: String,
+          arguments: String,
+          name: String,
+          server_label: String,
+          approval_request_id: String | nil,
+          error: String | nil,
+          output: String | nil,
+          status: OpenAI::Responses::ResponseItem::McpCall::Status | nil
+        }
+      )
+        nil
       end
     end
   end

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+require_relative "../../scripts/rubocop_directive_guard"
+
+class ValidateRuboCopDirectivesTest < Minitest::Test
+  def test_allows_narrow_disable_directives
+    assert_empty(violations("disable Lint/EmptyBlock"))
+  end
+
+  def test_rejects_disable_all
+    assert_includes(violations("disable all").first, "disable all is forbidden")
+  end
+
+  def test_rejects_department_wide_disables
+    assert_includes(violations("disable Lint").first, "department-wide")
+  end
+
+  def test_ignores_directive_text_inside_strings
+    source = %(message = "# rubocop:disable all"\n)
+
+    assert_empty(RuboCopDirectiveGuard.violations_for("example.rb", source))
+  end
+
+  def test_rejects_unowned_todos
+    errors = violations("todo Lint/EmptyBlock -- temporary exception; issue: #123")
+
+    assert(errors.any? { _1.include?("requires `owner: ...`") })
+  end
+
+  def test_rejects_untracked_todos
+    errors = violations("todo Lint/EmptyBlock -- temporary exception; owner: @sdk")
+
+    assert(errors.any? { _1.include?("requires `issue: #123`") })
+  end
+
+  def test_allows_owned_and_tracked_todos
+    assert_empty(
+      violations(
+        "todo Lint/EmptyBlock -- temporary exception; owner: @sdk; remove-by: 2026-09-01"
+      )
+    )
+  end
+
+  def test_recognizes_root_and_extensionless_ruby_entry_points
+    assert(RuboCopDirectiveGuard.ruby_source_path?("Rakefile", ""))
+    assert(RuboCopDirectiveGuard.ruby_source_path?("openai.gemspec", ""))
+    assert(
+      RuboCopDirectiveGuard.ruby_source_path?(
+        "scripts/check",
+        "#!/usr/bin/env ruby\nputs(:ok)\n"
+      )
+    )
+  end
+
+  def test_ignores_dependency_and_generated_tapioca_sources
+    refute(RuboCopDirectiveGuard.ruby_source_path?("vendor/example.rb", ""))
+    refute(RuboCopDirectiveGuard.ruby_source_path?("sorbet/rbi/gems/example.rbi", ""))
+  end
+
+  private
+
+  def violations(body)
+    directive = "# rubocop:#{body}\n"
+    RuboCopDirectiveGuard.violations_for("example.rb", directive)
+  end
+end

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -51,6 +51,17 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     assert_empty(RuboCopDirectiveGuard.violations_for("example.rb", source))
   end
 
+  def test_rejects_prefixed_directives_that_rubocop_applies
+    errors = violations_in("puts('bad') # rationale # rubocop:disable all")
+    assert_includes(errors.first, "disable all is forbidden")
+
+    errors = violations_in(
+      "puts('bad') # rationale # rubocop:todo Style/StringLiterals"
+    )
+    assert(errors.any? { _1.include?("requires `owner: ...`") })
+    assert(errors.any? { _1.include?("requires `issue: #123`") })
+  end
+
   def test_rejects_unowned_todos
     errors = violations("todo Lint/EmptyBlock -- temporary exception; issue: #123")
 
@@ -77,6 +88,17 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
 
       assert(errors.any? { _1.include?("requires `issue: #123`") }, tracking)
     end
+  end
+
+  def test_validates_remove_by_calendar_dates
+    %w[2026-99-99 2026-02-30].each do |date|
+      errors = violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: #{date}")
+      assert(errors.any? { _1.include?("requires `issue: #123`") }, date)
+    end
+
+    assert_empty(
+      violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: 2028-02-29")
+    )
   end
 
   def test_uses_rubocop_source_discovery

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "fileutils"
+require "tmpdir"
 
 require_relative "../../scripts/rubocop_directive_guard"
 
@@ -38,6 +40,11 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     assert_includes(violations("disable Lint").first, "department-wide")
   end
 
+  def test_allows_broad_enable_directives
+    assert_empty(violations("enable all"))
+    assert_empty(violations("enable Metrics"))
+  end
+
   def test_ignores_directive_text_inside_strings
     source = %(message = "# rubocop:disable all"\n)
 
@@ -72,21 +79,18 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     end
   end
 
-  def test_recognizes_root_and_extensionless_ruby_entry_points
-    assert(RuboCopDirectiveGuard.ruby_source_path?("Rakefile", ""))
-    assert(RuboCopDirectiveGuard.ruby_source_path?("Steepfile", ""))
-    assert(RuboCopDirectiveGuard.ruby_source_path?("openai.gemspec", ""))
-    assert(
-      RuboCopDirectiveGuard.ruby_source_path?(
-        "scripts/check",
-        "#!/usr/bin/env ruby\nputs(:ok)\n"
-      )
-    )
-  end
+  def test_uses_rubocop_source_discovery
+    Dir.mktmpdir do |directory|
+      paths = %w[config.ru nested/Rakefile nested/Gemfile nested/example.gemfile]
+      paths.each do |path|
+        full_path = File.join(directory, path)
+        FileUtils.mkdir_p(File.dirname(full_path))
+        File.write(full_path, "puts(:ok)\n")
+      end
 
-  def test_ignores_dependency_and_generated_tapioca_sources
-    refute(RuboCopDirectiveGuard.ruby_source_path?("vendor/example.rb", ""))
-    refute(RuboCopDirectiveGuard.ruby_source_path?("sorbet/rbi/gems/example.rbi", ""))
+      targets = RuboCopDirectiveGuard.rubocop_target_paths(directory)
+      paths.each { assert_includes(targets, File.join(directory, _1)) }
+    end
   end
 
   def test_skips_tracked_sources_missing_from_the_worktree

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -43,8 +43,17 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     )
   end
 
+  def test_rejects_malformed_tracking_values
+    ["issue: #123abc", "remove-by: 2026-09-011"].each do |tracking|
+      errors = violations("todo Lint/EmptyBlock -- owner: @sdk; #{tracking}")
+
+      assert(errors.any? { _1.include?("requires `issue: #123`") }, tracking)
+    end
+  end
+
   def test_recognizes_root_and_extensionless_ruby_entry_points
     assert(RuboCopDirectiveGuard.ruby_source_path?("Rakefile", ""))
+    assert(RuboCopDirectiveGuard.ruby_source_path?("Steepfile", ""))
     assert(RuboCopDirectiveGuard.ruby_source_path?("openai.gemspec", ""))
     assert(
       RuboCopDirectiveGuard.ruby_source_path?(

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -13,6 +13,27 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     assert_includes(violations("disable all").first, "disable all is forbidden")
   end
 
+  def test_matches_rubocop_directive_marker_whitespace
+    [
+      "# rubocop : disable all",
+      "# rubocop: disable all"
+    ].each do |directive|
+      assert_includes(violations_in(directive).first, "disable all is forbidden")
+    end
+
+    errors = violations_in("# rubocop : todo Lint/EmptyBlock")
+    assert(errors.any? { _1.include?("requires `owner: ...`") })
+    assert(errors.any? { _1.include?("requires `issue: #123`") })
+  end
+
+  def test_rejects_broad_disable_with_unspaced_trailing_explanation
+    errors = violations_in(
+      "# rubocop:disable all --https://github.com/openai/openai-ruby/issues/123"
+    )
+
+    assert_includes(errors.first, "disable all is forbidden")
+  end
+
   def test_rejects_department_wide_disables
     assert_includes(violations("disable Lint").first, "department-wide")
   end
@@ -68,10 +89,24 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     refute(RuboCopDirectiveGuard.ruby_source_path?("sorbet/rbi/gems/example.rbi", ""))
   end
 
+  def test_skips_tracked_sources_missing_from_the_worktree
+    status = Minitest::Mock.new
+    status.expect(:success?, true)
+
+    Open3.stub(:capture2, ["missing.rb\0", status]) do
+      assert_empty(RuboCopDirectiveGuard.tracked_ruby_sources)
+    end
+    status.verify
+  end
+
   private
 
   def violations(body)
     directive = "# rubocop:#{body}\n"
     RuboCopDirectiveGuard.violations_for("example.rb", directive)
+  end
+
+  def violations_in(directive)
+    RuboCopDirectiveGuard.violations_for("example.rb", "#{directive}\n")
   end
 end

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -75,11 +75,13 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
   end
 
   def test_allows_owned_and_tracked_todos
-    assert_empty(
-      violations(
-        "todo Lint/EmptyBlock -- temporary exception; owner: @sdk; remove-by: 2026-09-01"
+    Date.stub(:today, Date.new(2026, 8, 13)) do
+      assert_empty(
+        violations(
+          "todo Lint/EmptyBlock -- temporary exception; owner: @sdk; remove-by: 2026-09-01"
+        )
       )
-    )
+    end
   end
 
   def test_rejects_malformed_tracking_values
@@ -91,14 +93,27 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
   end
 
   def test_validates_remove_by_calendar_dates
-    %w[2026-99-99 2026-02-30].each do |date|
-      errors = violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: #{date}")
-      assert(errors.any? { _1.include?("requires `issue: #123`") }, date)
-    end
+    Date.stub(:today, Date.new(2026, 1, 1)) do
+      %w[2026-99-99 2026-02-30].each do |date|
+        errors = violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: #{date}")
+        assert(errors.any? { _1.include?("requires `issue: #123`") }, date)
+      end
 
-    assert_empty(
-      violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: 2028-02-29")
-    )
+      assert_empty(
+        violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: 2028-02-29")
+      )
+    end
+  end
+
+  def test_rejects_expired_remove_by_dates
+    Date.stub(:today, Date.new(2026, 8, 13)) do
+      errors = violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: 2026-08-12")
+      assert(errors.any? { _1.include?("requires `issue: #123`") })
+
+      assert_empty(
+        violations("todo Lint/EmptyBlock -- owner: @sdk; remove-by: 2026-08-13")
+      )
+    end
   end
 
   def test_uses_rubocop_source_discovery


### PR DESCRIPTION
## Summary

- add a required lint subtask that inspects tracked first-party Ruby comments with `Ripper`
- reject `rubocop:disable all` and department-wide disable or TODO directives
- require every `rubocop:todo` to name an owner and either an issue or a removal date
- cover root Ruby entry points, Ruby/RBI/Rake/gemspec files, and extensionless Ruby scripts while excluding dependency/tool-derived trees

## Ratchet evidence

- **Policy change:** new broad and unowned suppression directives now fail `rake lint`
- **Existing violations:** 0
- **Final:** 2,622 Ruby/RBI files lint-clean, including the new guard and its tests
- **Generator impact:** none. `Rakefile`, `scripts/**`, and `test/scripts/**` are SDK-owned and excluded from Castiron generation

## Validation

- `mise x ruby@4.0.6 -- bundle exec rake lint`
- directive guard unit tests: 9 runs / 17 assertions
- Sorbet clean
- 1,212 RBS files valid

Depends on openai/openai-ruby#407.
