### PR TITLE
fix: validate RuboCop directives without a Git checkout

### DIFF
--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "date"
-require "open3"
 require "ripper"
 require "rubocop"
 
@@ -62,17 +61,11 @@ module RuboCopDirectiveGuard
     false
   end
 
-  def tracked_ruby_sources
-    paths, status = Open3.capture2("git", "ls-files", "-z")
-    raise "git ls-files failed" unless status.success?
-
-    tracked_paths = paths.split("\0").to_h { [_1, true] }
+  def ruby_sources
     root = File.expand_path(".")
     root_prefix = "#{root}/"
-    rubocop_target_paths.filter_map do |target|
+    rubocop_target_paths.map do |target|
       path = File.expand_path(target).delete_prefix(root_prefix)
-      next unless tracked_paths.key?(path)
-
       [path, File.read(target)]
     end
   end
@@ -84,6 +77,6 @@ module RuboCopDirectiveGuard
   end
 
   def validate
-    tracked_ruby_sources.flat_map { |path, source| violations_for(path, source) }
+    ruby_sources.flat_map { |path, source| violations_for(path, source) }
   end
 end

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -2,6 +2,7 @@
 
 require "minitest/autorun"
 require "fileutils"
+require "open3"
 require "tmpdir"
 
 require_relative "../../scripts/rubocop_directive_guard"
@@ -130,17 +131,38 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     end
   end
 
-  def test_skips_tracked_sources_missing_from_the_worktree
-    status = Minitest::Mock.new
-    status.expect(:success?, true)
+  def test_validates_source_trees_without_git
+    Dir.mktmpdir do |directory|
+      FileUtils.cp(File.expand_path("../../.rubocop.yml", __dir__), directory)
+      %w[lib/generated.rb vendor/bundle/dependency.rb sorbet/rbi/gems/dependency.rbi].each do |path|
+        full_path = File.join(directory, path)
+        FileUtils.mkdir_p(File.dirname(full_path))
+        File.write(full_path, "# rubocop:disable Lint\n")
+      end
 
-    Open3.stub(:capture2, ["missing.rb\0", status]) do
-      assert_empty(RuboCopDirectiveGuard.tracked_ruby_sources)
+      _stdout, stderr, status = validate_directory(directory)
+      refute(status.success?)
+      assert_equal("lib/generated.rb:1: department-wide rubocop:disable Lint is forbidden\n", stderr)
     end
-    status.verify
+  end
+
+  def test_validates_new_untracked_sources
+    Dir.mktmpdir do |directory|
+      assert(system("git", "init", "--quiet", directory))
+      File.write(File.join(directory, "new.rb"), "# rubocop:disable Lint\n")
+
+      _stdout, stderr, status = validate_directory(directory)
+      refute(status.success?)
+      assert_equal("new.rb:1: department-wide rubocop:disable Lint is forbidden\n", stderr)
+    end
   end
 
   private
+
+  def validate_directory(directory)
+    script = File.expand_path("../../scripts/validate-rubocop-directives", __dir__)
+    Open3.capture3(RbConfig.ruby, script, chdir: directory)
+  end
 
   def violations(body)
     directive = "# rubocop:#{body}\n"


### PR DESCRIPTION
## Summary
The suppression guard added in #408 assumes every source tree has a Git index. That breaks linting in temporary SDK-generation directories and source archives with `git ls-files failed`. It also silently skips new Ruby files until they are staged. A source check should inspect the files RuboCop would inspect, regardless of how the tree was created.

Use RuboCop’s configured targets directly, preserving the existing suppression rules and dependency/tool-output exclusions. Regression tests cover a source tree without Git metadata, excluded dependency files, and a new untracked file. The guard tests and full RuboCop task pass.