### PR TITLE
chore: enforce outer local variable shadowing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,6 +144,8 @@ Lint/RequireRangeParentheses:
   Enabled: true
 Lint/RequireRelativeSelfPath:
   Enabled: true
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
 Lint/SharedMutableDefault:
   Enabled: true
 Lint/SuppressedExceptionInNumberConversion:


### PR DESCRIPTION
## Summary

Enable `Lint/ShadowingOuterLocalVariable` so future block parameters cannot silently shadow an existing local variable.

This is a config-only, zero-debt ratchet: the full repository has no existing offenses, so there are no source changes, suppressions, or exclusions.

## Generator impact

No Castiron companion is needed. The current generated clients, model index, webhook helpers, tests, and signatures are clean under this cop. The Ruby templates use fixed, non-colliding block locals for the currently generated OpenAI SDK; `.rubocop.yml` is SDK-owned, and Castiron's assembled-SDK validation already invokes the repository lint task.

Baseline: 0 offenses across 2,630 Ruby/RBI files.
Final: 0 offenses across 2,630 Ruby/RBI files.

## Validation

- `bundle exec rubocop --only Lint/ShadowingOuterLocalVariable`
- `bundle exec rake lint:rubocop`
- `bundle exec rake typecheck`
- `bundle exec rake build:gem`
- `git diff --check`