### PR TITLE
chore: synchronize generated response signatures and tests

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: e0a62312-b47a-4bc8-a154-1b0ff22ba46b
+generation_id: 2eec67ae-b82c-4e77-b588-32365f621ee7
 openapi_spec_hash: cc58e691f33751629ca4de3100082edb
 openapi_transformed_spec_hash: 6e9129151e5404deb042f722a97bb2a9
 config_hash: a356ac9fd5606025cdc3db3f68432996
-codegen_sha: 73414ecb5a77374a3e61b6bc41e36b9abfe4c62f
+codegen_sha: 50df80ca7ad40da124eb3c8af4cc115c3a3a4233

--- a/rbi/openai/models/beta/beta_responses_server_event.rbi
+++ b/rbi/openai/models/beta/beta_responses_server_event.rbi
@@ -109,8 +109,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.audio.delta`.
             type: :"response.audio.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -167,8 +167,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.audio.done`.
             type: :"response.audio.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -227,8 +227,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.audio.transcript.delta`.
             type: :"response.audio.transcript.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -287,8 +287,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.audio.transcript.done`.
             type: :"response.audio.transcript.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -356,8 +356,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.code_interpreter_call_code.delta`.
             type: :"response.code_interpreter_call_code.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -427,8 +427,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.code_interpreter_call_code.done`.
             type: :"response.code_interpreter_call_code.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -496,8 +496,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.code_interpreter_call.completed`.
             type: :"response.code_interpreter_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -564,8 +564,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.code_interpreter_call.in_progress`.
             type: :"response.code_interpreter_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -632,8 +632,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.code_interpreter_call.interpreting`.
             type: :"response.code_interpreter_call.interpreting",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -696,8 +696,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.completed`.
             type: :"response.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -771,8 +771,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.content_part.added`.
             type: :"response.content_part.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -852,8 +852,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.content_part.done`.
             type: :"response.content_part.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -919,8 +919,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.created`.
             type: :"response.created",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -982,8 +982,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.file_search_call.completed`.
             type: :"response.file_search_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1049,8 +1049,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.file_search_call.in_progress`.
             type: :"response.file_search_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1116,8 +1116,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.file_search_call.searching`.
             type: :"response.file_search_call.searching",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1186,8 +1186,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.function_call_arguments.delta`.
             type: :"response.function_call_arguments.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1259,8 +1259,8 @@ module OpenAI
             # The agent that owns this multi-agent streaming event.
             agent: nil,
             type: :"response.function_call_arguments.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1325,8 +1325,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.in_progress`.
             type: :"response.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1384,8 +1384,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.failed`.
             type: :"response.failed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1444,8 +1444,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.incomplete`.
             type: :"response.incomplete",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1531,7 +1531,10 @@ module OpenAI
             ).returns(T.attached_class)
           end
           def self.new(
-            # The output item that was added.
+            # The output item that was added. For reasoning items, `encrypted_content` may be
+            # incomplete while the item is in progress. Use the reasoning item from the
+            # corresponding `response.output_item.done` event when passing it as input to a
+            # subsequent request.
             item:,
             # The index of the output item that was added.
             output_index:,
@@ -1541,8 +1544,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.output_item.added`.
             type: :"response.output_item.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1641,8 +1644,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.output_item.done`.
             type: :"response.output_item.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1715,8 +1718,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.reasoning_summary_part.added`.
             type: :"response.reasoning_summary_part.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1797,8 +1800,8 @@ module OpenAI
             status: nil,
             # The type of the event. Always `response.reasoning_summary_part.done`.
             type: :"response.reasoning_summary_part.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1875,8 +1878,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.reasoning_summary_text.delta`.
             type: :"response.reasoning_summary_text.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1950,8 +1953,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.reasoning_summary_text.done`.
             type: :"response.reasoning_summary_text.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2025,8 +2028,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.reasoning_text.delta`.
             type: :"response.reasoning_text.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2100,8 +2103,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.reasoning_text.done`.
             type: :"response.reasoning_text.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2175,8 +2178,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.refusal.delta`.
             type: :"response.refusal.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2248,8 +2251,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.refusal.done`.
             type: :"response.refusal.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2327,8 +2330,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.output_text.delta`.
             type: :"response.output_text.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2408,8 +2411,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.output_text.done`.
             type: :"response.output_text.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2477,8 +2480,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.web_search_call.completed`.
             type: :"response.web_search_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2544,8 +2547,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.web_search_call.in_progress`.
             type: :"response.web_search_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2611,8 +2614,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always `response.web_search_call.searching`.
             type: :"response.web_search_call.searching",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2679,8 +2682,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.image_generation_call.completed'.
             type: :"response.image_generation_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2747,8 +2750,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.image_generation_call.generating'.
             type: :"response.image_generation_call.generating",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2814,8 +2817,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.image_generation_call.in_progress'.
             type: :"response.image_generation_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2888,8 +2891,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.image_generation_call.partial_image'.
             type: :"response.image_generation_call.partial_image",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2962,8 +2965,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_call_arguments.delta'.
             type: :"response.mcp_call_arguments.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3033,8 +3036,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_call_arguments.done'.
             type: :"response.mcp_call_arguments.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3101,8 +3104,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_call.completed'.
             type: :"response.mcp_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3168,8 +3171,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_call.failed'.
             type: :"response.mcp_call.failed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3235,8 +3238,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_call.in_progress'.
             type: :"response.mcp_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3302,8 +3305,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_list_tools.completed'.
             type: :"response.mcp_list_tools.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3369,8 +3372,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_list_tools.failed'.
             type: :"response.mcp_list_tools.failed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3437,8 +3440,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.mcp_list_tools.in_progress'.
             type: :"response.mcp_list_tools.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3482,7 +3485,15 @@ module OpenAI
           # Emitted when an annotation is added to output text content.
           sig do
             params(
-              annotation: T.anything,
+              annotation:
+                T.nilable(
+                  T.any(
+                    OpenAI::Beta::BetaResponseOutputTextAnnotationAddedEvent::Annotation::FileCitation::OrHash,
+                    OpenAI::Beta::BetaResponseOutputTextAnnotationAddedEvent::Annotation::URLCitation::OrHash,
+                    OpenAI::Beta::BetaResponseOutputTextAnnotationAddedEvent::Annotation::ContainerFileCitation::OrHash,
+                    OpenAI::Beta::BetaResponseOutputTextAnnotationAddedEvent::Annotation::FilePath::OrHash
+                  )
+                ),
               annotation_index: Integer,
               content_index: Integer,
               item_id: String,
@@ -3497,7 +3508,7 @@ module OpenAI
             ).returns(T.attached_class)
           end
           def self.new(
-            # The annotation object being added. (See annotation schema for details.)
+            # An annotation that applies to a span of output text.
             annotation:,
             # The index of the annotation within the content part.
             annotation_index:,
@@ -3513,8 +3524,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.output_text.annotation.added'.
             type: :"response.output_text.annotation.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3522,7 +3533,10 @@ module OpenAI
           sig do
             override.returns(
               {
-                annotation: T.anything,
+                annotation:
+                  T.nilable(
+                    OpenAI::Beta::BetaResponseOutputTextAnnotationAddedEvent::Annotation::Variants
+                  ),
                 annotation_index: Integer,
                 content_index: Integer,
                 item_id: String,
@@ -3578,8 +3592,8 @@ module OpenAI
             agent: nil,
             # The type of the event. Always 'response.queued'.
             type: :"response.queued",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3644,8 +3658,8 @@ module OpenAI
             agent: nil,
             # The event type identifier.
             type: :"response.custom_tool_call_input.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3715,8 +3729,8 @@ module OpenAI
             agent: nil,
             # The event type identifier.
             type: :"response.custom_tool_call_input.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end

--- a/rbi/openai/models/responses/responses_server_event.rbi
+++ b/rbi/openai/models/responses/responses_server_event.rbi
@@ -99,8 +99,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.audio.delta`.
             type: :"response.audio.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -149,8 +149,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.audio.done`.
             type: :"response.audio.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -197,8 +197,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.audio.transcript.delta`.
             type: :"response.audio.transcript.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -247,8 +247,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.audio.transcript.done`.
             type: :"response.audio.transcript.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -302,8 +302,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.code_interpreter_call_code.delta`.
             type: :"response.code_interpreter_call_code.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -363,8 +363,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.code_interpreter_call_code.done`.
             type: :"response.code_interpreter_call_code.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -422,8 +422,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.code_interpreter_call.completed`.
             type: :"response.code_interpreter_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -480,8 +480,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.code_interpreter_call.in_progress`.
             type: :"response.code_interpreter_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -538,8 +538,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.code_interpreter_call.interpreting`.
             type: :"response.code_interpreter_call.interpreting",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -592,8 +592,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.completed`.
             type: :"response.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -659,8 +659,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.content_part.added`.
             type: :"response.content_part.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -730,8 +730,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.content_part.done`.
             type: :"response.content_part.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -787,8 +787,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.created`.
             type: :"response.created",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -843,8 +843,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.file_search_call.completed`.
             type: :"response.file_search_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -900,8 +900,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.file_search_call.in_progress`.
             type: :"response.file_search_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -957,8 +957,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.file_search_call.searching`.
             type: :"response.file_search_call.searching",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1017,8 +1017,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.function_call_arguments.delta`.
             type: :"response.function_call_arguments.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1080,8 +1080,8 @@ module OpenAI
             # The sequence number of this event.
             sequence_number:,
             type: :"response.function_call_arguments.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1136,8 +1136,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.in_progress`.
             type: :"response.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1189,8 +1189,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.failed`.
             type: :"response.failed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1242,8 +1242,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.incomplete`.
             type: :"response.incomplete",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1320,7 +1320,10 @@ module OpenAI
             ).returns(T.attached_class)
           end
           def self.new(
-            # The output item that was added.
+            # The output item that was added. For reasoning items, `encrypted_content` may be
+            # incomplete while the item is in progress. Use the reasoning item from the
+            # corresponding `response.output_item.done` event when passing it as input to a
+            # subsequent request.
             item:,
             # The index of the output item that was added.
             output_index:,
@@ -1328,8 +1331,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.output_item.added`.
             type: :"response.output_item.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1415,8 +1418,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.output_item.done`.
             type: :"response.output_item.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1479,8 +1482,8 @@ module OpenAI
             summary_index:,
             # The type of the event. Always `response.reasoning_summary_part.added`.
             type: :"response.reasoning_summary_part.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1551,8 +1554,8 @@ module OpenAI
             status: nil,
             # The type of the event. Always `response.reasoning_summary_part.done`.
             type: :"response.reasoning_summary_part.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1619,8 +1622,8 @@ module OpenAI
             summary_index:,
             # The type of the event. Always `response.reasoning_summary_text.delta`.
             type: :"response.reasoning_summary_text.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1684,8 +1687,8 @@ module OpenAI
             text:,
             # The type of the event. Always `response.reasoning_summary_text.done`.
             type: :"response.reasoning_summary_text.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1749,8 +1752,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.reasoning_text.delta`.
             type: :"response.reasoning_text.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1814,8 +1817,8 @@ module OpenAI
             text:,
             # The type of the event. Always `response.reasoning_text.done`.
             type: :"response.reasoning_text.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1879,8 +1882,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.refusal.delta`.
             type: :"response.refusal.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -1944,8 +1947,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.refusal.done`.
             type: :"response.refusal.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2015,8 +2018,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.output_text.delta`.
             type: :"response.output_text.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2088,8 +2091,8 @@ module OpenAI
             text:,
             # The type of the event. Always `response.output_text.done`.
             type: :"response.output_text.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2149,8 +2152,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.web_search_call.completed`.
             type: :"response.web_search_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2206,8 +2209,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.web_search_call.in_progress`.
             type: :"response.web_search_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2263,8 +2266,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always `response.web_search_call.searching`.
             type: :"response.web_search_call.searching",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2321,8 +2324,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.image_generation_call.completed'.
             type: :"response.image_generation_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2379,8 +2382,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.image_generation_call.generating'.
             type: :"response.image_generation_call.generating",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2436,8 +2439,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.image_generation_call.in_progress'.
             type: :"response.image_generation_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2500,8 +2503,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.image_generation_call.partial_image'.
             type: :"response.image_generation_call.partial_image",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2564,8 +2567,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_call_arguments.delta'.
             type: :"response.mcp_call_arguments.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2625,8 +2628,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_call_arguments.done'.
             type: :"response.mcp_call_arguments.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2683,8 +2686,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_call.completed'.
             type: :"response.mcp_call.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2740,8 +2743,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_call.failed'.
             type: :"response.mcp_call.failed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2797,8 +2800,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_call.in_progress'.
             type: :"response.mcp_call.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2854,8 +2857,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_list_tools.completed'.
             type: :"response.mcp_list_tools.completed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2911,8 +2914,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_list_tools.failed'.
             type: :"response.mcp_list_tools.failed",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -2969,8 +2972,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.mcp_list_tools.in_progress'.
             type: :"response.mcp_list_tools.in_progress",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3010,7 +3013,15 @@ module OpenAI
           # Emitted when an annotation is added to output text content.
           sig do
             params(
-              annotation: T.anything,
+              annotation:
+                T.nilable(
+                  T.any(
+                    OpenAI::Responses::ResponseOutputTextAnnotationAddedEvent::Annotation::FileCitation::OrHash,
+                    OpenAI::Responses::ResponseOutputTextAnnotationAddedEvent::Annotation::URLCitation::OrHash,
+                    OpenAI::Responses::ResponseOutputTextAnnotationAddedEvent::Annotation::ContainerFileCitation::OrHash,
+                    OpenAI::Responses::ResponseOutputTextAnnotationAddedEvent::Annotation::FilePath::OrHash
+                  )
+                ),
               annotation_index: Integer,
               content_index: Integer,
               item_id: String,
@@ -3021,7 +3032,7 @@ module OpenAI
             ).returns(T.attached_class)
           end
           def self.new(
-            # The annotation object being added. (See annotation schema for details.)
+            # An annotation that applies to a span of output text.
             annotation:,
             # The index of the annotation within the content part.
             annotation_index:,
@@ -3035,8 +3046,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.output_text.annotation.added'.
             type: :"response.output_text.annotation.added",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3044,7 +3055,10 @@ module OpenAI
           sig do
             override.returns(
               {
-                annotation: T.anything,
+                annotation:
+                  T.nilable(
+                    OpenAI::Responses::ResponseOutputTextAnnotationAddedEvent::Annotation::Variants
+                  ),
                 annotation_index: Integer,
                 content_index: Integer,
                 item_id: String,
@@ -3092,8 +3106,8 @@ module OpenAI
             sequence_number:,
             # The type of the event. Always 'response.queued'.
             type: :"response.queued",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3151,8 +3165,8 @@ module OpenAI
             sequence_number:,
             # The event type identifier.
             type: :"response.custom_tool_call_input.delta",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end
@@ -3212,8 +3226,8 @@ module OpenAI
             sequence_number:,
             # The event type identifier.
             type: :"response.custom_tool_call_input.done",
-            # The WebSocket lane that emitted this event.
-            # This field is present when the originating response.create supplied a stream_id.
+            # The WebSocket lane that emitted this event. This field is present when the
+            # originating `response.create` event supplied a `stream_id`.
             stream_id: nil
           )
           end

--- a/sig/openai/models/beta/beta_responses_server_event.rbs
+++ b/sig/openai/models/beta/beta_responses_server_event.rbs
@@ -1772,7 +1772,7 @@ module OpenAI
 
         type beta_response_output_text_annotation_ws_added =
           {
-            annotation: top,
+            annotation: OpenAI::Models::Beta::BetaResponseOutputTextAnnotationAddedEvent::annotation?,
             annotation_index: Integer,
             content_index: Integer,
             item_id: String,
@@ -1789,7 +1789,7 @@ module OpenAI
           def stream_id=: (String _) -> String
 
           def initialize: (
-            annotation: top,
+            annotation: OpenAI::Models::Beta::BetaResponseOutputTextAnnotationAddedEvent::annotation?,
             annotation_index: Integer,
             content_index: Integer,
             item_id: String,
@@ -1801,7 +1801,7 @@ module OpenAI
           ) -> void
 
           def to_hash: -> {
-            annotation: top,
+            annotation: OpenAI::Models::Beta::BetaResponseOutputTextAnnotationAddedEvent::annotation?,
             annotation_index: Integer,
             content_index: Integer,
             item_id: String,

--- a/sig/openai/models/responses/responses_server_event.rbs
+++ b/sig/openai/models/responses/responses_server_event.rbs
@@ -1624,7 +1624,7 @@ module OpenAI
 
         type response_output_text_annotation_ws_added =
           {
-            annotation: top,
+            annotation: OpenAI::Models::Responses::ResponseOutputTextAnnotationAddedEvent::annotation?,
             annotation_index: Integer,
             content_index: Integer,
             item_id: String,
@@ -1640,7 +1640,7 @@ module OpenAI
           def stream_id=: (String _) -> String
 
           def initialize: (
-            annotation: top,
+            annotation: OpenAI::Models::Responses::ResponseOutputTextAnnotationAddedEvent::annotation?,
             annotation_index: Integer,
             content_index: Integer,
             item_id: String,
@@ -1651,7 +1651,7 @@ module OpenAI
           ) -> void
 
           def to_hash: -> {
-            annotation: top,
+            annotation: OpenAI::Models::Responses::ResponseOutputTextAnnotationAddedEvent::annotation?,
             annotation_index: Integer,
             content_index: Integer,
             item_id: String,

--- a/test/openai/resources/beta/chatkit/threads_test.rb
+++ b/test/openai/resources/beta/chatkit/threads_test.rb
@@ -95,62 +95,12 @@ class OpenAI::Test::Resources::Beta::ChatKit::ThreadsTest < OpenAI::Test::Resour
     assert_pattern do
       case row
       in (
-        {
-          type: :"chatkit.user_message",
-          id: String,
-          attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]),
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content]),
-          created_at: Integer,
-          inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil,
-          object: Symbol,
-          thread_id: String
-        } |
-        {
-          type: :"chatkit.assistant_message",
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitResponseOutputText]),
-          created_at: Integer,
-          object: Symbol,
-          thread_id: String
-        } |
-        {
-          type: :"chatkit.widget",
-          id: String,
-          created_at: Integer,
-          object: Symbol,
-          thread_id: String,
-          widget: String
-        } |
-        {
-          type: :"chatkit.client_tool_call",
-          id: String,
-          arguments: String,
-          call_id: String,
-          created_at: Integer,
-          name: String,
-          object: Symbol,
-          output: String | nil,
-          status: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall::Status,
-          thread_id: String
-        } |
-        {
-          type: :"chatkit.task",
-          id: String,
-          created_at: Integer,
-          heading: String | nil,
-          object: Symbol,
-          summary: String | nil,
-          task_type: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask::TaskType,
-          thread_id: String
-        } |
-        {
-          type: :"chatkit.task_group",
-          id: String,
-          created_at: Integer,
-          object: Symbol,
-          tasks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task]),
-          thread_id: String
-        }
+        {type: :"chatkit.user_message", id: String, attachments: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitAttachment]), content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::Content]), created_at: Integer, inference_options: OpenAI::Beta::ChatKit::ChatKitThreadUserMessageItem::InferenceOptions | nil, object: Symbol, thread_id: String} |
+        {type: :"chatkit.assistant_message", id: String, content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitResponseOutputText]), created_at: Integer, object: Symbol, thread_id: String} |
+        {type: :"chatkit.widget", id: String, created_at: Integer, object: Symbol, thread_id: String, widget: String} |
+        {type: :"chatkit.client_tool_call", id: String, arguments: String, call_id: String, created_at: Integer, name: String, object: Symbol, output: String | nil, status: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitClientToolCall::Status, thread_id: String} |
+        {type: :"chatkit.task", id: String, created_at: Integer, heading: String | nil, object: Symbol, summary: String | nil, task_type: OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTask::TaskType, thread_id: String} |
+        {type: :"chatkit.task_group", id: String, created_at: Integer, object: Symbol, tasks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::ChatKit::ChatKitThreadItemList::Data::ChatKitTaskGroup::Task]), thread_id: String}
       )
         nil
       end

--- a/test/openai/resources/beta/responses/input_items_test.rb
+++ b/test/openai/resources/beta/responses/input_items_test.rb
@@ -60,262 +60,35 @@ class OpenAI::Test::Resources::Beta::Responses::InputItemsTest < OpenAI::Test::R
     assert_pattern do
       case row
       in (
-        {
-          type: :message,
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseInputContent]),
-          role: OpenAI::Beta::BetaResponseInputMessageItem::Role,
-          agent: OpenAI::Beta::BetaResponseInputMessageItem::Agent | nil,
-          status: OpenAI::Beta::BetaResponseInputMessageItem::Status | nil
-        } |
-        {
-          type: :message,
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseOutputMessage::Content]),
-          role: Symbol,
-          status: OpenAI::Beta::BetaResponseOutputMessage::Status,
-          agent: OpenAI::Beta::BetaResponseOutputMessage::Agent | nil,
-          phase: OpenAI::Beta::BetaResponseOutputMessage::Phase | nil
-        } |
-        {
-          type: :file_search_call,
-          id: String,
-          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-          status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status,
-          agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil,
-          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFileSearchToolCall::Result]) | nil
-        } |
-        {
-          type: :computer_call,
-          id: String,
-          call_id: String,
-          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck]),
-          status: OpenAI::Beta::BetaResponseComputerToolCall::Status,
-          action: OpenAI::Beta::BetaComputerAction | nil,
-          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil,
-          agent: OpenAI::Beta::BetaResponseComputerToolCall::Agent | nil
-        } |
-        {
-          type: :computer_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot,
-          status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
-          agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :web_search_call,
-          id: String,
-          action: OpenAI::Beta::BetaResponseFunctionWebSearch::Action,
-          status: OpenAI::Beta::BetaResponseFunctionWebSearch::Status,
-          agent: OpenAI::Beta::BetaResponseFunctionWebSearch::Agent | nil
-        } |
-        {
-          type: :function_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Output,
-          status: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Status,
-          agent: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Agent | nil,
-          caller_: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Caller | nil,
-          created_by: String | nil,
-          name: String | nil,
-          namespace: String | nil
-        } |
-        {
-          type: :agent_message,
-          id: String,
-          author: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content]),
-          recipient: String,
-          agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil
-        } |
-        {
-          type: :multi_agent_call,
-          id: String,
-          action: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Action,
-          arguments: String,
-          call_id: String,
-          agent: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Agent | nil
-        } |
-        {
-          type: :multi_agent_call_output,
-          id: String,
-          action: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Action,
-          call_id: String,
-          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseOutputText]),
-          agent: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Agent | nil
-        } |
-        {
-          type: :tool_search_call,
-          id: String,
-          arguments: OpenAI::Internal::Type::Unknown,
-          call_id: String | nil,
-          execution: OpenAI::Beta::BetaResponseToolSearchCall::Execution,
-          status: OpenAI::Beta::BetaResponseToolSearchCall::Status,
-          agent: OpenAI::Beta::BetaResponseToolSearchCall::Agent | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :tool_search_output,
-          id: String,
-          call_id: String | nil,
-          execution: OpenAI::Beta::BetaResponseToolSearchOutputItem::Execution,
-          status: OpenAI::Beta::BetaResponseToolSearchOutputItem::Status,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
-          agent: OpenAI::Beta::BetaResponseToolSearchOutputItem::Agent | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :additional_tools,
-          id: String,
-          role: OpenAI::Beta::BetaResponseItem::AdditionalTools::Role,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]),
-          agent: OpenAI::Beta::BetaResponseItem::AdditionalTools::Agent | nil
-        } |
-        {
-          type: :reasoning,
-          id: String,
-          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Summary]),
-          agent: OpenAI::Beta::BetaResponseReasoningItem::Agent | nil,
-          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Content]) | nil,
-          encrypted_content: String | nil,
-          status: OpenAI::Beta::BetaResponseReasoningItem::Status | nil
-        } |
-        {
-          type: :program,
-          id: String,
-          call_id: String,
-          code: String,
-          fingerprint: String,
-          agent: OpenAI::Beta::BetaResponseItem::Program::Agent | nil
-        } |
-        {
-          type: :program_output,
-          id: String,
-          call_id: String,
-          result: String,
-          status: OpenAI::Beta::BetaResponseItem::ProgramOutput::Status,
-          agent: OpenAI::Beta::BetaResponseItem::ProgramOutput::Agent | nil
-        } |
-        {
-          type: :compaction,
-          id: String,
-          encrypted_content: String,
-          agent: OpenAI::Beta::BetaResponseCompactionItem::Agent | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :image_generation_call,
-          id: String,
-          result: String | nil,
-          status: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Status,
-          agent: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Agent | nil
-        } |
-        {
-          type: :code_interpreter_call,
-          id: String,
-          code: String | nil,
-          container_id: String,
-          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output]) | nil,
-          status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status,
-          agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil
-        } |
-        {
-          type: :local_shell_call,
-          id: String,
-          action: OpenAI::Beta::BetaResponseItem::LocalShellCall::Action,
-          call_id: String,
-          status: OpenAI::Beta::BetaResponseItem::LocalShellCall::Status,
-          agent: OpenAI::Beta::BetaResponseItem::LocalShellCall::Agent | nil
-        } |
-        {
-          type: :local_shell_call_output,
-          id: String,
-          output: String,
-          agent: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Agent | nil,
-          status: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Status | nil
-        } |
-        {
-          type: :shell_call,
-          id: String,
-          action: OpenAI::Beta::BetaResponseFunctionShellToolCall::Action,
-          call_id: String,
-          environment: OpenAI::Beta::BetaResponseFunctionShellToolCall::Environment | nil,
-          status: OpenAI::Beta::BetaResponseFunctionShellToolCall::Status,
-          agent: OpenAI::Beta::BetaResponseFunctionShellToolCall::Agent | nil,
-          caller_: OpenAI::Beta::BetaResponseFunctionShellToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :shell_call_output,
-          id: String,
-          call_id: String,
-          max_output_length: Integer | nil,
-          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output]),
-          status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status,
-          agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil,
-          caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call,
-          id: String,
-          call_id: String,
-          operation: OpenAI::Beta::BetaResponseApplyPatchToolCall::Operation,
-          status: OpenAI::Beta::BetaResponseApplyPatchToolCall::Status,
-          agent: OpenAI::Beta::BetaResponseApplyPatchToolCall::Agent | nil,
-          caller_: OpenAI::Beta::BetaResponseApplyPatchToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call_output,
-          id: String,
-          call_id: String,
-          status: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Status,
-          agent: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Agent | nil,
-          caller_: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Caller | nil,
-          created_by: String | nil,
-          output: String | nil
-        } |
-        {
-          type: :mcp_list_tools,
-          id: String,
-          server_label: String,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseItem::McpListTools::Tool]),
-          agent: OpenAI::Beta::BetaResponseItem::McpListTools::Agent | nil,
-          error: String | nil
-        } |
-        {
-          type: :mcp_approval_request,
-          id: String,
-          arguments: String,
-          name: String,
-          server_label: String,
-          agent: OpenAI::Beta::BetaResponseItem::McpApprovalRequest::Agent | nil
-        } |
-        {
-          type: :mcp_approval_response,
-          id: String,
-          approval_request_id: String,
-          approve: OpenAI::Internal::Type::Boolean,
-          agent: OpenAI::Beta::BetaResponseItem::McpApprovalResponse::Agent | nil,
-          reason: String | nil
-        } |
-        {
-          type: :mcp_call,
-          id: String,
-          arguments: String,
-          name: String,
-          server_label: String,
-          agent: OpenAI::Beta::BetaResponseItem::McpCall::Agent | nil,
-          approval_request_id: String | nil,
-          error: OpenAI::Beta::BetaMcpToolCallError | nil,
-          output: String | nil,
-          status: OpenAI::Beta::BetaResponseItem::McpCall::Status | nil
-        }
+        {type: :message, id: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseInputContent]), role: OpenAI::Beta::BetaResponseInputMessageItem::Role, agent: OpenAI::Beta::BetaResponseInputMessageItem::Agent | nil, status: OpenAI::Beta::BetaResponseInputMessageItem::Status | nil} |
+        {type: :message, id: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseOutputMessage::Content]), role: Symbol, status: OpenAI::Beta::BetaResponseOutputMessage::Status, agent: OpenAI::Beta::BetaResponseOutputMessage::Agent | nil, phase: OpenAI::Beta::BetaResponseOutputMessage::Phase | nil} |
+        {type: :file_search_call, id: String, queries: ^(OpenAI::Internal::Type::ArrayOf[String]), status: OpenAI::Beta::BetaResponseFileSearchToolCall::Status, agent: OpenAI::Beta::BetaResponseFileSearchToolCall::Agent | nil, results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFileSearchToolCall::Result]) | nil} |
+        {type: :computer_call, id: String, call_id: String, pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCall::PendingSafetyCheck]), status: OpenAI::Beta::BetaResponseComputerToolCall::Status, action: OpenAI::Beta::BetaComputerAction | nil, actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaComputerAction]) | nil, agent: OpenAI::Beta::BetaResponseComputerToolCall::Agent | nil} |
+        {type: :computer_call_output, id: String, call_id: String, output: OpenAI::Beta::BetaResponseComputerToolCallOutputScreenshot, status: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Status, acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil, agent: OpenAI::Beta::BetaResponseComputerToolCallOutputItem::Agent | nil, created_by: String | nil} |
+        {type: :web_search_call, id: String, action: OpenAI::Beta::BetaResponseFunctionWebSearch::Action, status: OpenAI::Beta::BetaResponseFunctionWebSearch::Status, agent: OpenAI::Beta::BetaResponseFunctionWebSearch::Agent | nil} |
+        {type: :function_call_output, id: String, call_id: String, output: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Output, status: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Status, agent: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Agent | nil, caller_: OpenAI::Beta::BetaResponseFunctionToolCallOutputItem::Caller | nil, created_by: String | nil, name: String | nil, namespace: String | nil} |
+        {type: :agent_message, id: String, author: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseItem::AgentMessage::Content]), recipient: String, agent: OpenAI::Beta::BetaResponseItem::AgentMessage::Agent | nil} |
+        {type: :multi_agent_call, id: String, action: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Action, arguments: String, call_id: String, agent: OpenAI::Beta::BetaResponseItem::MultiAgentCall::Agent | nil} |
+        {type: :multi_agent_call_output, id: String, action: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Action, call_id: String, output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseOutputText]), agent: OpenAI::Beta::BetaResponseItem::MultiAgentCallOutput::Agent | nil} |
+        {type: :tool_search_call, id: String, arguments: OpenAI::Internal::Type::Unknown, call_id: String | nil, execution: OpenAI::Beta::BetaResponseToolSearchCall::Execution, status: OpenAI::Beta::BetaResponseToolSearchCall::Status, agent: OpenAI::Beta::BetaResponseToolSearchCall::Agent | nil, created_by: String | nil} |
+        {type: :tool_search_output, id: String, call_id: String | nil, execution: OpenAI::Beta::BetaResponseToolSearchOutputItem::Execution, status: OpenAI::Beta::BetaResponseToolSearchOutputItem::Status, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]), agent: OpenAI::Beta::BetaResponseToolSearchOutputItem::Agent | nil, created_by: String | nil} |
+        {type: :additional_tools, id: String, role: OpenAI::Beta::BetaResponseItem::AdditionalTools::Role, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaTool]), agent: OpenAI::Beta::BetaResponseItem::AdditionalTools::Agent | nil} |
+        {type: :reasoning, id: String, summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Summary]), agent: OpenAI::Beta::BetaResponseReasoningItem::Agent | nil, content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseReasoningItem::Content]) | nil, encrypted_content: String | nil, status: OpenAI::Beta::BetaResponseReasoningItem::Status | nil} |
+        {type: :program, id: String, call_id: String, code: String, fingerprint: String, agent: OpenAI::Beta::BetaResponseItem::Program::Agent | nil} |
+        {type: :program_output, id: String, call_id: String, result: String, status: OpenAI::Beta::BetaResponseItem::ProgramOutput::Status, agent: OpenAI::Beta::BetaResponseItem::ProgramOutput::Agent | nil} |
+        {type: :compaction, id: String, encrypted_content: String, agent: OpenAI::Beta::BetaResponseCompactionItem::Agent | nil, created_by: String | nil} |
+        {type: :image_generation_call, id: String, result: String | nil, status: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Status, agent: OpenAI::Beta::BetaResponseItem::ImageGenerationCall::Agent | nil} |
+        {type: :code_interpreter_call, id: String, code: String | nil, container_id: String, outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Output]) | nil, status: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Status, agent: OpenAI::Beta::BetaResponseCodeInterpreterToolCall::Agent | nil} |
+        {type: :local_shell_call, id: String, action: OpenAI::Beta::BetaResponseItem::LocalShellCall::Action, call_id: String, status: OpenAI::Beta::BetaResponseItem::LocalShellCall::Status, agent: OpenAI::Beta::BetaResponseItem::LocalShellCall::Agent | nil} |
+        {type: :local_shell_call_output, id: String, output: String, agent: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Agent | nil, status: OpenAI::Beta::BetaResponseItem::LocalShellCallOutput::Status | nil} |
+        {type: :shell_call, id: String, action: OpenAI::Beta::BetaResponseFunctionShellToolCall::Action, call_id: String, environment: OpenAI::Beta::BetaResponseFunctionShellToolCall::Environment | nil, status: OpenAI::Beta::BetaResponseFunctionShellToolCall::Status, agent: OpenAI::Beta::BetaResponseFunctionShellToolCall::Agent | nil, caller_: OpenAI::Beta::BetaResponseFunctionShellToolCall::Caller | nil, created_by: String | nil} |
+        {type: :shell_call_output, id: String, call_id: String, max_output_length: Integer | nil, output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Output]), status: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Status, agent: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Agent | nil, caller_: OpenAI::Beta::BetaResponseFunctionShellToolCallOutput::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call, id: String, call_id: String, operation: OpenAI::Beta::BetaResponseApplyPatchToolCall::Operation, status: OpenAI::Beta::BetaResponseApplyPatchToolCall::Status, agent: OpenAI::Beta::BetaResponseApplyPatchToolCall::Agent | nil, caller_: OpenAI::Beta::BetaResponseApplyPatchToolCall::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call_output, id: String, call_id: String, status: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Status, agent: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Agent | nil, caller_: OpenAI::Beta::BetaResponseApplyPatchToolCallOutput::Caller | nil, created_by: String | nil, output: String | nil} |
+        {type: :mcp_list_tools, id: String, server_label: String, tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Beta::BetaResponseItem::McpListTools::Tool]), agent: OpenAI::Beta::BetaResponseItem::McpListTools::Agent | nil, error: String | nil} |
+        {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String, agent: OpenAI::Beta::BetaResponseItem::McpApprovalRequest::Agent | nil} |
+        {type: :mcp_approval_response, id: String, approval_request_id: String, approve: OpenAI::Internal::Type::Boolean, agent: OpenAI::Beta::BetaResponseItem::McpApprovalResponse::Agent | nil, reason: String | nil} |
+        {type: :mcp_call, id: String, arguments: String, name: String, server_label: String, agent: OpenAI::Beta::BetaResponseItem::McpCall::Agent | nil, approval_request_id: String | nil, error: OpenAI::Beta::BetaMcpToolCallError | nil, output: String | nil, status: OpenAI::Beta::BetaResponseItem::McpCall::Status | nil}
       )
         nil
       end

--- a/test/openai/resources/conversations/items_test.rb
+++ b/test/openai/resources/conversations/items_test.rb
@@ -71,204 +71,33 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
     assert_pattern do
       case response
       in (
-        {
-          type: :message,
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
-          role: OpenAI::Conversations::Message::Role,
-          status: OpenAI::Conversations::Message::Status,
-          phase: OpenAI::Conversations::Message::Phase | nil
-        } |
-        {
-          type: :function_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-          created_by: String | nil,
-          name: String | nil,
-          namespace: String | nil
-        } |
-        {
-          type: :file_search_call,
-          id: String,
-          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
-        } |
-        {
-          type: :web_search_call,
-          id: String,
-          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-        } |
-        {
-          type: :image_generation_call,
-          id: String,
-          result: String | nil,
-          status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
-        } |
-        {
-          type: :computer_call,
-          id: String,
-          call_id: String,
-          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
-          status: OpenAI::Responses::ResponseComputerToolCall::Status,
-          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-        } |
-        {
-          type: :computer_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :tool_search_call,
-          id: String,
-          arguments: OpenAI::Internal::Type::Unknown,
-          call_id: String | nil,
-          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-          status: OpenAI::Responses::ResponseToolSearchCall::Status,
-          created_by: String | nil
-        } |
-        {
-          type: :tool_search_output,
-          id: String,
-          call_id: String | nil,
-          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-          created_by: String | nil
-        } |
-        {
-          type: :additional_tools,
-          id: String,
-          role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-        } |
-        {
-          type: :reasoning,
-          id: String,
-          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-          encrypted_content: String | nil,
-          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-        } |
+        {type: :message, id: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]), role: OpenAI::Conversations::Message::Role, status: OpenAI::Conversations::Message::Status, phase: OpenAI::Conversations::Message::Phase | nil} |
+        {type: :function_call_output, id: String, call_id: String, output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output, status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status, caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil, created_by: String | nil, name: String | nil, namespace: String | nil} |
+        {type: :file_search_call, id: String, queries: ^(OpenAI::Internal::Type::ArrayOf[String]), status: OpenAI::Responses::ResponseFileSearchToolCall::Status, results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil} |
+        {type: :web_search_call, id: String, action: OpenAI::Responses::ResponseFunctionWebSearch::Action, status: OpenAI::Responses::ResponseFunctionWebSearch::Status} |
+        {type: :image_generation_call, id: String, result: String | nil, status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status} |
+        {type: :computer_call, id: String, call_id: String, pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]), status: OpenAI::Responses::ResponseComputerToolCall::Status, action: OpenAI::Responses::ResponseComputerToolCall::Action | nil, actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil} |
+        {type: :computer_call_output, id: String, call_id: String, output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot, status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status, acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil, created_by: String | nil} |
+        {type: :tool_search_call, id: String, arguments: OpenAI::Internal::Type::Unknown, call_id: String | nil, execution: OpenAI::Responses::ResponseToolSearchCall::Execution, status: OpenAI::Responses::ResponseToolSearchCall::Status, created_by: String | nil} |
+        {type: :tool_search_output, id: String, call_id: String | nil, execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution, status: OpenAI::Responses::ResponseToolSearchOutputItem::Status, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]), created_by: String | nil} |
+        {type: :additional_tools, id: String, role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])} |
+        {type: :reasoning, id: String, summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]), content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil, encrypted_content: String | nil, status: OpenAI::Responses::ResponseReasoningItem::Status | nil} |
         {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
-        {
-          type: :program_output,
-          id: String,
-          call_id: String,
-          result: String,
-          status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
-        } |
+        {type: :program_output, id: String, call_id: String, result: String, status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status} |
         {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
-        {
-          type: :code_interpreter_call,
-          id: String,
-          code: String | nil,
-          container_id: String,
-          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
-          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-        } |
-        {
-          type: :local_shell_call,
-          id: String,
-          action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
-          call_id: String,
-          status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
-        } |
-        {
-          type: :local_shell_call_output,
-          id: String,
-          output: String,
-          status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
-        } |
-        {
-          type: :shell_call,
-          id: String,
-          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-          call_id: String,
-          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :shell_call_output,
-          id: String,
-          call_id: String,
-          max_output_length: Integer | nil,
-          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
-          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call,
-          id: String,
-          call_id: String,
-          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call_output,
-          id: String,
-          call_id: String,
-          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-          created_by: String | nil,
-          output: String | nil
-        } |
-        {
-          type: :mcp_list_tools,
-          id: String,
-          server_label: String,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]),
-          error: String | nil
-        } |
+        {type: :code_interpreter_call, id: String, code: String | nil, container_id: String, outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil, status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status} |
+        {type: :local_shell_call, id: String, action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action, call_id: String, status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status} |
+        {type: :local_shell_call_output, id: String, output: String, status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil} |
+        {type: :shell_call, id: String, action: OpenAI::Responses::ResponseFunctionShellToolCall::Action, call_id: String, environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil, status: OpenAI::Responses::ResponseFunctionShellToolCall::Status, caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil, created_by: String | nil} |
+        {type: :shell_call_output, id: String, call_id: String, max_output_length: Integer | nil, output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]), status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status, caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call, id: String, call_id: String, operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation, status: OpenAI::Responses::ResponseApplyPatchToolCall::Status, caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call_output, id: String, call_id: String, status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status, caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil, created_by: String | nil, output: String | nil} |
+        {type: :mcp_list_tools, id: String, server_label: String, tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]), error: String | nil} |
         {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
-        {
-          type: :mcp_approval_response,
-          id: String,
-          approval_request_id: String,
-          approve: OpenAI::Internal::Type::Boolean,
-          reason: String | nil
-        } |
-        {
-          type: :mcp_call,
-          id: String,
-          arguments: String,
-          name: String,
-          server_label: String,
-          approval_request_id: String | nil,
-          error: OpenAI::Responses::McpToolCallError | nil,
-          output: String | nil,
-          status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
-        } |
-        {
-          type: :custom_tool_call,
-          call_id: String,
-          input: String,
-          name: String,
-          id: String | nil,
-          caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
-          namespace: String | nil
-        } |
-        {
-          type: :custom_tool_call_output,
-          call_id: String,
-          output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
-          id: String | nil,
-          caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
-        }
+        {type: :mcp_approval_response, id: String, approval_request_id: String, approve: OpenAI::Internal::Type::Boolean, reason: String | nil} |
+        {type: :mcp_call, id: String, arguments: String, name: String, server_label: String, approval_request_id: String | nil, error: OpenAI::Responses::McpToolCallError | nil, output: String | nil, status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil} |
+        {type: :custom_tool_call, call_id: String, input: String, name: String, id: String | nil, caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil, namespace: String | nil} |
+        {type: :custom_tool_call_output, call_id: String, output: OpenAI::Responses::ResponseCustomToolCallOutput::Output, id: String | nil, caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil}
       )
         nil
       end
@@ -328,204 +157,33 @@ class OpenAI::Test::Resources::Conversations::ItemsTest < OpenAI::Test::Resource
     assert_pattern do
       case row
       in (
-        {
-          type: :message,
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]),
-          role: OpenAI::Conversations::Message::Role,
-          status: OpenAI::Conversations::Message::Status,
-          phase: OpenAI::Conversations::Message::Phase | nil
-        } |
-        {
-          type: :function_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-          created_by: String | nil,
-          name: String | nil,
-          namespace: String | nil
-        } |
-        {
-          type: :file_search_call,
-          id: String,
-          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
-        } |
-        {
-          type: :web_search_call,
-          id: String,
-          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-        } |
-        {
-          type: :image_generation_call,
-          id: String,
-          result: String | nil,
-          status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status
-        } |
-        {
-          type: :computer_call,
-          id: String,
-          call_id: String,
-          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
-          status: OpenAI::Responses::ResponseComputerToolCall::Status,
-          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-        } |
-        {
-          type: :computer_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :tool_search_call,
-          id: String,
-          arguments: OpenAI::Internal::Type::Unknown,
-          call_id: String | nil,
-          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-          status: OpenAI::Responses::ResponseToolSearchCall::Status,
-          created_by: String | nil
-        } |
-        {
-          type: :tool_search_output,
-          id: String,
-          call_id: String | nil,
-          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-          created_by: String | nil
-        } |
-        {
-          type: :additional_tools,
-          id: String,
-          role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-        } |
-        {
-          type: :reasoning,
-          id: String,
-          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-          encrypted_content: String | nil,
-          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-        } |
+        {type: :message, id: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Conversations::Message::Content]), role: OpenAI::Conversations::Message::Role, status: OpenAI::Conversations::Message::Status, phase: OpenAI::Conversations::Message::Phase | nil} |
+        {type: :function_call_output, id: String, call_id: String, output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output, status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status, caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil, created_by: String | nil, name: String | nil, namespace: String | nil} |
+        {type: :file_search_call, id: String, queries: ^(OpenAI::Internal::Type::ArrayOf[String]), status: OpenAI::Responses::ResponseFileSearchToolCall::Status, results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil} |
+        {type: :web_search_call, id: String, action: OpenAI::Responses::ResponseFunctionWebSearch::Action, status: OpenAI::Responses::ResponseFunctionWebSearch::Status} |
+        {type: :image_generation_call, id: String, result: String | nil, status: OpenAI::Conversations::ConversationItem::ImageGenerationCall::Status} |
+        {type: :computer_call, id: String, call_id: String, pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]), status: OpenAI::Responses::ResponseComputerToolCall::Status, action: OpenAI::Responses::ResponseComputerToolCall::Action | nil, actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil} |
+        {type: :computer_call_output, id: String, call_id: String, output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot, status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status, acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil, created_by: String | nil} |
+        {type: :tool_search_call, id: String, arguments: OpenAI::Internal::Type::Unknown, call_id: String | nil, execution: OpenAI::Responses::ResponseToolSearchCall::Execution, status: OpenAI::Responses::ResponseToolSearchCall::Status, created_by: String | nil} |
+        {type: :tool_search_output, id: String, call_id: String | nil, execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution, status: OpenAI::Responses::ResponseToolSearchOutputItem::Status, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]), created_by: String | nil} |
+        {type: :additional_tools, id: String, role: OpenAI::Conversations::ConversationItem::AdditionalTools::Role, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])} |
+        {type: :reasoning, id: String, summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]), content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil, encrypted_content: String | nil, status: OpenAI::Responses::ResponseReasoningItem::Status | nil} |
         {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
-        {
-          type: :program_output,
-          id: String,
-          call_id: String,
-          result: String,
-          status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status
-        } |
+        {type: :program_output, id: String, call_id: String, result: String, status: OpenAI::Conversations::ConversationItem::ProgramOutput::Status} |
         {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
-        {
-          type: :code_interpreter_call,
-          id: String,
-          code: String | nil,
-          container_id: String,
-          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
-          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-        } |
-        {
-          type: :local_shell_call,
-          id: String,
-          action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action,
-          call_id: String,
-          status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status
-        } |
-        {
-          type: :local_shell_call_output,
-          id: String,
-          output: String,
-          status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil
-        } |
-        {
-          type: :shell_call,
-          id: String,
-          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-          call_id: String,
-          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :shell_call_output,
-          id: String,
-          call_id: String,
-          max_output_length: Integer | nil,
-          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
-          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call,
-          id: String,
-          call_id: String,
-          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call_output,
-          id: String,
-          call_id: String,
-          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-          created_by: String | nil,
-          output: String | nil
-        } |
-        {
-          type: :mcp_list_tools,
-          id: String,
-          server_label: String,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]),
-          error: String | nil
-        } |
+        {type: :code_interpreter_call, id: String, code: String | nil, container_id: String, outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil, status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status} |
+        {type: :local_shell_call, id: String, action: OpenAI::Conversations::ConversationItem::LocalShellCall::Action, call_id: String, status: OpenAI::Conversations::ConversationItem::LocalShellCall::Status} |
+        {type: :local_shell_call_output, id: String, output: String, status: OpenAI::Conversations::ConversationItem::LocalShellCallOutput::Status | nil} |
+        {type: :shell_call, id: String, action: OpenAI::Responses::ResponseFunctionShellToolCall::Action, call_id: String, environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil, status: OpenAI::Responses::ResponseFunctionShellToolCall::Status, caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil, created_by: String | nil} |
+        {type: :shell_call_output, id: String, call_id: String, max_output_length: Integer | nil, output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]), status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status, caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call, id: String, call_id: String, operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation, status: OpenAI::Responses::ResponseApplyPatchToolCall::Status, caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call_output, id: String, call_id: String, status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status, caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil, created_by: String | nil, output: String | nil} |
+        {type: :mcp_list_tools, id: String, server_label: String, tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Conversations::ConversationItem::McpListTools::Tool]), error: String | nil} |
         {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
-        {
-          type: :mcp_approval_response,
-          id: String,
-          approval_request_id: String,
-          approve: OpenAI::Internal::Type::Boolean,
-          reason: String | nil
-        } |
-        {
-          type: :mcp_call,
-          id: String,
-          arguments: String,
-          name: String,
-          server_label: String,
-          approval_request_id: String | nil,
-          error: OpenAI::Responses::McpToolCallError | nil,
-          output: String | nil,
-          status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil
-        } |
-        {
-          type: :custom_tool_call,
-          call_id: String,
-          input: String,
-          name: String,
-          id: String | nil,
-          caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil,
-          namespace: String | nil
-        } |
-        {
-          type: :custom_tool_call_output,
-          call_id: String,
-          output: OpenAI::Responses::ResponseCustomToolCallOutput::Output,
-          id: String | nil,
-          caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil
-        }
+        {type: :mcp_approval_response, id: String, approval_request_id: String, approve: OpenAI::Internal::Type::Boolean, reason: String | nil} |
+        {type: :mcp_call, id: String, arguments: String, name: String, server_label: String, approval_request_id: String | nil, error: OpenAI::Responses::McpToolCallError | nil, output: String | nil, status: OpenAI::Conversations::ConversationItem::McpCall::Status | nil} |
+        {type: :custom_tool_call, call_id: String, input: String, name: String, id: String | nil, caller_: OpenAI::Responses::ResponseCustomToolCall::Caller | nil, namespace: String | nil} |
+        {type: :custom_tool_call_output, call_id: String, output: OpenAI::Responses::ResponseCustomToolCallOutput::Output, id: String | nil, caller_: OpenAI::Responses::ResponseCustomToolCallOutput::Caller | nil}
       )
         nil
       end

--- a/test/openai/resources/responses/input_items_test.rb
+++ b/test/openai/resources/responses/input_items_test.rb
@@ -57,195 +57,32 @@ class OpenAI::Test::Resources::Responses::InputItemsTest < OpenAI::Test::Resourc
     assert_pattern do
       case row
       in (
-        {
-          type: :message,
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseInputContent]),
-          role: OpenAI::Responses::ResponseInputMessageItem::Role,
-          status: OpenAI::Responses::ResponseInputMessageItem::Status | nil
-        } |
-        {
-          type: :message,
-          id: String,
-          content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseOutputMessage::Content]),
-          role: Symbol,
-          status: OpenAI::Responses::ResponseOutputMessage::Status,
-          phase: OpenAI::Responses::ResponseOutputMessage::Phase | nil
-        } |
-        {
-          type: :file_search_call,
-          id: String,
-          queries: ^(OpenAI::Internal::Type::ArrayOf[String]),
-          status: OpenAI::Responses::ResponseFileSearchToolCall::Status,
-          results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil
-        } |
-        {
-          type: :computer_call,
-          id: String,
-          call_id: String,
-          pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]),
-          status: OpenAI::Responses::ResponseComputerToolCall::Status,
-          action: OpenAI::Responses::ResponseComputerToolCall::Action | nil,
-          actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil
-        } |
-        {
-          type: :computer_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot,
-          status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status,
-          acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :web_search_call,
-          id: String,
-          action: OpenAI::Responses::ResponseFunctionWebSearch::Action,
-          status: OpenAI::Responses::ResponseFunctionWebSearch::Status
-        } |
-        {
-          type: :function_call_output,
-          id: String,
-          call_id: String,
-          output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output,
-          status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status,
-          caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil,
-          created_by: String | nil,
-          name: String | nil,
-          namespace: String | nil
-        } |
-        {
-          type: :tool_search_call,
-          id: String,
-          arguments: OpenAI::Internal::Type::Unknown,
-          call_id: String | nil,
-          execution: OpenAI::Responses::ResponseToolSearchCall::Execution,
-          status: OpenAI::Responses::ResponseToolSearchCall::Status,
-          created_by: String | nil
-        } |
-        {
-          type: :tool_search_output,
-          id: String,
-          call_id: String | nil,
-          execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution,
-          status: OpenAI::Responses::ResponseToolSearchOutputItem::Status,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]),
-          created_by: String | nil
-        } |
-        {
-          type: :additional_tools,
-          id: String,
-          role: OpenAI::Responses::ResponseItem::AdditionalTools::Role,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])
-        } |
-        {
-          type: :reasoning,
-          id: String,
-          summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]),
-          content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil,
-          encrypted_content: String | nil,
-          status: OpenAI::Responses::ResponseReasoningItem::Status | nil
-        } |
+        {type: :message, id: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseInputContent]), role: OpenAI::Responses::ResponseInputMessageItem::Role, status: OpenAI::Responses::ResponseInputMessageItem::Status | nil} |
+        {type: :message, id: String, content: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseOutputMessage::Content]), role: Symbol, status: OpenAI::Responses::ResponseOutputMessage::Status, phase: OpenAI::Responses::ResponseOutputMessage::Phase | nil} |
+        {type: :file_search_call, id: String, queries: ^(OpenAI::Internal::Type::ArrayOf[String]), status: OpenAI::Responses::ResponseFileSearchToolCall::Status, results: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFileSearchToolCall::Result]) | nil} |
+        {type: :computer_call, id: String, call_id: String, pending_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCall::PendingSafetyCheck]), status: OpenAI::Responses::ResponseComputerToolCall::Status, action: OpenAI::Responses::ResponseComputerToolCall::Action | nil, actions: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ComputerAction]) | nil} |
+        {type: :computer_call_output, id: String, call_id: String, output: OpenAI::Responses::ResponseComputerToolCallOutputScreenshot, status: OpenAI::Responses::ResponseComputerToolCallOutputItem::Status, acknowledged_safety_checks: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseComputerToolCallOutputItem::AcknowledgedSafetyCheck]) | nil, created_by: String | nil} |
+        {type: :web_search_call, id: String, action: OpenAI::Responses::ResponseFunctionWebSearch::Action, status: OpenAI::Responses::ResponseFunctionWebSearch::Status} |
+        {type: :function_call_output, id: String, call_id: String, output: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Output, status: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Status, caller_: OpenAI::Responses::ResponseFunctionToolCallOutputItem::Caller | nil, created_by: String | nil, name: String | nil, namespace: String | nil} |
+        {type: :tool_search_call, id: String, arguments: OpenAI::Internal::Type::Unknown, call_id: String | nil, execution: OpenAI::Responses::ResponseToolSearchCall::Execution, status: OpenAI::Responses::ResponseToolSearchCall::Status, created_by: String | nil} |
+        {type: :tool_search_output, id: String, call_id: String | nil, execution: OpenAI::Responses::ResponseToolSearchOutputItem::Execution, status: OpenAI::Responses::ResponseToolSearchOutputItem::Status, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool]), created_by: String | nil} |
+        {type: :additional_tools, id: String, role: OpenAI::Responses::ResponseItem::AdditionalTools::Role, tools: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::Tool])} |
+        {type: :reasoning, id: String, summary: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Summary]), content: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseReasoningItem::Content]) | nil, encrypted_content: String | nil, status: OpenAI::Responses::ResponseReasoningItem::Status | nil} |
         {type: :program, id: String, call_id: String, code: String, fingerprint: String} |
-        {
-          type: :program_output,
-          id: String,
-          call_id: String,
-          result: String,
-          status: OpenAI::Responses::ResponseItem::ProgramOutput::Status
-        } |
+        {type: :program_output, id: String, call_id: String, result: String, status: OpenAI::Responses::ResponseItem::ProgramOutput::Status} |
         {type: :compaction, id: String, encrypted_content: String, created_by: String | nil} |
-        {
-          type: :image_generation_call,
-          id: String,
-          result: String | nil,
-          status: OpenAI::Responses::ResponseItem::ImageGenerationCall::Status
-        } |
-        {
-          type: :code_interpreter_call,
-          id: String,
-          code: String | nil,
-          container_id: String,
-          outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil,
-          status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status
-        } |
-        {
-          type: :local_shell_call,
-          id: String,
-          action: OpenAI::Responses::ResponseItem::LocalShellCall::Action,
-          call_id: String,
-          status: OpenAI::Responses::ResponseItem::LocalShellCall::Status
-        } |
-        {
-          type: :local_shell_call_output,
-          id: String,
-          output: String,
-          status: OpenAI::Responses::ResponseItem::LocalShellCallOutput::Status | nil
-        } |
-        {
-          type: :shell_call,
-          id: String,
-          action: OpenAI::Responses::ResponseFunctionShellToolCall::Action,
-          call_id: String,
-          environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil,
-          status: OpenAI::Responses::ResponseFunctionShellToolCall::Status,
-          caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :shell_call_output,
-          id: String,
-          call_id: String,
-          max_output_length: Integer | nil,
-          output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]),
-          status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status,
-          caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call,
-          id: String,
-          call_id: String,
-          operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation,
-          status: OpenAI::Responses::ResponseApplyPatchToolCall::Status,
-          caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil,
-          created_by: String | nil
-        } |
-        {
-          type: :apply_patch_call_output,
-          id: String,
-          call_id: String,
-          status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status,
-          caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil,
-          created_by: String | nil,
-          output: String | nil
-        } |
-        {
-          type: :mcp_list_tools,
-          id: String,
-          server_label: String,
-          tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseItem::McpListTools::Tool]),
-          error: String | nil
-        } |
+        {type: :image_generation_call, id: String, result: String | nil, status: OpenAI::Responses::ResponseItem::ImageGenerationCall::Status} |
+        {type: :code_interpreter_call, id: String, code: String | nil, container_id: String, outputs: ^(OpenAI::Internal::Type::ArrayOf[union: OpenAI::Responses::ResponseCodeInterpreterToolCall::Output]) | nil, status: OpenAI::Responses::ResponseCodeInterpreterToolCall::Status} |
+        {type: :local_shell_call, id: String, action: OpenAI::Responses::ResponseItem::LocalShellCall::Action, call_id: String, status: OpenAI::Responses::ResponseItem::LocalShellCall::Status} |
+        {type: :local_shell_call_output, id: String, output: String, status: OpenAI::Responses::ResponseItem::LocalShellCallOutput::Status | nil} |
+        {type: :shell_call, id: String, action: OpenAI::Responses::ResponseFunctionShellToolCall::Action, call_id: String, environment: OpenAI::Responses::ResponseFunctionShellToolCall::Environment | nil, status: OpenAI::Responses::ResponseFunctionShellToolCall::Status, caller_: OpenAI::Responses::ResponseFunctionShellToolCall::Caller | nil, created_by: String | nil} |
+        {type: :shell_call_output, id: String, call_id: String, max_output_length: Integer | nil, output: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseFunctionShellToolCallOutput::Output]), status: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Status, caller_: OpenAI::Responses::ResponseFunctionShellToolCallOutput::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call, id: String, call_id: String, operation: OpenAI::Responses::ResponseApplyPatchToolCall::Operation, status: OpenAI::Responses::ResponseApplyPatchToolCall::Status, caller_: OpenAI::Responses::ResponseApplyPatchToolCall::Caller | nil, created_by: String | nil} |
+        {type: :apply_patch_call_output, id: String, call_id: String, status: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Status, caller_: OpenAI::Responses::ResponseApplyPatchToolCallOutput::Caller | nil, created_by: String | nil, output: String | nil} |
+        {type: :mcp_list_tools, id: String, server_label: String, tools: ^(OpenAI::Internal::Type::ArrayOf[OpenAI::Responses::ResponseItem::McpListTools::Tool]), error: String | nil} |
         {type: :mcp_approval_request, id: String, arguments: String, name: String, server_label: String} |
-        {
-          type: :mcp_approval_response,
-          id: String,
-          approval_request_id: String,
-          approve: OpenAI::Internal::Type::Boolean,
-          reason: String | nil
-        } |
-        {
-          type: :mcp_call,
-          id: String,
-          arguments: String,
-          name: String,
-          server_label: String,
-          approval_request_id: String | nil,
-          error: OpenAI::Responses::McpToolCallError | nil,
-          output: String | nil,
-          status: OpenAI::Responses::ResponseItem::McpCall::Status | nil
-        }
+        {type: :mcp_approval_response, id: String, approval_request_id: String, approve: OpenAI::Internal::Type::Boolean, reason: String | nil} |
+        {type: :mcp_call, id: String, arguments: String, name: String, server_label: String, approval_request_id: String | nil, error: OpenAI::Responses::McpToolCallError | nil, output: String | nil, status: OpenAI::Responses::ResponseItem::McpCall::Status | nil}
       )
         nil
       end


### PR DESCRIPTION
## Summary

- Generate inherited WebSocket event fields in RBI/RBS constructor and `to_hash` signatures for both beta and stable Responses namespaces.
- Remove obsolete formatting-only customizations from four generated union resource tests; their position-independent Ruby ASTs are unchanged.
- Preserve runtime Ruby model declarations and direct property accessors unchanged.
- Refresh generated annotation typing and source documentation while reusing the exact pinned API and configuration inputs.

## Validation

- Castiron Ruby renderer unit suite: 578 passed
- Internal candidate scope: 4 signature files, 4 generated tests, and `.castiron.stats.yml`
- OpenAPI and Stainless configuration hashes are unchanged from the prior generation
