### PR TITLE
chore: restore generated line-length exemption

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/FirstMethodParameterLineBreak:
 Layout/LineLength:
   AllowedPatterns:
     - "^\\s*#.*$"
+    - "OpenAI::(Models|Resources|Test)::"
   Max: 110
 
 Layout/MultilineArrayLineBreaks:


### PR DESCRIPTION
## Summary

Restore the narrow `OpenAI::(Models|Resources|Test)::` `Layout/LineLength` allowed pattern removed by #419.

## Why

The companion Castiron physical-width formatter in openai/openai#1296986 was closed after architecture review. It could not guarantee 110 columns for indivisible identifiers, wire-value literals, or unsupported Ruby expression shapes, while adding substantial compiler complexity and exposing correctness risk—a review-discovered reindentation regression changed quoted symbols, including a JSON key and enum wire value.

Without the generator change, Ruby `main` is stricter than the merged generator can reproduce. Restoring the pre-#419 allowance keeps the existing 110-column default for ordinary Ruby while making generated output reproducible again.

This is a rollback of a rejected generator-dependent policy, not a new ratchet exemption.

## Impact

- Runtime/API behavior: none
- Generated files changed: none
- Castiron companion: none; the intended outcome is compatibility with merged Castiron
- Baseline/final offenses in the current tree: 0 / 0

## Validation

- `bundle exec rubocop --only Layout/LineLength .` — 2,625 files, 0 offenses
- `bundle exec rake lint:rubocop` — RuboCop and directive policy clean across 2,625 files
- `bundle exec rake typecheck` — Sorbet clean; 1,214 RBS files validated
- `bundle exec rake build:gem` — package built successfully

Tracking decision: [Ruby SDK Linting Ratchet](https://app.notion.com/p/openai/Ruby-SDK-Linting-Ratchet-Generator-Aware-Rollout-3b98e50b62b081489c4af454831417a9)
