### PR TITLE
[3/n] chore: remove obsolete Ruby layout workarounds

### DIFF
--- a/lib/openai/auth/workload_identity.rb
+++ b/lib/openai/auth/workload_identity.rb
@@ -14,8 +14,7 @@ module OpenAI
       )
         if identity_provider_id.to_s.strip.empty?
           raise ArgumentError,
-                "identity_provider_id must not be blank; pass identity_provider_id: " \
-                "or set IDENTITY_PROVIDER_ID"
+                "identity_provider_id must not be blank; pass identity_provider_id: or set IDENTITY_PROVIDER_ID"
         end
 
         if service_account_id.to_s.strip.empty?

--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -87,8 +87,7 @@ module OpenAI
         token_type = @config.provider.token_type
         subject_token_type = SUBJECT_TOKEN_TYPES.fetch(token_type) do
           raise ArgumentError,
-                "Unsupported token type: #{token_type.inspect}. " \
-                "Supported types: #{SUBJECT_TOKEN_TYPES.keys.join(', ')}"
+                "Unsupported token type: #{token_type.inspect}. Supported types: #{SUBJECT_TOKEN_TYPES.keys.join(', ')}"
         end
 
         request = Net::HTTP::Post.new(@token_exchange_url)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -315,9 +315,7 @@ module OpenAI
 
       if provider_runtime.nil? && api_key.nil? && admin_api_key.nil? && workload_identity.nil?
         raise ArgumentError,
-              "Missing credentials. Please pass an `api_key`, `workload_identity`, " \
-              "`admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` " \
-              "environment variable."
+              "Missing credentials. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable."
       end
 
       headers = {

--- a/lib/openai/errors.rb
+++ b/lib/openai/errors.rb
@@ -276,10 +276,7 @@ module OpenAI
       attr_reader :error_code
 
       def initialize(status:, body:, headers:)
-        @error_code = OpenAI::Internal::Type::Converter.coerce(
-          OpenAI::Models::OAuthErrorCode,
-          body&.dig(:error)
-        )
+        @error_code = OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::OAuthErrorCode, body&.dig(:error))
 
         message =
           if body&.dig(:error_description)

--- a/lib/openai/helpers/structured_output/base_model.rb
+++ b/lib/openai/helpers/structured_output/base_model.rb
@@ -60,9 +60,7 @@ module OpenAI
 
         class << self
           def optional(...)
-            message =
-              "`optional` is not supported for structured output APIs, " \
-              "use `#required` with `nil?: true` instead"
+            message = "`optional` is not supported for structured output APIs, use `#required` with `nil?: true` instead"
             raise message
           end
         end

--- a/lib/openai/helpers/structured_output/json_schema_converter.rb
+++ b/lib/openai/helpers/structured_output/json_schema_converter.rb
@@ -196,10 +196,7 @@ module OpenAI
               OpenAI::UnionOf
               OpenAI::BaseModel
             ]
-            message =
-              "#{type} does not implement the " \
-              "#{OpenAI::Helpers::StructuredOutput::JsonSchemaConverter} interface. " \
-              "Please use one of the supported types: #{models}"
+            message = "#{type} does not implement the #{OpenAI::Helpers::StructuredOutput::JsonSchemaConverter} interface. Please use one of the supported types: #{models}"
             raise ArgumentError.new(message)
           end
         end

--- a/lib/openai/internal/conversation_cursor_page.rb
+++ b/lib/openai/internal/conversation_cursor_page.rb
@@ -83,8 +83,7 @@ module OpenAI
       def inspect
         model = OpenAI::Internal::Type::Converter.inspect(@model, depth: 1)
 
-        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} " \
-          "has_more=#{has_more.inspect} last_id=#{last_id.inspect}>"
+        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} has_more=#{has_more.inspect} last_id=#{last_id.inspect}>"
       end
     end
   end

--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -20,20 +20,8 @@ module OpenAI
       MAX_ARRAY_ITEMS = 100
       OPAQUE_STRING_BYTES = 1_024
       SENSITIVE_BODY_KEY = /(?:api[-_]?key|authorization|credential|password|secret|signature|token)/i
-      SENSITIVE_QUERY_KEY = /
-        (?:
-          (?:\A|[-_\[])(?:key|sig)
-          | (?-i:K)ey
-          | api[-_]?key
-          | authorization
-          | credentials?
-          | password
-          | secret
-          | signature
-          | token
-        )
-        (?:\[|\]|\z)
-      /ix
+      SENSITIVE_QUERY_KEY =
+        /(?:(?:\A|[-_\[])(?:key|sig)|(?-i:K)ey|api[-_]?key|authorization|credentials?|password|secret|signature|token)(?:\[|\]|\z)/i
       URL_HEADER_KEY = /(?:\A|[-_])(?:location|url|uri)\z|\A(?:link|refresh)\z/i
 
       class Context

--- a/lib/openai/internal/next_cursor_page.rb
+++ b/lib/openai/internal/next_cursor_page.rb
@@ -83,8 +83,7 @@ module OpenAI
       def inspect
         model = OpenAI::Internal::Type::Converter.inspect(@model, depth: 1)
 
-        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} " \
-          "has_more=#{has_more.inspect} next_=#{next_.inspect}>"
+        "#<#{self.class}[#{model}]:0x#{object_id.to_s(16)} has_more=#{has_more.inspect} next_=#{next_.inspect}>"
       end
     end
   end

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -748,8 +748,7 @@ module OpenAI
         #
         # @return [String]
         def inspect
-          "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{@base_url} " \
-            "max_retries=#{@max_retries} timeout=#{@timeout}>"
+          "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{@base_url} max_retries=#{@max_retries} timeout=#{@timeout}>"
         end
 
         define_sorbet_constant!(:RequestComponents) do

--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -46,9 +46,7 @@ module OpenAI
         #
         # @return [Boolean]
         def ==(other)
-          other.is_a?(OpenAI::Internal::Type::ArrayOf) &&
-            other.nilable? == nilable? &&
-            other.item_type == item_type
+          other.is_a?(OpenAI::Internal::Type::ArrayOf) && other.nilable? == nilable? && other.item_type == item_type
         end
 
         # @api public

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -61,9 +61,7 @@ module OpenAI
         #
         # @return [Boolean]
         def ==(other)
-          other.is_a?(OpenAI::Internal::Type::HashOf) &&
-            other.nilable? == nilable? &&
-            other.item_type == item_type
+          other.is_a?(OpenAI::Internal::Type::HashOf) && other.nilable? == nilable? && other.item_type == item_type
         end
 
         # @api public

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -551,13 +551,7 @@ module OpenAI
           case val
           in Hash
             val.each do |name, value|
-              write_multipart_value(
-                y,
-                boundary: boundary,
-                key: "#{key}[#{name}]",
-                val: value,
-                closing: closing
-              )
+              write_multipart_value(y, boundary: boundary, key: "#{key}[#{name}]", val: value, closing: closing)
             end
           in Array
             val.each do |value|
@@ -608,10 +602,7 @@ module OpenAI
           case [content_type, body]
           in [OpenAI::Internal::Util::JSON_CONTENT, Hash | Array | -> { primitive?(_1) }]
             [headers, JSON.generate(body)]
-          in [
-            OpenAI::Internal::Util::JSONL_CONTENT,
-            Enumerable
-          ] unless OpenAI::Internal::Type::FileInput === body
+          in [OpenAI::Internal::Util::JSONL_CONTENT, Enumerable] unless OpenAI::Internal::Type::FileInput === body
             [headers, body.lazy.map { JSON.generate(_1) }]
           in [%r{^multipart/form-data}, Hash | OpenAI::Internal::Type::FileInput]
             boundary, strio = encode_multipart_streaming(body)

--- a/lib/openai/models/admin/organization/audit_log_list_params.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_params.rb
@@ -247,8 +247,7 @@ module OpenAI
             TENANT_POLICY_DELETED = :"tenant.policy.deleted"
             TENANT_POLICY_ATTACHED = :"tenant.policy.attached"
             TENANT_POLICY_DETACHED = :"tenant.policy.detached"
-            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED =
-              :"tenant.principal_authentication_policy.resolved"
+            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED = :"tenant.principal_authentication_policy.resolved"
             TENANT_SCIM_SETUP_STARTED = :"tenant.scim.setup.started"
             TENANT_SCIM_DELETION_REQUESTED = :"tenant.scim.deletion.requested"
             TENANT_SCIM_DIRECTORY_CREATED = :"tenant.scim.directory.created"

--- a/lib/openai/models/admin/organization/audit_log_list_response.rb
+++ b/lib/openai/models/admin/organization/audit_log_list_response.rb
@@ -100,9 +100,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated, nil]
           optional :checkpoint_permission_created,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated },
                    api_name: :"checkpoint.permission.created"
 
           # @!attribute checkpoint_permission_deleted
@@ -110,9 +108,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted, nil]
           optional :checkpoint_permission_deleted,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted },
                    api_name: :"checkpoint.permission.deleted"
 
           # @!attribute external_key_registered
@@ -184,9 +180,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated, nil]
           optional :ip_allowlist_config_activated,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated },
                    api_name: :"ip_allowlist.config.activated"
 
           # @!attribute ip_allowlist_config_deactivated
@@ -194,9 +188,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated, nil]
           optional :ip_allowlist_config_deactivated,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated },
                    api_name: :"ip_allowlist.config.deactivated"
 
           # @!attribute ip_allowlist_created
@@ -440,9 +432,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated, nil]
           optional :workload_identity_provider_mapping_created,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated },
                    api_name: :"workload_identity_provider_mapping.created"
 
           # @!attribute workload_identity_provider_mapping_deleted
@@ -450,9 +440,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted, nil]
           optional :workload_identity_provider_mapping_deleted,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted },
                    api_name: :"workload_identity_provider_mapping.deleted"
 
           # @!attribute workload_identity_provider_mapping_updated
@@ -460,9 +448,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated, nil]
           optional :workload_identity_provider_mapping_updated,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated },
                    api_name: :"workload_identity_provider_mapping.updated"
 
           # @!attribute workload_identity_provider_created
@@ -470,9 +456,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated, nil]
           optional :workload_identity_provider_created,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated },
                    api_name: :"workload_identity_provider.created"
 
           # @!attribute workload_identity_provider_deleted
@@ -480,9 +464,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted, nil]
           optional :workload_identity_provider_deleted,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted },
                    api_name: :"workload_identity_provider.deleted"
 
           # @!attribute workload_identity_provider_updated
@@ -490,9 +472,7 @@ module OpenAI
           #
           #   @return [OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated, nil]
           optional :workload_identity_provider_updated,
-                   -> {
-                     OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated
-                   },
+                   -> { OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated },
                    api_name: :"workload_identity_provider.updated"
 
           # @!method initialize(id:, effective_at:, type:, actor: nil, api_key_created: nil, api_key_deleted: nil, api_key_updated: nil, certificate_created: nil, certificate_deleted: nil, certificate_updated: nil, certificates_activated: nil, certificates_deactivated: nil, checkpoint_permission_created: nil, checkpoint_permission_deleted: nil, external_key_registered: nil, external_key_removed: nil, group_created: nil, group_deleted: nil, group_updated: nil, invite_accepted: nil, invite_deleted: nil, invite_sent: nil, ip_allowlist_config_activated: nil, ip_allowlist_config_deactivated: nil, ip_allowlist_created: nil, ip_allowlist_deleted: nil, ip_allowlist_updated: nil, login_failed: nil, login_succeeded: nil, logout_failed: nil, logout_succeeded: nil, organization_updated: nil, project: nil, project_archived: nil, project_created: nil, project_deleted: nil, project_updated: nil, rate_limit_deleted: nil, rate_limit_updated: nil, role_assignment_created: nil, role_assignment_deleted: nil, role_bound_to_resource: nil, role_created: nil, role_deleted: nil, role_unbound_from_resource: nil, role_updated: nil, scim_disabled: nil, scim_enabled: nil, service_account_created: nil, service_account_deleted: nil, service_account_updated: nil, user_added: nil, user_deleted: nil, user_updated: nil, workload_identity_provider_mapping_created: nil, workload_identity_provider_mapping_deleted: nil, workload_identity_provider_mapping_updated: nil, workload_identity_provider_created: nil, workload_identity_provider_deleted: nil, workload_identity_provider_updated: nil)
@@ -715,8 +695,7 @@ module OpenAI
             TENANT_POLICY_DELETED = :"tenant.policy.deleted"
             TENANT_POLICY_ATTACHED = :"tenant.policy.attached"
             TENANT_POLICY_DETACHED = :"tenant.policy.detached"
-            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED =
-              :"tenant.principal_authentication_policy.resolved"
+            TENANT_PRINCIPAL_AUTHENTICATION_POLICY_RESOLVED = :"tenant.principal_authentication_policy.resolved"
             TENANT_SCIM_SETUP_STARTED = :"tenant.scim.setup.started"
             TENANT_SCIM_DELETION_REQUESTED = :"tenant.scim.deletion.requested"
             TENANT_SCIM_DIRECTORY_CREATED = :"tenant.scim.directory.created"

--- a/lib/openai/models/admin/organization/groups/role_list_response.rb
+++ b/lib/openai/models/admin/organization/groups/role_list_response.rb
@@ -18,11 +18,7 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> do
-                       OpenAI::Internal::Type::ArrayOf[
-                         OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource
-                       ]
-                     end,
+                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource] },
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/groups/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/groups/role_retrieve_response.rb
@@ -18,11 +18,7 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> do
-                       OpenAI::Internal::Type::ArrayOf[
-                         OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource
-                       ]
-                     end,
+                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource] },
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/groups/role_list_response.rb
+++ b/lib/openai/models/admin/organization/projects/groups/role_list_response.rb
@@ -19,12 +19,7 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> do
-                         OpenAI::Internal::Type::ArrayOf[
-                           OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::
-                           AssignmentSource
-                         ]
-                       end,
+                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource] },
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/groups/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/projects/groups/role_retrieve_response.rb
@@ -19,12 +19,7 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> do
-                         OpenAI::Internal::Type::ArrayOf[
-                           OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::
-                           AssignmentSource
-                         ]
-                       end,
+                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource] },
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/service_account_create_response.rb
+++ b/lib/openai/models/admin/organization/projects/service_account_create_response.rb
@@ -16,9 +16,7 @@ module OpenAI
             #
             #   @return [OpenAI::Models::Admin::Organization::Projects::ServiceAccountCreateResponse::APIKey, nil]
             required :api_key,
-                     -> {
-                       OpenAI::Models::Admin::Organization::Projects::ServiceAccountCreateResponse::APIKey
-                     },
+                     -> { OpenAI::Models::Admin::Organization::Projects::ServiceAccountCreateResponse::APIKey },
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/users/role_list_response.rb
+++ b/lib/openai/models/admin/organization/projects/users/role_list_response.rb
@@ -19,12 +19,7 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> do
-                         OpenAI::Internal::Type::ArrayOf[
-                           OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::
-                           AssignmentSource
-                         ]
-                       end,
+                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource] },
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/projects/users/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/projects/users/role_retrieve_response.rb
@@ -19,12 +19,7 @@ module OpenAI
               #
               #   @return [Array<OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource>, nil]
               required :assignment_sources,
-                       -> do
-                         OpenAI::Internal::Type::ArrayOf[
-                           OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::
-                           AssignmentSource
-                         ]
-                       end,
+                       -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource] },
                        nil?: true
 
               # @!attribute created_at

--- a/lib/openai/models/admin/organization/users/role_list_response.rb
+++ b/lib/openai/models/admin/organization/users/role_list_response.rb
@@ -18,11 +18,7 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> do
-                       OpenAI::Internal::Type::ArrayOf[
-                         OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource
-                       ]
-                     end,
+                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource] },
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/admin/organization/users/role_retrieve_response.rb
+++ b/lib/openai/models/admin/organization/users/role_retrieve_response.rb
@@ -18,11 +18,7 @@ module OpenAI
             #
             #   @return [Array<OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource>, nil]
             required :assignment_sources,
-                     -> do
-                       OpenAI::Internal::Type::ArrayOf[
-                         OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource
-                       ]
-                     end,
+                     -> { OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource] },
                      nil?: true
 
             # @!attribute created_at

--- a/lib/openai/models/vector_store_search_response.rb
+++ b/lib/openai/models/vector_store_search_response.rb
@@ -13,9 +13,7 @@ module OpenAI
       #
       #   @return [Hash{Symbol=>String, Float, Boolean}, nil]
       required :attributes,
-               -> {
-                 OpenAI::Internal::Type::HashOf[union: OpenAI::Models::VectorStoreSearchResponse::Attribute]
-               },
+               -> { OpenAI::Internal::Type::HashOf[union: OpenAI::Models::VectorStoreSearchResponse::Attribute] },
                nil?: true
 
       # @!attribute content

--- a/lib/openai/resources/admin/organization/projects.rb
+++ b/lib/openai/resources/admin/organization/projects.rb
@@ -182,8 +182,7 @@ module OpenAI
           def initialize(client:)
             @client = client
             @users = OpenAI::Resources::Admin::Organization::Projects::Users.new(client: client)
-            @service_accounts =
-              OpenAI::Resources::Admin::Organization::Projects::ServiceAccounts.new(client: client)
+            @service_accounts = OpenAI::Resources::Admin::Organization::Projects::ServiceAccounts.new(client: client)
             @api_keys = OpenAI::Resources::Admin::Organization::Projects::APIKeys.new(client: client)
             @rate_limits = OpenAI::Resources::Admin::Organization::Projects::RateLimits.new(client: client)
             @model_permissions =
@@ -192,8 +191,7 @@ module OpenAI
               OpenAI::Resources::Admin::Organization::Projects::HostedToolPermissions.new(client: client)
             @groups = OpenAI::Resources::Admin::Organization::Projects::Groups.new(client: client)
             @roles = OpenAI::Resources::Admin::Organization::Projects::Roles.new(client: client)
-            @data_retention =
-              OpenAI::Resources::Admin::Organization::Projects::DataRetention.new(client: client)
+            @data_retention = OpenAI::Resources::Admin::Organization::Projects::DataRetention.new(client: client)
             @spend_limit = OpenAI::Resources::Admin::Organization::Projects::SpendLimit.new(client: client)
             @spend_alerts = OpenAI::Resources::Admin::Organization::Projects::SpendAlerts.new(client: client)
             @certificates = OpenAI::Resources::Admin::Organization::Projects::Certificates.new(client: client)

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -662,8 +662,7 @@ module OpenAI
               tool_models.store(name, params)
               tool[:function][:parameters] = params.to_json_schema
               tool
-            in {type: _, function: Hash => func} if func[:parameters].is_a?(Class) &&
-              func[:parameters] < OpenAI::Internal::Type::BaseModel
+            in {type: _, function: Hash => func} if func[:parameters].is_a?(Class) && func[:parameters] < OpenAI::Internal::Type::BaseModel
               params = func[:parameters]
               name = func[:name] || params.name.split("::").last
               tool_models.store(name, params)

--- a/test/openai/logging_test.rb
+++ b/test/openai/logging_test.rb
@@ -472,14 +472,7 @@ class LoggingTest < Minitest::Test
     assert_equal(0.0, event.delay)
     assert_equal(429, event.status)
     assert_equal("req_1", event.request_id)
-    assert_equal(
-      {
-        "content-type" => "application/json",
-        "retry-after" => "0",
-        "x-request-id" => "req_1"
-      },
-      event.response.headers
-    )
+    assert_equal({"content-type" => "application/json", "retry-after" => "0", "x-request-id" => "req_1"}, event.response.headers)
     assert_nil(event.error)
     assert_predicate(event, :frozen?)
   end

--- a/test/openai/resources/admin/organization/audit_logs_test.rb
+++ b/test/openai/resources/admin/organization/audit_logs_test.rb
@@ -26,46 +26,31 @@ class OpenAI::Test::Resources::Admin::Organization::AuditLogsTest < OpenAI::Test
         api_key_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::APIKeyCreated | nil,
         api_key_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::APIKeyDeleted | nil,
         api_key_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::APIKeyUpdated | nil,
-        certificate_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateCreated | nil,
-        certificate_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateDeleted | nil,
-        certificate_updated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateUpdated | nil,
-        certificates_activated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesActivated | nil,
-        certificates_deactivated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesDeactivated | nil,
-        checkpoint_permission_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated | nil,
-        checkpoint_permission_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted | nil,
-        external_key_registered:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRegistered | nil,
-        external_key_removed:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRemoved | nil,
+        certificate_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateCreated | nil,
+        certificate_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateDeleted | nil,
+        certificate_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificateUpdated | nil,
+        certificates_activated: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesActivated | nil,
+        certificates_deactivated: OpenAI::Models::Admin::Organization::AuditLogListResponse::CertificatesDeactivated | nil,
+        checkpoint_permission_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionCreated | nil,
+        checkpoint_permission_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::CheckpointPermissionDeleted | nil,
+        external_key_registered: OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRegistered | nil,
+        external_key_removed: OpenAI::Models::Admin::Organization::AuditLogListResponse::ExternalKeyRemoved | nil,
         group_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::GroupCreated | nil,
         group_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::GroupDeleted | nil,
         group_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::GroupUpdated | nil,
         invite_accepted: OpenAI::Models::Admin::Organization::AuditLogListResponse::InviteAccepted | nil,
         invite_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::InviteDeleted | nil,
         invite_sent: OpenAI::Models::Admin::Organization::AuditLogListResponse::InviteSent | nil,
-        ip_allowlist_config_activated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated | nil,
-        ip_allowlist_config_deactivated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated | nil,
-        ip_allowlist_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistCreated | nil,
-        ip_allowlist_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistDeleted | nil,
-        ip_allowlist_updated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistUpdated | nil,
+        ip_allowlist_config_activated: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigActivated | nil,
+        ip_allowlist_config_deactivated: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistConfigDeactivated | nil,
+        ip_allowlist_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistCreated | nil,
+        ip_allowlist_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistDeleted | nil,
+        ip_allowlist_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::IPAllowlistUpdated | nil,
         login_failed: OpenAI::Models::Admin::Organization::AuditLogListResponse::LoginFailed | nil,
         login_succeeded: OpenAI::Internal::Type::Unknown | nil,
         logout_failed: OpenAI::Models::Admin::Organization::AuditLogListResponse::LogoutFailed | nil,
         logout_succeeded: OpenAI::Internal::Type::Unknown | nil,
-        organization_updated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::OrganizationUpdated | nil,
+        organization_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::OrganizationUpdated | nil,
         project: OpenAI::Models::Admin::Organization::AuditLogListResponse::Project | nil,
         project_archived: OpenAI::Models::Admin::Organization::AuditLogListResponse::ProjectArchived | nil,
         project_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::ProjectCreated | nil,
@@ -73,43 +58,27 @@ class OpenAI::Test::Resources::Admin::Organization::AuditLogsTest < OpenAI::Test
         project_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::ProjectUpdated | nil,
         rate_limit_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::RateLimitDeleted | nil,
         rate_limit_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::RateLimitUpdated | nil,
-        role_assignment_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentCreated | nil,
-        role_assignment_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentDeleted | nil,
-        role_bound_to_resource:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleBoundToResource | nil,
+        role_assignment_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentCreated | nil,
+        role_assignment_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleAssignmentDeleted | nil,
+        role_bound_to_resource: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleBoundToResource | nil,
         role_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleCreated | nil,
         role_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleDeleted | nil,
-        role_unbound_from_resource:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleUnboundFromResource | nil,
+        role_unbound_from_resource: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleUnboundFromResource | nil,
         role_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::RoleUpdated | nil,
         scim_disabled: OpenAI::Models::Admin::Organization::AuditLogListResponse::ScimDisabled | nil,
         scim_enabled: OpenAI::Models::Admin::Organization::AuditLogListResponse::ScimEnabled | nil,
-        service_account_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountCreated | nil,
-        service_account_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountDeleted | nil,
-        service_account_updated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountUpdated | nil,
+        service_account_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountCreated | nil,
+        service_account_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountDeleted | nil,
+        service_account_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::ServiceAccountUpdated | nil,
         user_added: OpenAI::Models::Admin::Organization::AuditLogListResponse::UserAdded | nil,
         user_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::UserDeleted | nil,
         user_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::UserUpdated | nil,
-        workload_identity_provider_mapping_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::
-          WorkloadIdentityProviderMappingCreated | nil,
-        workload_identity_provider_mapping_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::
-          WorkloadIdentityProviderMappingDeleted | nil,
-        workload_identity_provider_mapping_updated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::
-          WorkloadIdentityProviderMappingUpdated | nil,
-        workload_identity_provider_created:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated | nil,
-        workload_identity_provider_deleted:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted | nil,
-        workload_identity_provider_updated:
-          OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated | nil
+        workload_identity_provider_mapping_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingCreated | nil,
+        workload_identity_provider_mapping_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingDeleted | nil,
+        workload_identity_provider_mapping_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderMappingUpdated | nil,
+        workload_identity_provider_created: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderCreated | nil,
+        workload_identity_provider_deleted: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderDeleted | nil,
+        workload_identity_provider_updated: OpenAI::Models::Admin::Organization::AuditLogListResponse::WorkloadIdentityProviderUpdated | nil
       }
     end
   end

--- a/test/openai/resources/admin/organization/groups/roles_test.rb
+++ b/test/openai/resources/admin/organization/groups/roles_test.rb
@@ -29,12 +29,7 @@ class OpenAI::Test::Resources::Admin::Organization::Groups::RolesTest < OpenAI::
     assert_pattern do
       response => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleRetrieveResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -66,12 +61,7 @@ class OpenAI::Test::Resources::Admin::Organization::Groups::RolesTest < OpenAI::
     assert_pattern do
       row => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Groups::RoleListResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/admin/organization/projects/groups/roles_test.rb
+++ b/test/openai/resources/admin/organization/projects/groups/roles_test.rb
@@ -39,12 +39,7 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Groups::RolesTest 
     assert_pattern do
       response => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleRetrieveResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -76,12 +71,7 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Groups::RolesTest 
     assert_pattern do
       row => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Groups::RoleListResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/admin/organization/projects/users/roles_test.rb
+++ b/test/openai/resources/admin/organization/projects/users/roles_test.rb
@@ -39,12 +39,7 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Users::RolesTest <
     assert_pattern do
       response => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleRetrieveResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -76,12 +71,7 @@ class OpenAI::Test::Resources::Admin::Organization::Projects::Users::RolesTest <
     assert_pattern do
       row => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Projects::Users::RoleListResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/admin/organization/usage_test.rb
+++ b/test/openai/resources/admin/organization/usage_test.rb
@@ -12,12 +12,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageAudioSpeechesResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageAudioSpeechesResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -34,12 +29,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageAudioTranscriptionsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageAudioTranscriptionsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -56,12 +46,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageCodeInterpreterSessionsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageCodeInterpreterSessionsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -78,12 +63,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageCompletionsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageCompletionsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -100,12 +80,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageCostsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageCostsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -122,12 +97,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageEmbeddingsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageEmbeddingsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -144,12 +114,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageFileSearchCallsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageFileSearchCallsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -166,12 +131,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageImagesResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageImagesResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -188,12 +148,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageModerationsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageModerationsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -210,12 +165,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageVectorStoresResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageVectorStoresResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol
@@ -232,12 +182,7 @@ class OpenAI::Test::Resources::Admin::Organization::UsageTest < OpenAI::Test::Re
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::UsageWebSearchCallsResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::UsageWebSearchCallsResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         next_page: String | nil,
         object: Symbol

--- a/test/openai/resources/admin/organization/users/roles_test.rb
+++ b/test/openai/resources/admin/organization/users/roles_test.rb
@@ -29,12 +29,7 @@ class OpenAI::Test::Resources::Admin::Organization::Users::RolesTest < OpenAI::T
     assert_pattern do
       response => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleRetrieveResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,
@@ -66,12 +61,7 @@ class OpenAI::Test::Resources::Admin::Organization::Users::RolesTest < OpenAI::T
     assert_pattern do
       row => {
         id: String,
-        assignment_sources:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource
-            ]
-          ) | nil,
+        assignment_sources: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Admin::Organization::Users::RoleListResponse::AssignmentSource]) | nil,
         created_at: Integer | nil,
         created_by: String | nil,
         created_by_user_obj: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]) | nil,

--- a/test/openai/resources/beta/chatkit/threads_test.rb
+++ b/test/openai/resources/beta/chatkit/threads_test.rb
@@ -99,12 +99,7 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
           type: :"chatkit.user_message",
           id: String,
           attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
-          content:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content
-              ]
-            ),
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content]),
           created_at: Integer,
           inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
           object: Symbol,
@@ -153,12 +148,7 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
           id: String,
           created_at: Integer,
           object: Symbol,
-          tasks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task
-              ]
-            ),
+          tasks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task]),
           thread_id: String
         }
       )

--- a/test/openai/resources/beta/responses/input_items_test.rb
+++ b/test/openai/resources/beta/responses/input_items_test.rb
@@ -83,23 +83,13 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
           queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
           status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
           agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
-          results:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Beta::BetaResponseFileSearchToolCall::Result
-              ]
-            ) | nil
+          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFileSearchToolCall::Result]) | nil
         } |
         {
           type: :computer_call,
           id: String,
           call_id: String,
-          pending_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck
-              ]
-            ),
+          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck]),
           status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
           action: OpenAI::Beta::BetaComputerAction | nil,
           actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
@@ -111,12 +101,7 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
           call_id: String,
           output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
           status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-              ]
-            ) | nil,
+          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
           agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
           created_by: String | nil
         } |
@@ -143,12 +128,7 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
           type: :agent_message,
           id: String,
           author: String,
-          content:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content
-              ]
-            ),
+          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content]),
           recipient: String,
           agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
         } |
@@ -239,12 +219,7 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
           id: String,
           code: String | nil,
           container_id: String,
-          outputs:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output
-              ]
-            ) | nil,
+          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output]) | nil,
           status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
           agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
         } |
@@ -279,12 +254,7 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
           id: String,
           call_id: String,
           max_output_length: Integer | nil,
-          output:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output
-              ]
-            ),
+          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output]),
           status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
           agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
           caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,

--- a/test/openai/resources/conversations/items_test.rb
+++ b/test/openai/resources/conversations/items_test.rb
@@ -95,12 +95,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           id: String,
           queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
           status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-          results:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseFileSearchToolCall::Result
-              ]
-            ) | nil
+          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
         } |
         {
           type: :web_search_call,
@@ -118,12 +113,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           type: :computer_call,
           id: String,
           call_id: String,
-          pending_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-              ]
-            ),
+          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
           status: OpenAI::Responses::ResponseComputerToolCall::Status,
           action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
           actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
@@ -134,12 +124,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           call_id: String,
           output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
           status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-              ]
-            ) | nil,
+          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
           created_by: String | nil
         } |
         {
@@ -170,12 +155,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           type: :reasoning,
           id: String,
           summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-          content:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseReasoningItem::Content
-              ]
-            ) | nil,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
           encrypted_content: String | nil,
           status: OpenAI::Responses::ResponseReasoningItem::Status | nil
         } |
@@ -193,12 +173,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           id: String,
           code: String | nil,
           container_id: String,
-          outputs:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-              ]
-            ) | nil,
+          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
           status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
         } |
         {
@@ -229,12 +204,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           id: String,
           call_id: String,
           max_output_length: Integer | nil,
-          output:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-              ]
-            ),
+          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
           status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
           caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
           created_by: String | nil
@@ -261,12 +231,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           type: :mcp_list_tools,
           id: String,
           server_label: String,
-          tools:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Conversations::ConversationItem::McpListTools::Tool
-              ]
-            ),
+          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]),
           error: String | nil
         } |
         {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
@@ -387,12 +352,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           id: String,
           queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
           status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-          results:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseFileSearchToolCall::Result
-              ]
-            ) | nil
+          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
         } |
         {
           type: :web_search_call,
@@ -410,12 +370,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           type: :computer_call,
           id: String,
           call_id: String,
-          pending_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-              ]
-            ),
+          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
           status: OpenAI::Responses::ResponseComputerToolCall::Status,
           action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
           actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
@@ -426,12 +381,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           call_id: String,
           output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
           status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-              ]
-            ) | nil,
+          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
           created_by: String | nil
         } |
         {
@@ -462,12 +412,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           type: :reasoning,
           id: String,
           summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-          content:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseReasoningItem::Content
-              ]
-            ) | nil,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
           encrypted_content: String | nil,
           status: OpenAI::Responses::ResponseReasoningItem::Status | nil
         } |
@@ -485,12 +430,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           id: String,
           code: String | nil,
           container_id: String,
-          outputs:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-              ]
-            ) | nil,
+          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
           status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
         } |
         {
@@ -521,12 +461,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           id: String,
           call_id: String,
           max_output_length: Integer | nil,
-          output:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-              ]
-            ),
+          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
           status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
           caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
           created_by: String | nil
@@ -553,12 +488,7 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
           type: :mcp_list_tools,
           id: String,
           server_label: String,
-          tools:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Conversations::ConversationItem::McpListTools::Tool
-              ]
-            ),
+          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]),
           error: String | nil
         } |
         {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |

--- a/test/openai/resources/evals/runs/output_items_test.rb
+++ b/test/openai/resources/evals/runs/output_items_test.rb
@@ -19,12 +19,7 @@ class OpenAI::Test::Resources::Evals::Runs::OutputItemsTest < OpenAI::Test::Reso
         datasource_item_id: Integer,
         eval_id: String,
         object: Symbol,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::Runs::OutputItemRetrieveResponse::Result
-            ]
-          ),
+        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::Runs::OutputItemRetrieveResponse::Result]),
         run_id: String,
         sample: OpenAI::Models::Evals::Runs::OutputItemRetrieveResponse::Sample,
         status: String
@@ -54,12 +49,7 @@ class OpenAI::Test::Resources::Evals::Runs::OutputItemsTest < OpenAI::Test::Reso
         datasource_item_id: Integer,
         eval_id: String,
         object: Symbol,
-        results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::Runs::OutputItemListResponse::Result
-            ]
-          ),
+        results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::Runs::OutputItemListResponse::Result]),
         run_id: String,
         sample: OpenAI::Models::Evals::Runs::OutputItemListResponse::Sample,
         status: String

--- a/test/openai/resources/evals/runs_test.rb
+++ b/test/openai/resources/evals/runs_test.rb
@@ -25,18 +25,8 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunCreateResponse::PerModelUsage
-            ]
-          ),
-        per_testing_criteria_results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunCreateResponse::PerTestingCriteriaResult
-            ]
-          ),
+        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCreateResponse::PerModelUsage]),
+        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCreateResponse::PerTestingCriteriaResult]),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunCreateResponse::ResultCounts,
         status: String
@@ -62,18 +52,8 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunRetrieveResponse::PerModelUsage
-            ]
-          ),
-        per_testing_criteria_results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunRetrieveResponse::PerTestingCriteriaResult
-            ]
-          ),
+        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunRetrieveResponse::PerModelUsage]),
+        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunRetrieveResponse::PerTestingCriteriaResult]),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunRetrieveResponse::ResultCounts,
         status: String
@@ -106,18 +86,8 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunListResponse::PerModelUsage
-            ]
-          ),
-        per_testing_criteria_results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunListResponse::PerTestingCriteriaResult
-            ]
-          ),
+        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunListResponse::PerModelUsage]),
+        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunListResponse::PerTestingCriteriaResult]),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunListResponse::ResultCounts,
         status: String
@@ -159,18 +129,8 @@ class OpenAI::Test::Resources::Evals::RunsTest < OpenAI::Test::ResourceTest
         model: String,
         name: String,
         object: Symbol,
-        per_model_usage:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunCancelResponse::PerModelUsage
-            ]
-          ),
-        per_testing_criteria_results:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::Evals::RunCancelResponse::PerTestingCriteriaResult
-            ]
-          ),
+        per_model_usage: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCancelResponse::PerModelUsage]),
+        per_testing_criteria_results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::Evals::RunCancelResponse::PerTestingCriteriaResult]),
         report_url: String,
         result_counts: OpenAI::Models::Evals::RunCancelResponse::ResultCounts,
         status: String

--- a/test/openai/resources/evals_test.rb
+++ b/test/openai/resources/evals_test.rb
@@ -31,12 +31,7 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Models::EvalCreateResponse::TestingCriterion
-            ]
-          )
+        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalCreateResponse::TestingCriterion])
       }
     end
   end
@@ -56,12 +51,7 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Models::EvalRetrieveResponse::TestingCriterion
-            ]
-          )
+        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalRetrieveResponse::TestingCriterion])
       }
     end
   end
@@ -81,12 +71,7 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Models::EvalUpdateResponse::TestingCriterion
-            ]
-          )
+        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalUpdateResponse::TestingCriterion])
       }
     end
   end
@@ -113,12 +98,7 @@ class OpenAI::Test::Resources::EvalsTest < OpenAI::Test::ResourceTest
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         name: String,
         object: Symbol,
-        testing_criteria:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              union: OpenAI::Models::EvalListResponse::TestingCriterion
-            ]
-          )
+        testing_criteria: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Models::EvalListResponse::TestingCriterion])
       }
     end
   end

--- a/test/openai/resources/fine_tuning/alpha/graders_test.rb
+++ b/test/openai/resources/fine_tuning/alpha/graders_test.rb
@@ -17,12 +17,7 @@ class OpenAI::Test::Resources::FineTuning::Alpha::GradersTest < OpenAI::Test::Re
     assert_pattern do
       response => {
         metadata: OpenAI::Models::FineTuning::Alpha::GraderRunResponse::Metadata,
-        model_grader_token_usage_per_model:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              OpenAI::Internal::Type::Unknown
-            ]
-          ),
+        model_grader_token_usage_per_model: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]),
         reward: Float,
         sub_rewards: ^(OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown])
       }

--- a/test/openai/resources/fine_tuning/checkpoints/permissions_test.rb
+++ b/test/openai/resources/fine_tuning/checkpoints/permissions_test.rb
@@ -40,12 +40,7 @@ class OpenAI::Test::Resources::FineTuning::Checkpoints::PermissionsTest < OpenAI
 
     assert_pattern do
       response => {
-        data:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::Models::FineTuning::Checkpoints::PermissionRetrieveResponse::Data
-            ]
-          ),
+        data: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::FineTuning::Checkpoints::PermissionRetrieveResponse::Data]),
         has_more: OpenAI::Internal::Type::Boolean,
         object: Symbol,
         first_id: String | nil,

--- a/test/openai/resources/fine_tuning/jobs_test.rb
+++ b/test/openai/resources/fine_tuning/jobs_test.rb
@@ -28,12 +28,7 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
-            ]
-          ) | nil,
+        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -65,12 +60,7 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
-            ]
-          ) | nil,
+        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -109,12 +99,7 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
-            ]
-          ) | nil,
+        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -146,12 +131,7 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
-            ]
-          ) | nil,
+        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -210,12 +190,7 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
-            ]
-          ) | nil,
+        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }
@@ -247,12 +222,7 @@ class OpenAI::Test::Resources::FineTuning::JobsTest < OpenAI::Test::ResourceTest
         training_file: String,
         validation_file: String | nil,
         estimated_finish: Integer | nil,
-        integrations:
-          ^(
-            OpenAI::Internal::Type::ArrayOf[
-              OpenAI::FineTuning::FineTuningJobWandbIntegrationObject
-            ]
-          ) | nil,
+        integrations: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::FineTuning::FineTuningJobWandbIntegrationObject]) | nil,
         metadata: ^(OpenAI::Internal::Type::HashOf[String]) | nil,
         method_: OpenAI::FineTuning::FineTuningJob::Method | nil
       }

--- a/test/openai/resources/responses/input_items_test.rb
+++ b/test/openai/resources/responses/input_items_test.rb
@@ -77,23 +77,13 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
           id: String,
           queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
           status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-          results:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseFileSearchToolCall::Result
-              ]
-            ) | nil
+          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
         } |
         {
           type: :computer_call,
           id: String,
           call_id: String,
-          pending_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck
-              ]
-            ),
+          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
           status: OpenAI::Responses::ResponseComputerToolCall::Status,
           action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
           actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
@@ -104,12 +94,7 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
           call_id: String,
           output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
           status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck
-              ]
-            ) | nil,
+          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
           created_by: String | nil
         } |
         {
@@ -157,12 +142,7 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
           type: :reasoning,
           id: String,
           summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-          content:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseReasoningItem::Content
-              ]
-            ) | nil,
+          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
           encrypted_content: String | nil,
           status: OpenAI::Responses::ResponseReasoningItem::Status | nil
         } |
@@ -186,12 +166,7 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
           id: String,
           code: String | nil,
           container_id: String,
-          outputs:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output
-              ]
-            ) | nil,
+          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
           status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
         } |
         {
@@ -222,12 +197,7 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
           id: String,
           call_id: String,
           max_output_length: Integer | nil,
-          output:
-            ^(
-              OpenAI::Internal::Type::ArrayOf[
-                OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output
-              ]
-            ),
+          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
           status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
           caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
           created_by: String | nil

--- a/test/openai/resources/vector_stores/file_batches_test.rb
+++ b/test/openai/resources/vector_stores/file_batches_test.rb
@@ -83,12 +83,7 @@ class OpenAI::Test::Resources::VectorStores::FileBatchesTest < OpenAI::Test::Res
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              union: OpenAI::VectorStores::VectorStoreFile::Attribute
-            ]
-          ) | nil,
+        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end

--- a/test/openai/resources/vector_stores/files_test.rb
+++ b/test/openai/resources/vector_stores/files_test.rb
@@ -19,12 +19,7 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              union: OpenAI::VectorStores::VectorStoreFile::Attribute
-            ]
-          ) | nil,
+        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end
@@ -46,12 +41,7 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              union: OpenAI::VectorStores::VectorStoreFile::Attribute
-            ]
-          ) | nil,
+        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end
@@ -78,12 +68,7 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              union: OpenAI::VectorStores::VectorStoreFile::Attribute
-            ]
-          ) | nil,
+        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end
@@ -112,12 +97,7 @@ class OpenAI::Test::Resources::VectorStores::FilesTest < OpenAI::Test::ResourceT
         status: OpenAI::VectorStores::VectorStoreFile::Status,
         usage_bytes: Integer,
         vector_store_id: String,
-        attributes:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              union: OpenAI::VectorStores::VectorStoreFile::Attribute
-            ]
-          ) | nil,
+        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::VectorStores::VectorStoreFile::Attribute]) | nil,
         chunking_strategy: OpenAI::FileChunkingStrategy | nil
       }
     end

--- a/test/openai/resources/vector_stores_test.rb
+++ b/test/openai/resources/vector_stores_test.rb
@@ -138,12 +138,7 @@ class OpenAI::Test::Resources::VectorStoresTest < OpenAI::Test::ResourceTest
 
     assert_pattern do
       row => {
-        attributes:
-          ^(
-            OpenAI::Internal::Type::HashOf[
-              union: OpenAI::Models::VectorStoreSearchResponse::Attribute
-            ]
-          ) | nil,
+        attributes: ^(OpenAI::Internal::Type::HashOf[union: OpenAI::Models::VectorStoreSearchResponse::Attribute]) | nil,
         content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Models::VectorStoreSearchResponse::Content]),
         file_id: String,
         filename: String,

--- a/test/openai/resources/webhooks_test.rb
+++ b/test/openai/resources/webhooks_test.rb
@@ -15,10 +15,7 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     @webhook_service = @client.webhooks
 
     # Standardized test data matching TypeScript
-    @test_payload =
-      '{"id": "evt_685c059ae3a481909bdc86819b066fb6", "object": "event", ' \
-      '"created_at": 1750861210, "type": "response.completed", ' \
-      '"data": {"id": "resp_123"}}'
+    @test_payload = '{"id": "evt_685c059ae3a481909bdc86819b066fb6", "object": "event", "created_at": 1750861210, "type": "response.completed", "data": {"id": "resp_123"}}'
     @test_secret = "whsec_RdvaYFYUXuIFuEbvZHwMfYFhUf7aMYjYcmM24+Aj40c="
 
     @fixed_timestamp = "1750861210"
@@ -203,8 +200,7 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
     old_timestamp = (1_750_861_210 - 400).to_s
 
     headers = {
-      # This won't match the old timestamp, but this test exercises time validation.
-      "webhook-signature" => @webhook_signature,
+      "webhook-signature" => @webhook_signature, # This won't match old timestamp but we're testing time validation
       "webhook-timestamp" => old_timestamp,
       "webhook-id" => @webhook_id
     }


### PR DESCRIPTION
## Summary

Remove the source-layout workarounds added to satisfy the former 110-column RuboCop policy. Those edits created unnecessary custom-code differences in generated SDK files and made subsequent regeneration harder to merge.

Undo the formatting-only changes from #406 and #416 while preserving later API additions, combined pattern alternatives, explicit branch bodies, and the logging security fixes. Castiron's companion change removes the generator-side width policy; rubyfmt will take ownership of source layout in the next PR. The API reference and generation checkpoint are unchanged.


<!-- castiron-custom-code-audit:start -->
<details>
<summary>Full generated-file custom-code audit: 73 → 45 mixed files</summary>

Compared all **3,649 Castiron-generated files** (`lib`, `test`, `rbi`, and `sig`) against the same pure-generated tree, using the SDK's original API/config inputs and the compiler with the layout cleanup applied. Before: [`cf48c0157`](https://github.com/openai/openai-ruby/commit/cf48c0157183797b5c4c66635ad4bfcb14fe2b3a); after: [`bbb85f601`](https://github.com/openai/openai-ruby/commit/bbb85f60183fae3525ba676fa81118f40b2adee6). The API reference and generation checkpoint are unchanged.

A **mixed file** is a generator-owned file whose SDK contents differ from pure codegen. The numbers below count added plus deleted lines in that textual diff (line-level `SequenceMatcher`, with `autojunk=False`). They include intentional handwritten behavior and generator drift; a remaining difference is not automatically something to remove. Handwritten-only files are excluded.

**Whole-tree result:** 73 → 45 mixed files; 10,611 → 9,936 differing lines. All 35 generated files changed by this PR improve, 28 become exact matches, and no file regresses. The other 3,576 generated files match exactly on both sides.

Every generated file that differs on either side is listed below, including differences untouched by this PR.

| Generated file | Before | After | Result |
| --- | ---: | ---: | --- |
| `lib/openai.rb` | 31 | 31 | Unchanged; remains mixed |
| `lib/openai/client.rb` | 169 | 167 | Reduced; remains mixed |
| `lib/openai/models/admin/organization/audit_log_list_params.rb` | 3 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/audit_log_list_response.rb` | 43 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/groups/role_list_response.rb` | 6 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/groups/role_retrieve_response.rb` | 6 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/projects/groups/role_list_response.rb` | 7 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/projects/groups/role_retrieve_response.rb` | 7 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/projects/service_account_create_response.rb` | 4 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/projects/users/role_list_response.rb` | 7 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/projects/users/role_retrieve_response.rb` | 7 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/users/role_list_response.rb` | 6 | 0 | Matches codegen |
| `lib/openai/models/admin/organization/users/role_retrieve_response.rb` | 6 | 0 | Matches codegen |
| `lib/openai/models/chat/chat_completion_message.rb` | 8 | 8 | Unchanged; remains mixed |
| `lib/openai/models/chat/chat_completion_message_function_tool_call.rb` | 8 | 8 | Unchanged; remains mixed |
| `lib/openai/models/chat/completion_create_params.rb` | 21 | 21 | Unchanged; remains mixed |
| `lib/openai/models/response_format_json_schema.rb` | 10 | 10 | Unchanged; remains mixed |
| `lib/openai/models/responses/function_tool.rb` | 7 | 7 | Unchanged; remains mixed |
| `lib/openai/models/responses/response.rb` | 20 | 20 | Unchanged; remains mixed |
| `lib/openai/models/responses/response_create_params.rb` | 8 | 8 | Unchanged; remains mixed |
| `lib/openai/models/responses/response_format_text_config.rb` | 6 | 6 | Unchanged; remains mixed |
| `lib/openai/models/responses/response_format_text_json_schema_config.rb` | 11 | 11 | Unchanged; remains mixed |
| `lib/openai/models/responses/response_function_tool_call.rb` | 8 | 8 | Unchanged; remains mixed |
| `lib/openai/models/responses/response_function_web_search.rb` | 12 | 12 | Unchanged; remains mixed |
| `lib/openai/models/responses/response_output_text.rb` | 8 | 8 | Unchanged; remains mixed |
| `lib/openai/models/responses/tool.rb` | 2 | 2 | Unchanged; remains mixed |
| `lib/openai/models/vector_store_search_response.rb` | 4 | 0 | Matches codegen |
| `lib/openai/resources/admin/organization/projects.rb` | 6 | 0 | Matches codegen |
| `lib/openai/resources/beta/responses.rb` | 2 | 2 | Unchanged; remains mixed |
| `lib/openai/resources/beta/threads.rb` | 4 | 4 | Unchanged; remains mixed |
| `lib/openai/resources/chat/completions.rb` | 135 | 135 | Unchanged; remains mixed |
| `lib/openai/resources/responses.rb` | 298 | 297 | Reduced; remains mixed |
| `lib/openai/resources/webhooks.rb` | 111 | 111 | Unchanged; remains mixed |
| `rbi/openai/client.rbi` | 25 | 25 | Unchanged; remains mixed |
| `rbi/openai/models/beta/beta_responses_server_event.rbi` | 2,471 | 2,471 | Unchanged; remains mixed |
| `rbi/openai/models/chat/chat_completion_message.rbi` | 4 | 4 | Unchanged; remains mixed |
| `rbi/openai/models/chat/chat_completion_message_function_tool_call.rbi` | 4 | 4 | Unchanged; remains mixed |
| `rbi/openai/models/chat/completion_create_params.rbi` | 7 | 7 | Unchanged; remains mixed |
| `rbi/openai/models/response_format_json_schema.rbi` | 21 | 21 | Unchanged; remains mixed |
| `rbi/openai/models/responses/response_create_params.rbi` | 10 | 10 | Unchanged; remains mixed |
| `rbi/openai/models/responses/response_function_tool_call.rbi` | 4 | 4 | Unchanged; remains mixed |
| `rbi/openai/models/responses/response_function_web_search.rbi` | 12 | 12 | Unchanged; remains mixed |
| `rbi/openai/models/responses/response_output_text.rbi` | 4 | 4 | Unchanged; remains mixed |
| `rbi/openai/models/responses/responses_server_event.rbi` | 1,968 | 1,968 | Unchanged; remains mixed |
| `rbi/openai/resources/chat/completions.rbi` | 2 | 2 | Unchanged; remains mixed |
| `rbi/openai/resources/responses.rbi` | 269 | 269 | Unchanged; remains mixed |
| `rbi/openai/resources/webhooks.rbi` | 33 | 33 | Unchanged; remains mixed |
| `sig/openai/client.rbs` | 13 | 13 | Unchanged; remains mixed |
| `sig/openai/models/beta/beta_responses_server_event.rbs` | 1,526 | 1,526 | Unchanged; remains mixed |
| `sig/openai/models/responses/response_function_web_search.rbs` | 4 | 4 | Unchanged; remains mixed |
| `sig/openai/models/responses/responses_server_event.rbs` | 1,384 | 1,384 | Unchanged; remains mixed |
| `sig/openai/resources/responses.rbs` | 28 | 28 | Unchanged; remains mixed |
| `sig/openai/resources/webhooks.rbs` | 11 | 11 | Unchanged; remains mixed |
| `test/openai/resources/admin/organization/audit_logs_test.rb` | 87 | 0 | Matches codegen |
| `test/openai/resources/admin/organization/groups/roles_test.rb` | 14 | 0 | Matches codegen |
| `test/openai/resources/admin/organization/projects/groups/roles_test.rb` | 14 | 0 | Matches codegen |
| `test/openai/resources/admin/organization/projects/users/roles_test.rb` | 14 | 0 | Matches codegen |
| `test/openai/resources/admin/organization/usage_test.rb` | 77 | 0 | Matches codegen |
| `test/openai/resources/admin/organization/users/roles_test.rb` | 14 | 0 | Matches codegen |
| `test/openai/resources/beta/chatkit/threads_test.rb` | 72 | 62 | Reduced; remains mixed |
| `test/openai/resources/beta/responses/input_items_test.rb` | 315 | 285 | Reduced; remains mixed |
| `test/openai/resources/conversations/items_test.rb` | 508 | 438 | Reduced; remains mixed |
| `test/openai/resources/evals/runs/output_items_test.rb` | 14 | 0 | Matches codegen |
| `test/openai/resources/evals/runs_test.rb` | 56 | 0 | Matches codegen |
| `test/openai/resources/evals_test.rb` | 28 | 0 | Matches codegen |
| `test/openai/resources/fine_tuning/alpha/graders_test.rb` | 7 | 0 | Matches codegen |
| `test/openai/resources/fine_tuning/checkpoints/permissions_test.rb` | 7 | 0 | Matches codegen |
| `test/openai/resources/fine_tuning/jobs_test.rb` | 42 | 0 | Matches codegen |
| `test/openai/resources/responses/input_items_test.rb` | 239 | 209 | Reduced; remains mixed |
| `test/openai/resources/vector_stores/file_batches_test.rb` | 7 | 0 | Matches codegen |
| `test/openai/resources/vector_stores/files_test.rb` | 28 | 0 | Matches codegen |
| `test/openai/resources/vector_stores_test.rb` | 7 | 0 | Matches codegen |
| `test/openai/resources/webhooks_test.rb` | 270 | 266 | Reduced; remains mixed |
| **Total** | **10,611** | **9,936** | **45 remain mixed** |

</details>
<!-- castiron-custom-code-audit:end -->

## Stack

- https://github.com/openai/openai-ruby/pull/425
- https://github.com/openai/openai-ruby/pull/426
- https://github.com/openai/openai/pull/1307156
- https://github.com/openai/openai-ruby/pull/427 👈 this PR
- https://github.com/openai/openai/pull/1307196
- https://github.com/openai/openai-ruby/pull/428
- https://github.com/openai/openai/pull/1307238
