### PR TITLE
chore: enforce heredoc method call position

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,6 +110,8 @@ Lint/EmptyInPattern:
   Enabled: true
 Lint/HashNewWithKeywordArgumentsAsDefault:
   Enabled: true
+Lint/HeredocMethodCallPosition:
+  Enabled: true
 Lint/IncompatibleIoSelectWithFiberScheduler:
   Enabled: true
 Lint/ItWithoutArgumentsInBlock:


### PR DESCRIPTION
## Summary

Enable `Lint/HeredocMethodCallPosition` explicitly in the repository RuboCop policy.

## Why

The cop prevents method calls on heredoc receivers from being placed after the heredoc terminator, where Ruby parsing is easy to misread. It is currently disabled even though the full repository already follows the rule, so this is a zero-debt correctness ratchet.

## Impact

- Runtime/API behavior: none
- Baseline/final offenses: 0 / 0 across 2,626 files
- Source changes: none
- Suppressions or exclusions: none
- Castiron impact: none. The current generated models/resources/signatures contain no heredoc receiver method calls; existing heredocs are already compliant, and the generated output assembly already runs the SDK lint task. No renderer or template change is needed.

## Validation

- `bundle exec rubocop --only Lint/HeredocMethodCallPosition .` — 2,626 files, 0 offenses
- `bundle exec rake lint:rubocop` — directive policy clean; 2,626 files, 0 offenses
- `bundle exec rake typecheck` — Sorbet clean; 1,214 RBS files validated
- `bundle exec rake build:gem` — package built successfully

Tracking: [Ruby SDK Linting Ratchet](https://app.notion.com/p/openai/Ruby-SDK-Linting-Ratchet-Generator-Aware-Rollout-3b98e50b62b081489c4af454831417a9)
