### PR TITLE
chore: restore generated namespace line-length allowance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
+    - '^\s*OpenAI::(Models|Resources|Test)::[A-Za-z0-9_:]+\s*$'
   Max: 110
 
 Layout/MultilineArrayLineBreaks:


### PR DESCRIPTION
## Summary

- Restore a narrowly anchored `Layout/LineLength` allowance only for complete generated `OpenAI::Models`, `OpenAI::Resources`, or `OpenAI::Test` qualified-identifier lines.
- Ensure this exception does not match assignments, method calls, arguments, or other handwritten application expressions.
- Keep the existing 110-column limit and every unrelated RuboCop rule unchanged.

## Validation

- `rubocop _1.81.7_ --format simple`: 2,625 files inspected, no offenses.
- Parsed the RuboCop YAML and verified the 110-column limit and exactly one generated namespace exception.
- Confirmed the exception accepts identifier-only `Models`, `Resources`, and `Test` lines while rejecting assignments, method calls, arguments, and the reported handwritten streaming-test expression.