### PR TITLE
chore: enforce line length on requires

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,6 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
-    - ^require(_relative)?
     - "OpenAI::Internal::Type::BaseModel$"
     - "^\\s*[A-Z0-9_]+ = :"
     - "OpenAI::(Models|Resources|Test)::"


### PR DESCRIPTION
## Summary

Remove the unused `^require(_relative)?` exemption from `Layout/LineLength`.

## Ratchet evidence

- Baseline offenses when this pattern is removed: **0**
- Final offenses: **0**
- Castiron impact: **none**; no generated or handwritten line currently depends on this exemption, so regeneration cannot recreate an offense
- Suppressions or replacement exemptions: **none**

## Validation

- `bundle exec rubocop --only Layout/LineLength .` — 2,621 files, 0 offenses
- `bundle exec rake lint` — RuboCop, Sorbet, directive policy, and 1,212 RBS files clean
- Thermo-nuclear code-quality review — no structural findings; this is a single declarative policy deletion