### PR TITLE
docs(api): describe response stream event unions

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 5ed901d9-b61d-4024-85c6-3c2c3c644e7b
-openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
-openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
+generation_id: 3e40bcd9-5b91-4cc8-8ae4-93fb791a2b10
+openapi_spec_hash: 143aa2ed6323d61a1834c74044e29d30
+openapi_transformed_spec_hash: 5af6fa4fd590fcc79ba2fdd69b9f7b82
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: 6cd339ea7101be79ffe790f61ecba715a64cd4a3
+codegen_sha: 6e22a7390117c38b78353ac1d0dfe74bbf8844d2

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54296,6 +54296,7 @@ components:
             "sequence_number": 1
           }
     ResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/ResponseAudioDoneEvent'
@@ -77148,6 +77149,7 @@ components:
               when the originating `response.create` event supplied a
               `stream_id`.
     BetaResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'

--- a/lib/openai/models/beta/beta_response_stream_event.rb
+++ b/lib/openai/models/beta/beta_response_stream_event.rb
@@ -3,7 +3,7 @@
 module OpenAI
   module Models
     module Beta
-      # Emitted when there is a partial audio response.
+      # Event emitted while a response is streamed.
       module BetaResponseStreamEvent
         extend OpenAI::Internal::Type::Union
 

--- a/lib/openai/models/responses/response_stream_event.rb
+++ b/lib/openai/models/responses/response_stream_event.rb
@@ -3,7 +3,7 @@
 module OpenAI
   module Models
     module Responses
-      # Emitted when there is a partial audio response.
+      # Event emitted while a response is streamed.
       module ResponseStreamEvent
         extend OpenAI::Internal::Type::Union
 

--- a/rbi/openai/models/beta/beta_response_stream_event.rbi
+++ b/rbi/openai/models/beta/beta_response_stream_event.rbi
@@ -5,7 +5,7 @@ module OpenAI
     BetaResponseStreamEvent = Beta::BetaResponseStreamEvent
 
     module Beta
-      # Emitted when there is a partial audio response.
+      # Event emitted while a response is streamed.
       module BetaResponseStreamEvent
         extend OpenAI::Internal::Type::Union
 

--- a/rbi/openai/models/responses/response_stream_event.rbi
+++ b/rbi/openai/models/responses/response_stream_event.rbi
@@ -3,7 +3,7 @@
 module OpenAI
   module Models
     module Responses
-      # Emitted when there is a partial audio response.
+      # Event emitted while a response is streamed.
       module ResponseStreamEvent
         extend OpenAI::Internal::Type::Union
 


### PR DESCRIPTION
## Summary
- Describe stable and beta Responses streaming unions consistently in Ruby and RBI models.
- Refresh the transformed OpenAPI reference and real Castiron generation metadata.
- Source: https://github.com/openai/openai/pull/1277036
- OpenAPI commit: bc61c5299f7f6fdd6061ccad0ac7e4ec0f659098

## Validation
- Castiron Ruby dry run using the merged upstream line-length renderer fix; no lint suppression.
- Excluded unrelated generated test rewrites; exact relevant-candidate patch identity verified.
- Focused RuboCop and ruby syntax checks pass.