### PR TITLE
chore: enforce redundant enable directives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,8 +39,9 @@ Lint/UselessAssignment:
 # The directive guard still rejects broad or unowned suppressions.
 Lint/RedundantCopDisableDirective:
   Enabled: false
+# Every enable directive must still close an active disable.
 Lint/RedundantCopEnableDirective:
-  Enabled: false
+  Enabled: true
 
 # Dependency ordering is layout, not package correctness.
 Bundler/OrderedGems:


### PR DESCRIPTION
## Summary

- enable `Lint/RedundantCopEnableDirective`
- keep the existing temporary allowance for narrow disable directives
- reject unmatched or otherwise unnecessary `rubocop:enable` comments

## Why

The formatting migration still makes some narrow disable directives harmless, but their closing enable directives should remain structurally valid. This separates the two policies instead of disabling both directive checks together.

## Ratchet evidence

- Rule: `Lint/RedundantCopEnableDirective`
- Baseline: 0 offenses across 2,632 current Ruby/RBI files
- Final: 0 offenses; no suppressions or exclusions added
- Regression proof: a temporary untracked Ruby file with an unmatched `rubocop:enable Lint/EmptyBlock` was rejected by the cop, then removed before commit

## Castiron impact

No companion PR is needed. Castiron's Ruby renderer emits one paired `Lint/RedundantRequireStatement` disable/enable region in the generated root file, and its existing renderer fixture covers that region. Current generated output is clean; this SDK-owned config change cannot be overwritten by regeneration, while assembled-SDK validation already runs the repository RuboCop task.

## Validation

- focused `Lint/RedundantCopEnableDirective`: clean
- full `rake lint`: RuboCop clean, directive guard clean, Sorbet clean, 1,214 RBS files validated
- gem package build: successful
- `git diff --check`: clean
- thermo-nuclear maintainability review: no findings