### PR TITLE
docs: strengthen Ruby SDK security guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,27 @@
 ## Ruby implementation guidelines
 
 - Prefer direct method calls over Ruby reflection (`send`, `__send__`, or `public_send`) for internal SDK plumbing. When an internal method must be callable across components without becoming supported public API, keep the method public for direct dispatch and mark it `@api private`. Keep its RBI and RBS declarations at the same visibility.
+
+## Security requirements
+
+- Never commit real API keys, access tokens, signing keys, credentials, or
+  customer data. Read secrets from environment variables such as
+  `OPENAI_API_KEY` and use clearly fake values in examples, tests, and fixtures.
+- Redact authorization headers, cookies, tokens, signed URLs, request/response
+  bodies, prompts, uploaded files, and other sensitive data from logs, errors,
+  snapshots, and CI artifacts.
+- Review direct and transitive dependency changes in `Gemfile`, `Gemfile.lock`,
+  and `openai.gemspec`, including gem sources, locked Git revisions, native
+  extensions, and install/build scripts. Do not run unreviewed scripts.
+- Pin GitHub Actions to full commit SHAs and preserve least-privilege job
+  permissions, `permissions: {}`, and `persist-credentials: false`.
+- Protect GitHub App private keys and release credentials. Preserve protected
+  release environments and RubyGems trusted publishing; grant `id-token: write`
+  only to the publishing job and never introduce long-lived publishing tokens.
+- Request `@openai/sdks-team` review for changes involving authentication,
+  endpoints/transports, redirects, TLS, file uploads/paths, deserialization,
+  logging, webhooks, dependencies, or CI/release behavior. Add focused
+  regression/security tests and follow the generated-code guidance in
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+- Report suspected vulnerabilities privately as described in
+  [SECURITY.md](SECURITY.md), never in public issues or pull requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@
 - Never commit real API keys, access tokens, signing keys, credentials, or
   customer data. Read secrets from environment variables such as
   `OPENAI_API_KEY` and use clearly fake values in examples, tests, and fixtures.
-- Redact authorization headers, cookies, tokens, signed URLs, request/response
-  bodies, prompts, uploaded files, and other sensitive data from logs, errors,
-  snapshots, and CI artifacts.
+- Redact authorization headers, cookies, tokens, signed URLs, customer data,
+  and sensitive request/response bodies, prompts, or uploaded files from logs,
+  errors, snapshots, and CI artifacts. Clearly fake or sanitized payloads may
+  remain in tests and diagnostics.
 - Review direct and transitive dependency changes in `Gemfile`, `Gemfile.lock`,
   and `openai.gemspec`, including gem sources, locked Git revisions, native
   extensions, and install/build scripts. Do not run unreviewed scripts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,10 @@ This will install all the required dependencies.
   as `OPENAI_API_KEY`; use clearly fake values in examples, tests, snapshots,
   and WebMock fixtures.
 - **Logs and diagnostics:** Redact authorization headers, cookies, signed URLs,
-  credential-bearing query parameters, request/response bodies, prompts,
-  uploaded files, and customer data from logs, exceptions, error messages,
-  fixtures, and CI artifacts.
+  credential-bearing query parameters, customer data, and sensitive
+  request/response bodies, prompts, or uploaded files from logs, exceptions,
+  error messages, fixtures, and CI artifacts. Clearly fake or sanitized
+  payloads may remain in tests and diagnostics.
 - **Dependencies:** Review `Gemfile`, `Gemfile.lock`, and `openai.gemspec`
   changes, including direct and transitive gems, sources, locked Git revisions,
   native extensions, and install/build scripts. Do not run unreviewed scripts
@@ -115,19 +116,21 @@ The live example suite executes every example marked as `covered` in
 `examples/e2e.yml`. It requires `OPENAI_API_KEY`, makes real API requests, and
 writes JSON and Markdown execution reports under `tmp/examples-e2e/` by default.
 
-Keep `OPENAI_API_KEY` in the environment and ensure reports, terminal output,
-and uploaded CI artifacts never contain credentials, prompts, model responses,
-uploaded files, or other customer data. Prefer the offline inventory check when
-live requests are unnecessary.
-
-```bash
-$ bundle exec rake test:examples:e2e
-```
-
-To validate the example inventory without making API requests:
+Keep `OPENAI_API_KEY` in the environment. Prefer the offline inventory check,
+which makes no API requests:
 
 ```bash
 $ bundle exec rake test:examples:inventory
+```
+
+Failed live examples currently include captured stdout and stderr in their
+reports, and the live CI workflow uploads those reports even on failure. Do not
+run the live suite or workflow until captured output and reports redact or omit
+credentials, customer data, and other sensitive prompts, model responses, or
+uploaded files. Only run the suite after those safeguards are in place:
+
+```bash
+$ bundle exec rake test:examples:e2e
 ```
 
 Every `examples/**/*.rb` file must be classified as covered or explicitly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 See the [versioning policy](VERSIONING.md) before changing the public API,
 minimum Ruby version, dependencies, or release behavior.
 
+Review the [security requirements](#security-requirements) before installing
+dependencies, changing SDK behavior, or running live examples.
+
 This repository contains a `.ruby-version` file, which should work with either [rbenv](https://github.com/rbenv/rbenv) or [asdf](https://github.com/asdf-vm/asdf) with the [ruby plugin](https://github.com/asdf-vm/asdf-ruby).
 
 Please follow the instructions for your preferred version manager to install the Ruby version specified in the `.ruby-version` file.
@@ -14,6 +17,33 @@ $ ./scripts/bootstrap
 ```
 
 This will install all the required dependencies.
+
+## Security requirements
+
+- **Secrets and fixtures:** Never commit API keys, access tokens, private keys,
+  credentials, or customer data. Load secrets from environment variables such
+  as `OPENAI_API_KEY`; use clearly fake values in examples, tests, snapshots,
+  and WebMock fixtures.
+- **Logs and diagnostics:** Redact authorization headers, cookies, signed URLs,
+  credential-bearing query parameters, request/response bodies, prompts,
+  uploaded files, and customer data from logs, exceptions, error messages,
+  fixtures, and CI artifacts.
+- **Dependencies:** Review `Gemfile`, `Gemfile.lock`, and `openai.gemspec`
+  changes, including direct and transitive gems, sources, locked Git revisions,
+  native extensions, and install/build scripts. Do not run unreviewed scripts
+  or accept unexplained lockfile changes.
+- **CI and publishing:** Pin GitHub Actions to full commit SHAs, grant minimum
+  per-job permissions, and preserve `permissions: {}`,
+  `persist-credentials: false`, protected release environments, and RubyGems
+  trusted publishing. Restrict `id-token: write` to the publishing job; protect
+  GitHub App private keys and do not introduce long-lived publishing tokens.
+- **Sensitive changes:** Request `@openai/sdks-team` review for authentication,
+  network endpoints/transports, redirects, TLS, uploads and file paths,
+  JSON/YAML/Marshal deserialization, request logging, webhooks, dependencies,
+  and CI/release changes. Add targeted regression/security tests for affected
+  credential, network, file, serialization, or publishing boundaries.
+- **Vulnerability reports:** Follow [SECURITY.md](SECURITY.md). Never report a
+  suspected vulnerability in a public issue, pull request, or discussion.
 
 ## Modifying/Adding code
 
@@ -84,6 +114,11 @@ $ bundle exec rake test
 The live example suite executes every example marked as `covered` in
 `examples/e2e.yml`. It requires `OPENAI_API_KEY`, makes real API requests, and
 writes JSON and Markdown execution reports under `tmp/examples-e2e/` by default.
+
+Keep `OPENAI_API_KEY` in the environment and ensure reports, terminal output,
+and uploaded CI artifacts never contain credentials, prompts, model responses,
+uploaded files, or other customer data. Prefer the offline inventory check when
+live requests are unnecessary.
 
 ```bash
 $ bundle exec rake test:examples:e2e

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,18 @@ Please report potential security vulnerabilities through OpenAI's
 [coordinated vulnerability disclosure process](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
 For questions about that process, contact disclosure@openai.com.
 
+Do not report suspected vulnerabilities in public GitHub issues, pull requests,
+or discussions. Submit only the information needed to reproduce the issue, and
+remove API keys, access tokens, private keys, customer data, and sensitive
+request/response logs before sharing it through the private disclosure channel.
+
+## Protecting Credentials and Diagnostics
+
+Load API keys from environment variables or an approved secrets manager; never
+commit them to source code, examples, tests, fixtures, or generated artifacts.
+Redact authorization headers, signed URLs, prompts, model responses, uploaded
+files, and other customer data from logs, error reports, and shared diagnostics.
+
 ## Responsible Disclosure
 
 Please allow OpenAI a reasonable amount of time to investigate and address the


### PR DESCRIPTION
## Summary

- Add concrete agent and contributor security requirements for secret-free Ruby examples and WebMock fixtures, redacted logs/errors/live-example artifacts, Bundler and gemspec supply-chain review, sensitive-change review, and focused regression tests.
- Document existing SHA-pinned GitHub Actions, least-privilege workflow tokens, protected release environments, GitHub App credential handling, and RubyGems OIDC trusted publishing safeguards.
- Strengthen the packaged security policy with private vulnerability reporting and safe credential/diagnostic handling.

## Verification

- `git diff origin/main...HEAD --check`
- `markdown-it AGENTS.md CONTRIBUTING.md SECURITY.md > /dev/null`
- Python `markdown_it` validation confirmed all three documents parse, local links and anchors resolve, code fences are balanced, and required security guidance is present.
- Confirmed only `AGENTS.md`, `CONTRIBUTING.md`, and `SECURITY.md` changed.

Ruby and Bundler are unavailable on the devbox; no runtime code or dependencies changed.