### PR TITLE
chore: enforce top-level return arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,6 +152,10 @@ Lint/SuppressedExceptionInNumberConversion:
   Enabled: true
 Lint/SymbolConversion:
   Enabled: true
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+  # Remove RuboCop's built-in `.jb` exclusion.
+  Exclude: ~
 Lint/ToEnumArguments:
   Enabled: true
 Lint/TripleQuotes:


### PR DESCRIPTION
## Summary

Explicitly enforce `Lint/TopLevelReturnWithArgument` for every RuboCop-supported Ruby file type, including `.jb` files.

RuboCop enables this cop by default but also ships a blanket `**/*.jb` exclusion. This ratchet cancels only that inherited cop-specific exclusion with RuboCop's documented YAML `~` override. The repository's global dependency/build exclusions remain unchanged.

## Impact

The current tree contains no `.jb` files and has zero existing offenses, so this is a zero-debt policy ratchet with no source changes, suppressions, or new exclusions. A temporary untracked `.jb` fixture containing `return 1` was rejected by the cop, proving the inherited exclusion is removed; the fixture was deleted before commit.

Baseline: 0 offenses across 2,630 Ruby/RBI files.
Final: 0 offenses across 2,630 Ruby/RBI files.

## Generator impact

No Castiron companion is needed. Castiron's Ruby output assembly emits `.rb`, `.rbi`, and `.rbs` surfaces only; neither Castiron nor the SDK currently contains `.jb` output. `.rubocop.yml` is SDK-owned, and assembled-SDK validation already runs the repository lint task.

## Validation

- `bundle exec rubocop --show-cops Lint/TopLevelReturnWithArgument` (effective config has no `Exclude`)
- temporary `.jb` regression fixture rejected with `Lint/TopLevelReturnWithArgument`
- `bundle exec rubocop --only Lint/TopLevelReturnWithArgument` (2,630 files, 0 offenses)
- `bundle exec rake lint:rubocop` (2,630 files, 0 offenses)
- `bundle exec rake typecheck` (Sorbet clean; 1,214 RBS files valid)
- `bundle exec rake build:gem`
- `git diff --check`
- thermo-nuclear maintainability review: no findings