### PR TITLE
[1/n] chore: suspend Ruby layout enforcement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,6 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.3
 
-
 Bundler:
   Enabled: false
 Gemspec:
@@ -48,3 +47,24 @@ Lint/RedundantCopDisableDirective:
   Enabled: false
 Lint/RedundantCopEnableDirective:
   Enabled: false
+
+# Retain non-layout checks that RuboCop classifies in other departments.
+Bundler/DuplicatedGem:
+  Enabled: true
+Bundler/InsecureProtocolSource:
+  Enabled: true
+Gemspec/DuplicatedAssignment:
+  Enabled: true
+Gemspec/RequiredRubyVersion:
+  Enabled: true
+Style/MutableConstant:
+  Enabled: true
+  Exclude:
+    - "**/*.rbi"
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+  Exclude:
+    - "**/*.rbi"
+Style/MissingRespondToMissing:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,8 @@ inherit_mode:
     - Include
     - Exclude
 
-# Explicitly disable pending cops for now. This is the default behaviour but
-# this avoids a large warning every time we run it.
-# Stop RuboCop nagging about rubocop-rake.
-# Ensure that RuboCop validates according to the lowest version of Ruby that we support.
+# RuboCop checks correctness and security, not source layout.
+# New rules should be enabled deliberately, not by a dependency update.
 AllCops:
   Include:
     - "**/*.rbi"
@@ -18,242 +16,35 @@ AllCops:
     - "sorbet/rbi/annotations/**/*"
     - "sorbet/rbi/gems/**/*"
     - "sorbet/tapioca/**/*"
-  NewCops: enable
+  NewCops: disable
   SuggestExtensions: false
   TargetRubyVersion: 3.3
 
-# Don't require this extra line break, it can be excessive.
-Layout/EmptyLineAfterGuardClause:
+
+Bundler:
+  Enabled: false
+Gemspec:
+  Enabled: false
+Layout:
+  Enabled: false
+Metrics:
+  Enabled: false
+Migration:
+  Enabled: false
+Naming:
+  Enabled: false
+Style:
   Enabled: false
 
-# Don't leave complex assignment values hanging off to the right.
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
-
-Layout/FirstArrayElementLineBreak:
-  Enabled: true
-
-Layout/FirstHashElementLineBreak:
-  Enabled: true
-
-Layout/FirstMethodArgumentLineBreak:
-  Enabled: true
-
-Layout/FirstMethodParameterLineBreak:
-  Enabled: true
-
-# Set a reasonable line length; rely on other cops to correct long lines.
-Layout/LineLength:
-  AllowedPatterns:
-    - "^\\s*#.*$"
-  Max: 110
-
-Layout/MultilineArrayLineBreaks:
-  Enabled: true
-
-# Start the assignment on the same line variable is mentioned.
-Layout/MultilineAssignmentLayout:
-  EnforcedStyle: same_line
-
-Layout/MultilineHashKeyLineBreaks:
-  Enabled: true
-
-Layout/MultilineMethodArgumentLineBreaks:
-  Enabled: true
-
-Layout/MultilineMethodParameterLineBreaks:
-  Enabled: true
-
-# Prefer compact hash literals.
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-  Exclude:
-    - "**/*.rbi"
-
-# Disabled for safety reasons, this option changes code semantics.
+# These autocorrections can change behavior.
 Lint/UnusedMethodArgument:
   AutoCorrect: false
-
-# This option is prone to causing accidental bugs.
 Lint/UselessAssignment:
   AutoCorrect: false
 
-Metrics/AbcSize:
+# Existing narrow suppressions are harmless while the formatting policy changes.
+# The directive guard still rejects broad or unowned suppressions.
+Lint/RedundantCopDisableDirective:
   Enabled: false
-
-Metrics/BlockLength:
-  AllowedPatterns:
-    - assert_pattern
-    - type_alias
-    - define_sorbet_constant!
-  Exclude:
-    - "**/*.rbi"
-
-Metrics/ClassLength:
+Lint/RedundantCopEnableDirective:
   Enabled: false
-
-Metrics/CollectionLiteralLength:
-  Exclude:
-    - "test/**/*"
-
-Metrics/CyclomaticComplexity:
-  Enabled: false
-
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Metrics/ParameterLists:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false
-
-Naming/AccessorMethodName:
-  Enabled: false
-
-# Need to preserve block identifier for documentation.
-Naming/BlockForwarding:
-  Enabled: false
-
-# Underscores are generally useful for disambiguation.
-Naming/ClassAndModuleCamelCase:
-  Enabled: false
-
-Naming/MethodParameterName:
-  Enabled: false
-
-Naming/PredicatePrefix:
-  Exclude:
-    - "**/*.rbi"
-
-Naming/VariableNumber:
-  Enabled: false
-
-# Nothing wrong with inline private methods.
-Style/AccessModifierDeclarations:
-  Enabled: false
-
-Style/AccessorGrouping:
-  Exclude:
-    - "**/*.rbi"
-
-# Behaviour of alias_method is more predictable.
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-
-# And/or have confusing precedence, avoid them.
-Style/AndOr:
-  EnforcedStyle: always
-
-Style/ArgumentsForwarding:
-  Enabled: false
-
-Style/BisectedAttrAccessor:
-  Exclude:
-    - "**/*.rbi"
-
-# We prefer nested modules in lib/, but are currently using compact style for tests.
-Style/ClassAndModuleChildren:
-  Exclude:
-    - "test/**/*"
-
-Style/CommentAnnotation:
-  Enabled: false
-
-# We should go back and add these docs, but ignore for now.
-Style/Documentation:
-  Enabled: false
-
-Style/EmptyMethod:
-  Exclude:
-    - "**/*.rbi"
-
-# We commonly use ENV['KEY'], it's OK.
-Style/FetchEnvVar:
-  Enabled: false
-
-# Just to be safe, ensure nobody is mutating our internal strings.
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
-  Exclude:
-    - "**/*.rbi"
-
-# Nothing wrong with clear if statements.
-Style/IfUnlessModifier:
-  Enabled: false
-
-# Rubocop is pretty bad about mangling single line lambdas.
-Style/Lambda:
-  Enabled: false
-
-# Prefer consistency in method calling syntax.
-Style/MethodCallWithArgsParentheses:
-  AllowedMethods:
-    - raise
-  Enabled: true
-  Exclude:
-    - "**/*.gemspec"
-
-Style/MultilineBlockChain:
-  Enabled: false
-
-# Perfectly fine.
-Style/MultipleComparison:
-  Enabled: false
-
-Style/MutableConstant:
-  Exclude:
-    - "**/*.rbi"
-
-# Not all parameters should be named.
-Style/NumberedParameters:
-  Enabled: false
-
-Style/NumberedParametersLimit:
-  Max: 2
-
-# Reasonable to use brackets for errors with long messages.
-Style/RaiseArgs:
-  Enabled: false
-
-Style/RedundantInitialize:
-  Exclude:
-    - "**/*.rbi"
-
-Style/RedundantParentheses:
-  Exclude:
-    - "**/*.rbi"
-
-# Prefer slashes for regex literals.
-Style/RegexpLiteral:
-  EnforcedStyle: slashes
-
-# Allow explicit ifs, especially for imperative use.
-Style/SafeNavigation:
-  Enabled: false
-
-Style/SignalException:
-  Exclude:
-    - Rakefile
-    - "**/*.rake"
-
-# We use these sparingly, where we anticipate future branches for the
-# inner conditional.
-Style/SoleNestedConditional:
-  Enabled: false
-
-# Prefer double quotes so that interpolation can be easily added.
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-# Prefer explicit symbols for clarity; you can search for `:the_symbol`.
-Style/SymbolArray:
-  EnforcedStyle: brackets
-
-# This option makes examples harder to read for ruby novices.
-Style/SymbolProc:
-  Exclude:
-    - "examples/**/*.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,15 +20,9 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.3
 
-Bundler:
-  Enabled: false
-Gemspec:
-  Enabled: false
 Layout:
   Enabled: false
 Metrics:
-  Enabled: false
-Migration:
   Enabled: false
 Naming:
   Enabled: false
@@ -46,6 +40,12 @@ Lint/UselessAssignment:
 Lint/RedundantCopDisableDirective:
   Enabled: false
 Lint/RedundantCopEnableDirective:
+  Enabled: false
+
+# Dependency ordering is layout, not package correctness.
+Bundler/OrderedGems:
+  Enabled: false
+Gemspec/OrderedDependencies:
   Enabled: false
 
 # Retain non-layout checks that RuboCop classifies in other departments.
@@ -67,4 +67,112 @@ Style/FrozenStringLiteralComment:
   Exclude:
     - "**/*.rbi"
 Style/MissingRespondToMissing:
+  Enabled: true
+
+Gemspec/RequireMFA:
+  Enabled: true
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: true
+
+# Preserve the safety cops already enforced by RuboCop 1.81.7.
+# Future pending cops remain opt-in.
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+Lint/AmbiguousRange:
+  Enabled: true
+Lint/ArrayLiteralInRegexp:
+  Enabled: true
+Lint/ConstantOverwrittenInRescue:
+  Enabled: true
+Lint/ConstantReassignment:
+  Enabled: true
+Lint/CopDirectiveSyntax:
+  Enabled: true
+Lint/DeprecatedConstants:
+  Enabled: true
+Lint/DuplicateBranch:
+  Enabled: true
+Lint/DuplicateMagicComment:
+  Enabled: true
+Lint/DuplicateMatchPattern:
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+Lint/DuplicateSetElement:
+  Enabled: true
+Lint/EmptyBlock:
+  Enabled: true
+Lint/EmptyClass:
+  Enabled: true
+Lint/EmptyInPattern:
+  Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault:
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: true
+Lint/ItWithoutArgumentsInBlock:
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+Lint/LiteralAssignmentInCondition:
+  Enabled: true
+Lint/MixedCaseRange:
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+Lint/NonAtomicFileOperation:
+  Enabled: true
+Lint/NumberedParameterAssignment:
+  Enabled: true
+Lint/NumericOperationWithConstantResult:
+  Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
+Lint/RedundantRegexpQuantifiers:
+  Enabled: true
+Lint/RedundantTypeConversion:
+  Enabled: true
+Lint/RefinementImportMethods:
+  Enabled: true
+Lint/RequireRangeParentheses:
+  Enabled: true
+Lint/RequireRelativeSelfPath:
+  Enabled: true
+Lint/SharedMutableDefault:
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion:
+  Enabled: true
+Lint/SymbolConversion:
+  Enabled: true
+Lint/ToEnumArguments:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/UnescapedBracketInRegexp:
+  Enabled: true
+Lint/UnexpectedBlockArity:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+Lint/UselessConstantScoping:
+  Enabled: true
+Lint/UselessDefaultValueArgument:
+  Enabled: true
+Lint/UselessDefined:
+  Enabled: true
+Lint/UselessNumericOperation:
+  Enabled: true
+Lint/UselessOr:
+  Enabled: true
+Lint/UselessRescue:
+  Enabled: true
+Lint/UselessRuby2Keywords:
+  Enabled: true
+Security/CompoundHash:
+  Enabled: true
+Security/IoMethods:
   Enabled: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ $ bundle exec rake test
 
 ## Linting and formatting
 
-This repository uses [rubocop](https://github.com/rubocop/rubocop) for linting and formatting of `*.rb` files; And [syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree) is used for formatting of both `*.rbi` and `*.rbs` files.
+This repository uses [rubocop](https://github.com/rubocop/rubocop) for correctness and security checks. Ruby source formatting is temporarily paused while we switch to rubyfmt. [syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree) continues to format `*.rbi` and `*.rbs` files.
 
 There are two separate type checkers supported by this library: [sorbet](https://github.com/sorbet/sorbet) and [steep](https://github.com/soutaro/steep) are used for verifying `*.rbi` and `*.rbs` files respectively.
 
@@ -91,7 +91,7 @@ To lint and typecheck:
 $ bundle exec rake lint
 ```
 
-To format and fix all lint issues automatically:
+To run the available formatters:
 
 ```bash
 $ bundle exec rake format

--- a/Rakefile
+++ b/Rakefile
@@ -70,12 +70,9 @@ Rake::Task[:"lint:rubocop"].enhance([:"lint:rubocop_directives"])
 
 norm_lines = %w[tr -- \n \0].shelljoin
 
-desc("Format `*.rb`")
+desc("Format `*.rb` (paused until rubyfmt is installed)")
 multitask(:"format:rb") do
-  # while `syntax_tree` is much faster than `rubocop`, `rubocop` is the only formatter with full syntax support
-  files = filtered["rb", %w[./lib ./test ./examples]]
-  fmt = xargs + %w[rubocop --fail-level F --autocorrect --format simple --]
-  sh("#{files.shelljoin} | #{norm_lines} | #{fmt.shelljoin}")
+  puts("Ruby source formatting is paused until the rubyfmt cutover.")
 end
 
 desc("Format `*.rbi`")

--- a/scripts/rubocop_directive_guard.rb
+++ b/scripts/rubocop_directive_guard.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "date"
-require "open3"
 require "ripper"
 require "rubocop"
 
@@ -62,17 +61,11 @@ module RuboCopDirectiveGuard
     false
   end
 
-  def tracked_ruby_sources
-    paths, status = Open3.capture2("git", "ls-files", "-z")
-    raise "git ls-files failed" unless status.success?
-
-    tracked_paths = paths.split("\0").to_h { [_1, true] }
+  def ruby_sources
     root = File.expand_path(".")
     root_prefix = "#{root}/"
-    rubocop_target_paths.filter_map do |target|
+    rubocop_target_paths.map do |target|
       path = File.expand_path(target).delete_prefix(root_prefix)
-      next unless tracked_paths.key?(path)
-
       [path, File.read(target)]
     end
   end
@@ -84,6 +77,6 @@ module RuboCopDirectiveGuard
   end
 
   def validate
-    tracked_ruby_sources.flat_map { |path, source| violations_for(path, source) }
+    ruby_sources.flat_map { |path, source| violations_for(path, source) }
   end
 end

--- a/test/scripts/formatting_policy_test.rb
+++ b/test/scripts/formatting_policy_test.rb
@@ -8,13 +8,25 @@ require "tmpdir"
 class FormattingPolicyTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
 
+  NON_LAYOUT_COPS = %w[
+    Bundler/DuplicatedGem
+    Bundler/InsecureProtocolSource
+    Gemspec/DuplicatedAssignment
+    Gemspec/RequiredRubyVersion
+    Style/FrozenStringLiteralComment
+    Style/MissingRespondToMissing
+    Style/MutableConstant
+  ].freeze
+
   def test_rubocop_only_enables_correctness_and_security_checks
     config = RuboCop::ConfigStore.new.for_dir(ROOT)
     enabled = RuboCop::Cop::Registry.global.select do |cop|
       config.for_cop(cop)["Enabled"] == true
     end
 
-    assert_equal(%w[Lint Security], enabled.map { _1.department.to_s }.uniq.sort)
+    other_cops = enabled.reject { %w[Lint Security].include?(_1.department.to_s) }
+    assert_equal(NON_LAYOUT_COPS, other_cops.map(&:cop_name).sort)
+    NON_LAYOUT_COPS.each { assert(config.for_cop(_1)["Enabled"], _1) }
     assert(config.for_cop("Lint/Syntax")["Enabled"])
     assert(config.for_cop("Security/Eval")["Enabled"])
     assert_equal("disable", config["AllCops"]["NewCops"])

--- a/test/scripts/formatting_policy_test.rb
+++ b/test/scripts/formatting_policy_test.rb
@@ -8,28 +8,38 @@ require "tmpdir"
 class FormattingPolicyTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
 
-  NON_LAYOUT_COPS = %w[
-    Bundler/DuplicatedGem
-    Bundler/InsecureProtocolSource
-    Gemspec/DuplicatedAssignment
-    Gemspec/RequiredRubyVersion
+  STYLE_SAFETY_COPS = %w[
     Style/FrozenStringLiteralComment
     Style/MissingRespondToMissing
     Style/MutableConstant
   ].freeze
 
-  def test_rubocop_only_enables_correctness_and_security_checks
+  def test_rubocop_preserves_safety_checks_without_enforcing_layout
     config = RuboCop::ConfigStore.new.for_dir(ROOT)
-    enabled = RuboCop::Cop::Registry.global.select do |cop|
-      config.for_cop(cop)["Enabled"] == true
-    end
+    enabled = RuboCop::Cop::Registry.global.enabled(config).map(&:cop_name)
 
-    other_cops = enabled.reject { %w[Lint Security].include?(_1.department.to_s) }
-    assert_equal(NON_LAYOUT_COPS, other_cops.map(&:cop_name).sort)
-    NON_LAYOUT_COPS.each { assert(config.for_cop(_1)["Enabled"], _1) }
-    assert(config.for_cop("Lint/Syntax")["Enabled"])
-    assert(config.for_cop("Security/Eval")["Enabled"])
+    formatting = enabled.grep(/\A(?:Layout|Metrics|Naming|Style)\//)
+    assert_equal(STYLE_SAFETY_COPS, formatting.sort)
+    %w[
+      Bundler/DuplicatedGem
+      Bundler/InsecureProtocolSource
+      Gemspec/DuplicatedAssignment
+      Gemspec/RequiredRubyVersion
+      Gemspec/RequireMFA
+      Lint/Syntax
+      Security/Eval
+      Security/IoMethods
+    ].each { assert_includes(enabled, _1) }
+    refute_includes(enabled, "Bundler/OrderedGems")
+    refute_includes(enabled, "Gemspec/OrderedDependencies")
     assert_equal("disable", config["AllCops"]["NewCops"])
+
+    # A RuboCop upgrade must make an explicit decision about new safety cops.
+    RuboCop::ConfigLoader.default_configuration.each do |name, options|
+      next unless name.match?(/\A(?:Lint|Security)\//) && options["Enabled"] == "pending"
+
+      assert_includes(enabled, name)
+    end
   end
 
   def test_ruby_formatter_does_not_rewrite_source_during_transition

--- a/test/scripts/formatting_policy_test.rb
+++ b/test/scripts/formatting_policy_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "rubocop"
+require "tmpdir"
+
+class FormattingPolicyTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_rubocop_only_enables_correctness_and_security_checks
+    config = RuboCop::ConfigStore.new.for_dir(ROOT)
+    enabled = RuboCop::Cop::Registry.global.select do |cop|
+      config.for_cop(cop)["Enabled"] == true
+    end
+
+    assert_equal(%w[Lint Security], enabled.map { _1.department.to_s }.uniq.sort)
+    assert(config.for_cop("Lint/Syntax")["Enabled"])
+    assert(config.for_cop("Security/Eval")["Enabled"])
+    assert_equal("disable", config["AllCops"]["NewCops"])
+  end
+
+  def test_ruby_formatter_does_not_rewrite_source_during_transition
+    Dir.mktmpdir do |directory|
+      path = File.join(directory, "example.rb")
+      source = "value={hello: 'world'}\n"
+      File.write(path, source)
+      paths = File.join(directory, "paths")
+      File.write(paths, "#{path}\n")
+
+      stdout, stderr, status = Open3.capture3(
+        "bundle", "exec", "rake", "format:rb", "FORMAT_FILE=#{paths}", chdir: ROOT
+      )
+
+      assert(status.success?, "#{stdout}\n#{stderr}")
+      assert_equal(source, File.read(path))
+    end
+  end
+end

--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -2,6 +2,7 @@
 
 require "minitest/autorun"
 require "fileutils"
+require "open3"
 require "tmpdir"
 
 require_relative "../../scripts/rubocop_directive_guard"
@@ -130,17 +131,38 @@ class ValidateRuboCopDirectivesTest < Minitest::Test
     end
   end
 
-  def test_skips_tracked_sources_missing_from_the_worktree
-    status = Minitest::Mock.new
-    status.expect(:success?, true)
+  def test_validates_source_trees_without_git
+    Dir.mktmpdir do |directory|
+      FileUtils.cp(File.expand_path("../../.rubocop.yml", __dir__), directory)
+      %w[lib/generated.rb vendor/bundle/dependency.rb sorbet/rbi/gems/dependency.rbi].each do |path|
+        full_path = File.join(directory, path)
+        FileUtils.mkdir_p(File.dirname(full_path))
+        File.write(full_path, "# rubocop:disable Lint\n")
+      end
 
-    Open3.stub(:capture2, ["missing.rb\0", status]) do
-      assert_empty(RuboCopDirectiveGuard.tracked_ruby_sources)
+      _stdout, stderr, status = validate_directory(directory)
+      refute(status.success?)
+      assert_equal("lib/generated.rb:1: department-wide rubocop:disable Lint is forbidden\n", stderr)
     end
-    status.verify
+  end
+
+  def test_validates_new_untracked_sources
+    Dir.mktmpdir do |directory|
+      assert(system("git", "init", "--quiet", directory))
+      File.write(File.join(directory, "new.rb"), "# rubocop:disable Lint\n")
+
+      _stdout, stderr, status = validate_directory(directory)
+      refute(status.success?)
+      assert_equal("new.rb:1: department-wide rubocop:disable Lint is forbidden\n", stderr)
+    end
   end
 
   private
+
+  def validate_directory(directory)
+    script = File.expand_path("../../scripts/validate-rubocop-directives", __dir__)
+    Open3.capture3(RbConfig.ruby, script, chdir: directory)
+  end
 
   def violations(body)
     directive = "# rubocop:#{body}\n"


### PR DESCRIPTION
## Summary

Let the Ruby SDK stop enforcing source layout while we replace RuboCop formatting with rubyfmt. The current layout rules force generated-code edits and block otherwise valid SDK updates.

Keep RuboCop's correctness and security checks, the suppression guard, type checks, and package/tests. Temporarily pause `.rb` rewriting so the next PR can remove formatting-only customizations without having them reapplied. RBI/RBS formatting is unchanged.


## Stack

- https://github.com/openai/openai-ruby/pull/425
- https://github.com/openai/openai-ruby/pull/426 👈 this PR
- https://github.com/openai/openai/pull/1307156
- https://github.com/openai/openai-ruby/pull/427
- https://github.com/openai/openai/pull/1307196
- https://github.com/openai/openai-ruby/pull/428
- https://github.com/openai/openai/pull/1307238
