### PR TITLE
chore: enforce line length on constants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,6 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
-    - "^\\s*[A-Z0-9_]+ = :"
     - "OpenAI::(Models|Resources|Test)::"
   Max: 110
 

--- a/lib/openai/models/admin/organization/audit_log_list_params.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_params.rb
@@ -247,7 +247,8 @@ module OpenAI
             TENANT_POLICY_DELETED = :"tenant.policy.deleted"
             TENANT_POLICY_ATTACHED = :"tenant.policy.attached"
             TENANT_POLICY_DETACHED = :"tenant.policy.detached"
-            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED = :"tenant.principal_authentication_policy.resolved"
+            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED =
+              :"tenant.principal_authentication_policy.resolved"
             TENANT_SCIM_SETUP_STARTED = :"tenant.scim.setup.started"
             TENANT_SCIM_DELETION_REQUESTED = :"tenant.scim.deletion.requested"
             TENANT_SCIM_DIRECTORY_CREATED = :"tenant.scim.directory.created"

--- a/lib/openai/models/admin/organization/audit_log_list_response.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_response.rb
@@ -695,7 +695,8 @@ module OpenAI
             TENANT_POLICY_DELETED = :"tenant.policy.deleted"
             TENANT_POLICY_ATTACHED = :"tenant.policy.attached"
             TENANT_POLICY_DETACHED = :"tenant.policy.detached"
-            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED = :"tenant.principal_authentication_policy.resolved"
+            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED =
+              :"tenant.principal_authentication_policy.resolved"
             TENANT_SCIM_SETUP_STARTED = :"tenant.scim.setup.started"
             TENANT_SCIM_DELETION_REQUESTED = :"tenant.scim.deletion.requested"
             TENANT_SCIM_DIRECTORY_CREATED = :"tenant.scim.directory.created"


### PR DESCRIPTION
Remove the broad `Layout/LineLength` exemption for constant assignments and split the two generated assignments that it was hiding.

This is the third atomic layer in the line-length ratchet stack. Baseline after removing the exemption: 2 offenses. Final: 0 offenses.

Generator impact is covered by openai/openai#1296847, which teaches Castiron to account for physical nesting indentation when rendering enum constants.

Validation:
- `bundle exec rubocop --only Layout/LineLength .` (2,621 files, 0 offenses)
- `bundle exec rake lint` (RuboCop, Sorbet, directive guard, and 1,212 RBS files)