### PR TITLE
fix: enable streaming when retrieving responses

### DIFF
--- a/lib/openai/resources/beta/responses.rb
+++ b/lib/openai/resources/beta/responses.rb
@@ -301,12 +301,12 @@ module OpenAI
         def retrieve_streaming(response_id, params = {})
           query_params = [:include, :include_obfuscation, :starting_after, :stream]
           parsed, options = OpenAI::Beta::ResponseRetrieveParams.dump_request(params)
-          query = OpenAI::Internal::Util.encode_query_params(parsed.slice(*query_params))
           unless parsed.fetch(:stream, true)
             message = "Please use `#retrieve` for the non-streaming use case."
             raise ArgumentError.new(message)
           end
           parsed.store(:stream, true)
+          query = OpenAI::Internal::Util.encode_query_params(parsed.slice(*query_params))
           @client.request(
             method: :get,
             path: ["responses/%1$s?beta=true", response_id],

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -407,12 +407,12 @@ module OpenAI
       # @see OpenAI::Models::Responses::ResponseRetrieveParams
       def retrieve_streaming(response_id, params = {})
         parsed, options = OpenAI::Responses::ResponseRetrieveParams.dump_request(params)
-        query = OpenAI::Internal::Util.encode_query_params(parsed)
         unless parsed.fetch(:stream, true)
           message = "Please use `#retrieve` for the non-streaming use case."
           raise ArgumentError.new(message)
         end
         parsed.store(:stream, true)
+        query = OpenAI::Internal::Util.encode_query_params(parsed)
         @client.request(
           method: :get,
           path: ["responses/%1$s", response_id],

--- a/test/openai/path_parameter_query_test.rb
+++ b/test/openai/path_parameter_query_test.rb
@@ -47,6 +47,73 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
     assert_requested(request)
   end
 
+  def test_response_retrieve_streaming_enables_stream_query_parameter
+    request = stub_response_stream(query: {"stream" => "true"})
+
+    events = @client.responses.retrieve_streaming("resp_audit").to_a
+
+    assert_equal(1, events.length)
+    assert_instance_of(OpenAI::Responses::ResponseTextDeltaEvent, events.first)
+    assert_equal("streamed text", events.first.delta)
+    assert_requested(request)
+  end
+
+  def test_response_retrieve_streaming_preserves_query_parameters
+    request = stub_response_stream(
+      query: {
+        "include" => ["file_search_call.results"],
+        "include_obfuscation" => "false",
+        "starting_after" => "7",
+        "stream" => "true"
+      }
+    )
+
+    events = @client.responses.retrieve_streaming(
+      "resp_audit",
+      include: [:"file_search_call.results"],
+      include_obfuscation: false,
+      starting_after: 7
+    ).to_a
+
+    assert_equal("streamed text", events.first.delta)
+    assert_requested(request)
+  end
+
+  def test_beta_response_retrieve_streaming_enables_stream_query_parameter
+    request = stub_response_stream(query: {"beta" => "true", "stream" => "true"})
+
+    events = @client.beta.responses.retrieve_streaming("resp_audit").to_a
+
+    assert_equal(1, events.length)
+    assert_instance_of(OpenAI::Beta::BetaResponseTextDeltaEvent, events.first)
+    assert_equal("streamed text", events.first.delta)
+    assert_requested(request)
+  end
+
+  def test_beta_response_retrieve_streaming_preserves_query_parameters_and_beta_header
+    request = stub_response_stream(
+      query: {
+        "beta" => "true",
+        "include" => ["file_search_call.results"],
+        "include_obfuscation" => "false",
+        "starting_after" => "7",
+        "stream" => "true"
+      },
+      headers: {"OpenAI-Beta" => "responses_multi_agent=v1"}
+    )
+
+    events = @client.beta.responses.retrieve_streaming(
+      "resp_audit",
+      include: [:"file_search_call.results"],
+      include_obfuscation: false,
+      starting_after: 7,
+      betas: [:"responses_multi_agent=v1"]
+    ).to_a
+
+    assert_equal("streamed text", events.first.delta)
+    assert_requested(request)
+  end
+
   def test_eval_output_items_list_excludes_eval_id
     request = stub_get(
       "/evals/eval_123/runs/run_123/output_items",
@@ -197,6 +264,29 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
   end
 
   private
+
+  def stub_response_stream(query:, headers: {})
+    event = {
+      type: "response.output_text.delta",
+      content_index: 0,
+      delta: "streamed text",
+      item_id: "item_123",
+      logprobs: [],
+      output_index: 0,
+      sequence_number: 8
+    }
+
+    stub_request(:get, "http://localhost/responses/resp_audit")
+      .with(
+        query: query,
+        headers: {"Accept" => "text/event-stream", "Accept-Encoding" => "identity", **headers}
+      )
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: "event: response.output_text.delta\ndata: #{JSON.generate(event)}\n\n"
+      )
+  end
 
   def stub_get(path, query:, body: {data: [], has_more: false})
     stub_request(:get, "http://localhost#{path}")


### PR DESCRIPTION
## Summary

- Fix stable and beta `retrieve_streaming` methods that encoded GET query parameters before adding their implicit `stream=true` discriminator, causing normal JSON responses to be exposed as empty event streams.
- Preserve existing `include`, `starting_after`, `include_obfuscation`, `beta=true`, streaming transport headers, and beta feature headers.
- Add four WebMock transport regressions that assert the actual request query and decode real server-sent events without passing `stream:` explicitly.

## Verification

- `bundle exec rake test`: 699 tests and 3,142 assertions pass on Ruby 3.3.12, 3.4.10, and 4.0.6.
- `bundle exec rake lint:rubocop`: 2,618 files pass.
- `bundle exec rake typecheck:sorbet`: passes.
- `bundle exec rake validate:rbs`: 1,212 RBS files pass.
- `bundle exec rake build:gem`: passes.

Upstream Castiron generator fix: https://github.com/openai/openai/pull/1292380.