### PR TITLE
docs(security): standardize Ruby vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,11 +19,13 @@ When reporting a vulnerability, include:
 
 Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
 
-For this repository, identify the `openai` gem version, Ruby version, operating
-system, and any relevant provider or transport. Redact authorization headers,
-access tokens, private keys, signed URLs, prompts, model responses, uploaded
-files, and sensitive request/response bodies from logs, error reports, and
-shared diagnostics.
+For this repository, identify the `openai` gem version or relevant source
+commit, Ruby version, operating system, and any relevant provider or transport.
+When relevant, include the installation method (RubyGems, Git, or a local
+path), without sharing private registry URLs or local filesystem paths. Redact
+authorization headers, access tokens, private keys, signed URLs, prompts, model
+responses, uploaded files, and sensitive request/response bodies from logs,
+error reports, and shared diagnostics.
 
 Load API keys from environment variables or an approved secrets manager; never
 commit them to source code, examples, tests, fixtures, or generated artifacts.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,40 @@
 # Security Policy
 
-## Reporting Security Issues
+## Reporting a vulnerability
 
 Please report potential security vulnerabilities through OpenAI's
 [coordinated vulnerability disclosure process](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
 For questions about that process, contact disclosure@openai.com.
 
-Do not report suspected vulnerabilities in public GitHub issues, pull requests,
-or discussions. Submit only the information needed to reproduce the issue, and
-remove API keys, access tokens, private keys, customer data, and sensitive
-request/response logs before sharing it through the private disclosure channel.
+Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
 
-## Protecting Credentials and Diagnostics
+## What to include
+
+When reporting a vulnerability, include:
+
+- The affected package or product and version, or the relevant source commit.
+- A clear description of the potential impact.
+- Sanitized reproduction steps or a minimal proof of concept.
+- Any relevant environment details or known mitigations.
+
+Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+
+For this repository, identify the `openai` gem version, Ruby version, operating
+system, and any relevant provider or transport. Redact authorization headers,
+access tokens, private keys, signed URLs, prompts, model responses, uploaded
+files, and sensitive request/response bodies from logs, error reports, and
+shared diagnostics.
 
 Load API keys from environment variables or an approved secrets manager; never
 commit them to source code, examples, tests, fixtures, or generated artifacts.
-Redact authorization headers, signed URLs, prompts, model responses, uploaded
-files, and other customer data from logs, error reports, and shared diagnostics.
 
-## Responsible Disclosure
+This policy applies to the source code in this repository and official releases
+of the `openai` Ruby gem. See [VERSIONING.md](VERSIONING.md) for supported Ruby
+versions and release policy. Older release lines remain available without
+guaranteed security fixes or backports.
 
-Please allow OpenAI a reasonable amount of time to investigate and address the
-issue before making information public. Thank you for helping us keep this SDK
-and the systems it interacts with secure.
+## Coordinated disclosure
+
+Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
+
+Thank you for helping us keep this SDK and the systems it interacts with secure.


### PR DESCRIPTION
## Summary

- Standardize the existing root `SECURITY.md` around the shared `Reporting a vulnerability`, `What to include`, and `Coordinated disclosure` sections and exact cross-SDK private-disclosure warnings.
- Preserve Ruby's existing OpenAI coordinated-vulnerability-disclosure URL, `disclosure@openai.com`, stronger credential/log/error/diagnostic redaction requirements, and coordinated-disclosure commitment.
- Ask reporters for the affected `openai` gem version or source commit, Ruby/runtime environment, impact, sanitized reproduction steps, and relevant mitigations.
- Scope the policy to this repository and official Ruby gem releases, link the existing packaged `VERSIONING.md`, and preserve the documented no-guaranteed-backports policy.

## Verification

- `markdown-it SECURITY.md > /dev/null`
- `git diff origin/main...HEAD --check`
- Python/CommonMark assertions verified exact shared headings, sentence text/order, reporting checklist, unchanged disclosure destination/email, complete prior redaction protections, Ruby gem scope, version/support wording, one-file scope, and packaged relative-link coverage.
- Confirmed the existing disclosure policy URL returns HTTP 200 and the `VERSIONING.md` link exists and is covered by the existing gem-packaging regression test.
- Two independent read-only reviews found no issues; only `SECURITY.md` changed.