### PR TITLE
ci: run CodeQL analysis for merge queue entries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- Add `merge_group: {types: [checks_requested]}` to the existing advanced CodeQL workflow so merge-queue commits receive the same real `actions` and `ruby` analyses already run for pull requests.
- Preserve all existing main-push/PR triggers, fork-safe execution, deny-all workflow permissions, narrowly scoped SARIF-upload permissions, full-SHA-pinned Actions, checkout credential isolation, language matrix, and distinct SARIF categories.
- Keep the change intentionally limited to three added lines in `.github/workflows/codeql.yml`.

## Verification

- `git diff origin/main...HEAD --check`
- Strict YAML 1.2/duplicate-key validation and `yq` confirmed `push(main)`, `pull_request(main)`, and `merge_group(checks_requested)` triggers.
- A full parsed-workflow comparison confirmed the new merge-group event is the only semantic change.
- Assertions verified both actual CodeQL init/analyze jobs, exact existing job contexts `analyze (actions)` and `analyze (ruby)`, minimal permissions, immutable 40-character Action SHAs, disabled credential persistence, fork safety, SARIF categories, and one-file scope.
- Historical fork PR execution confirms the existing pull-request CodeQL upload succeeds without privileged fork tokens.

## Required-check rollout

No live branch rules or repository settings were changed. The existing CodeQL workflow has never run for `merge_group`, so requiring either CodeQL context now would deadlock the protected merge queue. After this workflow lands on the default branch, verify both `analyze (actions)` and `analyze (ruby)` succeed on actual pull-request and merge-group SHAs, refresh any pre-existing eligible PRs missing those contexts, and only then add those exact GitHub Actions check names (app integration `15368`) alongside the existing `ci / ci-required` requirement.