### PR TITLE
chore: enforce line length on base models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,6 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
-    - "OpenAI::Internal::Type::BaseModel$"
     - "^\\s*[A-Z0-9_]+ = :"
     - "OpenAI::(Models|Resources|Test)::"
   Max: 110

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,6 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
-    - "^\\s*[A-Z0-9_]+ = :"
     - "OpenAI::(Models|Resources|Test)::"
   Max: 110
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,6 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
-    - ^require(_relative)?
     - "OpenAI::Internal::Type::BaseModel$"
     - "^\\s*[A-Z0-9_]+ = :"
     - "OpenAI::(Models|Resources|Test)::"

--- a/lib/openai/errors.rb
+++ b/lib/openai/errors.rb
@@ -276,7 +276,10 @@ module OpenAI
       attr_reader :error_code
 
       def initialize(status:, body:, headers:)
-        @error_code = OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::OAuthErrorCode, body&.dig(:error))
+        @error_code = OpenAI::Internal::Type::Converter.coerce(
+          OpenAI::Models::OAuthErrorCode,
+          body&.dig(:error)
+        )
 
         message =
           if body&.dig(:error_description)

--- a/lib/openai/models/admin/organization/audit_log_list_params.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_params.rb
@@ -247,7 +247,8 @@ module OpenAI
             TENANT_POLICY_DELETED = :"tenant.policy.deleted"
             TENANT_POLICY_ATTACHED = :"tenant.policy.attached"
             TENANT_POLICY_DETACHED = :"tenant.policy.detached"
-            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED = :"tenant.principal_authentication_policy.resolved"
+            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED =
+              :"tenant.principal_authentication_policy.resolved"
             TENANT_SCIM_SETUP_STARTED = :"tenant.scim.setup.started"
             TENANT_SCIM_DELETION_REQUESTED = :"tenant.scim.deletion.requested"
             TENANT_SCIM_DIRECTORY_CREATED = :"tenant.scim.directory.created"

--- a/lib/openai/models/admin/organization/audit_log_list_response.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_response.rb
@@ -100,7 +100,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated, nil]
           optional :checkpoint_permission_created,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated
+                   },
                    api_name: :"checkpoint.permission.created"
 
           # @!attribute checkpoint_permission_deleted
@@ -108,7 +110,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted, nil]
           optional :checkpoint_permission_deleted,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted
+                   },
                    api_name: :"checkpoint.permission.deleted"
 
           # @!attribute external_key_registered
@@ -180,7 +184,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated, nil]
           optional :ip_allowlist_config_activated,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated
+                   },
                    api_name: :"ip_allowlist.config.activated"
 
           # @!attribute ip_allowlist_config_deactivated
@@ -188,7 +194,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated, nil]
           optional :ip_allowlist_config_deactivated,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated
+                   },
                    api_name: :"ip_allowlist.config.deactivated"
 
           # @!attribute ip_allowlist_created
@@ -432,7 +440,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated, nil]
           optional :workload_identity_provider_mapping_created,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated
+                   },
                    api_name: :"workload_identity_provider_mapping.created"
 
           # @!attribute workload_identity_provider_mapping_deleted
@@ -440,7 +450,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted, nil]
           optional :workload_identity_provider_mapping_deleted,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted
+                   },
                    api_name: :"workload_identity_provider_mapping.deleted"
 
           # @!attribute workload_identity_provider_mapping_updated
@@ -448,7 +460,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated, nil]
           optional :workload_identity_provider_mapping_updated,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated
+                   },
                    api_name: :"workload_identity_provider_mapping.updated"
 
           # @!attribute workload_identity_provider_created
@@ -456,7 +470,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated, nil]
           optional :workload_identity_provider_created,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated
+                   },
                    api_name: :"workload_identity_provider.created"
 
           # @!attribute workload_identity_provider_deleted
@@ -464,7 +480,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted, nil]
           optional :workload_identity_provider_deleted,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted
+                   },
                    api_name: :"workload_identity_provider.deleted"
 
           # @!attribute workload_identity_provider_updated
@@ -472,7 +490,9 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated, nil]
           optional :workload_identity_provider_updated,
-                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated },
+                   -> {
+                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated
+                   },
                    api_name: :"workload_identity_provider.updated"
 
           # @!method initialize(id:, effective_at:, type:, actor: nil, api_key_created: nil, api_key_deleted: nil, api_key_updated: nil, certificate_created: nil, certificate_deleted: nil, certificate_updated: nil, certificates_activated: nil, certificates_deactivated: nil, checkpoint_permission_created: nil, checkpoint_permission_deleted: nil, external_key_registered: nil, external_key_removed: nil, group_created: nil, group_deleted: nil, group_updated: nil, invite_accepted: nil, invite_deleted: nil, invite_sent: nil, ip_allowlist_config_activated: nil, ip_allowlist_config_deactivated: nil, ip_allowlist_created: nil, ip_allowlist_deleted: nil, ip_allowlist_updated: nil, login_failed: nil, login_succeeded: nil, logout_failed: nil, logout_succeeded: nil, organization_updated: nil, project: nil, project_archived: nil, project_created: nil, project_deleted: nil, project_updated: nil, rate_limit_deleted: nil, rate_limit_updated: nil, role_assignment_created: nil, role_assignment_deleted: nil, role_bound_to_resource: nil, role_created: nil, role_deleted: nil, role_unbound_from_resource: nil, role_updated: nil, scim_disabled: nil, scim_enabled: nil, service_account_created: nil, service_account_deleted: nil, service_account_updated: nil, user_added: nil, user_deleted: nil, user_updated: nil, workload_identity_provider_mapping_created: nil, workload_identity_provider_mapping_deleted: nil, workload_identity_provider_mapping_updated: nil, workload_identity_provider_created: nil, workload_identity_provider_deleted: nil, workload_identity_provider_updated: nil)

--- a/lib/openai/models/admin/organization/audit_log_list_response.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_response.rb
@@ -695,7 +695,8 @@ module OpenAI
             TENANT_POLICY_DELETED = :"tenant.policy.deleted"
             TENANT_POLICY_ATTACHED = :"tenant.policy.attached"
             TENANT_POLICY_DETACHED = :"tenant.policy.detached"
-            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED = :"tenant.principal_authentication_policy.resolved"
+            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED =
+              :"tenant.principal_authentication_policy.resolved"
             TENANT_SCIM_SETUP_STARTED = :"tenant.scim.setup.started"
             TENANT_SCIM_DELETION_REQUESTED = :"tenant.scim.deletion.requested"
             TENANT_SCIM_DIRECTORY_CREATED = :"tenant.scim.directory.created"

--- a/lib/openai/models/admin/organization/groups/role_list_response.rb
+++ b/lib/openai/models/admin/organization/groups/role_list_response.rb
@@ -18,7 +18,11 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource] },
+                     -> do
+                       OpenAI::Internal::Type::ArrayOf[
+                         OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource
+                       ]
+                     end,
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/groups/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/groups/role_retrieve_response.rb
@@ -18,7 +18,11 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource] },
+                     -> do
+                       OpenAI::Internal::Type::ArrayOf[
+                         OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource
+                       ]
+                     end,
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/groups/role_list_response.rb
+++ b/lib/openai/models/admin/organization/projects/groups/role_list_response.rb
@@ -19,7 +19,12 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource] },
+                       -> do
+                         OpenAI::Internal::Type::ArrayOf[
+                           OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::
+                           AssignmentSource
+                         ]
+                       end,
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/groups/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/projects/groups/role_retrieve_response.rb
@@ -19,7 +19,12 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource] },
+                       -> do
+                         OpenAI::Internal::Type::ArrayOf[
+                           OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::
+                           AssignmentSource
+                         ]
+                       end,
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/service_account_create_response.rb
+++ b/lib/openai/models/admin/organization/projects/service_account_create_response.rb
@@ -16,7 +16,9 @@ module OpenAI
             #
             #   @return [OpenAI::Models::Admin::Organization::Projects::ServiceAccountCreateResponse::APIKey, nil]
             required :api_key,
-                     -> { OpenAI::Models::Admin::Organization::Projects::ServiceAccountCreateResponse::APIKey },
+                     -> {
+                       OpenAI::Models::Admin::Organization::Projects::ServiceAccountCreateResponse::APIKey
+                     },
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/users/role_list_response.rb
+++ b/lib/openai/models/admin/organization/projects/users/role_list_response.rb
@@ -19,7 +19,12 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource] },
+                       -> do
+                         OpenAI::Internal::Type::ArrayOf[
+                           OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::
+                           AssignmentSource
+                         ]
+                       end,
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/users/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/projects/users/role_retrieve_response.rb
@@ -19,7 +19,12 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource] },
+                       -> do
+                         OpenAI::Internal::Type::ArrayOf[
+                           OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::
+                           AssignmentSource
+                         ]
+                       end,
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/users/role_list_response.rb
+++ b/lib/openai/models/admin/organization/users/role_list_response.rb
@@ -18,7 +18,11 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource] },
+                     -> do
+                       OpenAI::Internal::Type::ArrayOf[
+                         OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource
+                       ]
+                     end,
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/users/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/users/role_retrieve_response.rb
@@ -18,7 +18,11 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource] },
+                     -> do
+                       OpenAI::Internal::Type::ArrayOf[
+                         OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource
+                       ]
+                     end,
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/vector_store_search_response.rb
+++ b/lib/openai/models/vector_store_search_response.rb
@@ -13,7 +13,9 @@ module OpenAI
       #
       #   @return [Hash{Symbol=>String, Float, Boolean}, nil]
       required :attributes,
-               -> { OpenAI::Internal::Type::HashOf[union: OpenAI::Models::VectorStoreSearchResponse::Attribute] },
+               -> {
+                 OpenAI::Internal::Type::HashOf[union: OpenAI::Models::VectorStoreSearchResponse::Attribute]
+               },
                nil?: true
 
       # @!attribute content

--- a/lib/openai/resources/admin/organization/projects.rb
+++ b/lib/openai/resources/admin/organization/projects.rb
@@ -182,7 +182,8 @@ module OpenAI
           def initialize(client:)
             @client = client
             @users = OpenAI::Resources::Admin::Organization::Projects::Users.new(client: client)
-            @service_accounts = OpenAI::Resources::Admin::Organization::Projects::ServiceAccounts.new(client: client)
+            @service_accounts =
+              OpenAI::Resources::Admin::Organization::Projects::ServiceAccounts.new(client: client)
             @api_keys = OpenAI::Resources::Admin::Organization::Projects::APIKeys.new(client: client)
             @rate_limits = OpenAI::Resources::Admin::Organization::Projects::RateLimits.new(client: client)
             @model_permissions =
@@ -191,7 +192,8 @@ module OpenAI
               OpenAI::Resources::Admin::Organization::Projects::HostedToolPermissions.new(client: client)
             @groups = OpenAI::Resources::Admin::Organization::Projects::Groups.new(client: client)
             @roles = OpenAI::Resources::Admin::Organization::Projects::Roles.new(client: client)
-            @data_retention = OpenAI::Resources::Admin::Organization::Projects::DataRetention.new(client: client)
+            @data_retention =
+              OpenAI::Resources::Admin::Organization::Projects::DataRetention.new(client: client)
             @spend_limit = OpenAI::Resources::Admin::Organization::Projects::SpendLimit.new(client: client)
             @spend_alerts = OpenAI::Resources::Admin::Organization::Projects::SpendAlerts.new(client: client)
             @certificates = OpenAI::Resources::Admin::Organization::Projects::Certificates.new(client: client)

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -662,7 +662,8 @@ module OpenAI
               tool_models.store(name, params)
               tool[:function][:parameters] = params.to_json_schema
               tool
-            in {type: _, function: Hash => func} if func[:parameters].is_a?(Class) && func[:parameters] < OpenAI::Internal::Type::BaseModel
+            in {type: _, function: Hash => func} if func[:parameters].is_a?(Class) &&
+              func[:parameters] < OpenAI::Internal::Type::BaseModel
               params = func[:parameters]
               name = func[:name] || params.name.split("::").last
               tool_models.store(name, params)

--- a/test/openai/resources/admin/organization/audit_logs_test.rb
+++ b/test/openai/resources/admin/organization/audit_logs_test.rb
@@ -26,31 +26,46 @@ class OpenAI::Test::Resources::Admin::Organization::AuditLogsTest < OpenAI::Test
         api_key_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::APIKeyCreated | nil,
         api_key_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::APIKeyDeleted | nil,
         api_key_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::APIKeyUpdated | nil,
-        certificate_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateCreated | nil,
-        certificate_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateDeleted | nil,
-        certificate_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateUpdated | nil,
-        certificates_activated: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesActivated | nil,
-        certificates_deactivated: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesDeactivated | nil,
-        checkpoint_permission_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated | nil,
-        checkpoint_permission_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted | nil,
-        external_key_registered: OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRegistered | nil,
-        external_key_removed: OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRemoved | nil,
+        certificate_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateCreated | nil,
+        certificate_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateDeleted | nil,
+        certificate_updated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateUpdated | nil,
+        certificates_activated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesActivated | nil,
+        certificates_deactivated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesDeactivated | nil,
+        checkpoint_permission_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated | nil,
+        checkpoint_permission_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted | nil,
+        external_key_registered:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRegistered | nil,
+        external_key_removed:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRemoved | nil,
         group_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::GroupCreated | nil,
         group_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::GroupDeleted | nil,
         group_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::GroupUpdated | nil,
         invite_accepted: OpenAI::Models::Admin::Organization::AuditLogListResponse::InviteAccepted | nil,
         invite_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::InviteDeleted | nil,
         invite_sent: OpenAI::Models::Admin::Organization::AuditLogListResponse::InviteSent | nil,
-        ip_allowlist_config_activated: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated | nil,
-        ip_allowlist_config_deactivated: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated | nil,
-        ip_allowlist_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistCreated | nil,
-        ip_allowlist_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistDeleted | nil,
-        ip_allowlist_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistUpdated | nil,
+        ip_allowlist_config_activated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated | nil,
+        ip_allowlist_config_deactivated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated | nil,
+        ip_allowlist_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistCreated | nil,
+        ip_allowlist_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistDeleted | nil,
+        ip_allowlist_updated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistUpdated | nil,
         login_failed: OpenAI::Models::Admin::Organization::AuditLogListResponse::LoginFailed | nil,
         login_succeeded: OpenAI::Internal::Type::Unknown | nil,
         logout_failed: OpenAI::Models::Admin::Organization::AuditLogListResponse::LogoutFailed | nil,
         logout_succeeded: OpenAI::Internal::Type::Unknown | nil,
-        organization_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::OrganizationUpdated | nil,
+        organization_updated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::OrganizationUpdated | nil,
         project: OpenAI::Models::Admin::Organization::AuditLogListResponse::Project | nil,
         project_archived: OpenAI::Models::Admin::Organization::AuditLogListResponse::ProjectArchived | nil,
         project_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::ProjectCreated | nil,
@@ -58,27 +73,43 @@ class OpenAI::Test::Resources::Admin::Organization::AuditLogsTest < OpenAI::Test
         project_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::ProjectUpdated | nil,
         rate_limit_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::RateLimitDeleted | nil,
         rate_limit_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::RateLimitUpdated | nil,
-        role_assignment_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentCreated | nil,
-        role_assignment_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentDeleted | nil,
-        role_bound_to_resource: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleBoundToResource | nil,
+        role_assignment_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentCreated | nil,
+        role_assignment_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentDeleted | nil,
+        role_bound_to_resource:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleBoundToResource | nil,
         role_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleCreated | nil,
         role_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleDeleted | nil,
-        role_unbound_from_resource: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleUnboundFromResource | nil,
+        role_unbound_from_resource:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleUnboundFromResource | nil,
         role_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleUpdated | nil,
         scim_disabled: OpenAI::Models::Admin::Organization::AuditLogListResponse::ScimDisabled | nil,
         scim_enabled: OpenAI::Models::Admin::Organization::AuditLogListResponse::ScimEnabled | nil,
-        service_account_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountCreated | nil,
-        service_account_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountDeleted | nil,
-        service_account_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountUpdated | nil,
+        service_account_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountCreated | nil,
+        service_account_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountDeleted | nil,
+        service_account_updated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountUpdated | nil,
         user_added: OpenAI::Models::Admin::Organization::AuditLogListResponse::UserAdded | nil,
         user_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::UserDeleted | nil,
         user_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::UserUpdated | nil,
-        workload_identity_provider_mapping_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated | nil,
-        workload_identity_provider_mapping_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted | nil,
-        workload_identity_provider_mapping_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated | nil,
-        workload_identity_provider_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated | nil,
-        workload_identity_provider_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted | nil,
-        workload_identity_provider_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated | nil
+        workload_identity_provider_mapping_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::
+          WorkloadIdentityProviderMappingCreated | nil,
+        workload_identity_provider_mapping_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::
+          WorkloadIdentityProviderMappingDeleted | nil,
+        workload_identity_provider_mapping_updated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::
+          WorkloadIdentityProviderMappingUpdated | nil,
+        workload_identity_provider_created:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated | nil,
+        workload_identity_provider_deleted:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted | nil,
+        workload_identity_provider_updated:
+          OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated | nil
       }
     end
   end


### PR DESCRIPTION
## Summary

Remove the unused `OpenAI::Internal::Type::BaseModel$` exemption from `Layout/LineLength`.

## Ratchet evidence

- Baseline offenses when this pattern is removed: **0**
- Final offenses: **0**
- Castiron impact: **none**; generated output does not currently depend on this exemption
- Suppressions or replacement exemptions: **none**
- Depends on: #415

## Validation

- `bundle exec rake lint` — 2,621 RuboCop targets, Sorbet, directive policy, and 1,212 RBS files clean
- Thermo-nuclear code-quality review — no structural findings; this is a single declarative policy deletion