### PR TITLE
feat: add Realtime transcription over WebSockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ end
 ### Realtime WebSockets
 
 The SDK supports block-scoped, typed Realtime WebSocket sessions for
-server-side text workflows. Add the optional `async-websocket` gem, then use
-`client.realtime.connect`:
+server-side text and committed-turn transcription workflows. Add the optional
+`async-websocket` gem, then use `client.realtime.connect`:
 
 ```ruby
 client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
@@ -74,8 +74,8 @@ end
 ```
 
 See the [Realtime WebSocket guide](realtime.md) and the runnable
-[text example](examples/realtime/README.md) for lifecycle, authentication,
-proxy, TLS, and custom transport details.
+[text and transcription examples](examples/realtime/README.md) for lifecycle,
+authentication, proxy, TLS, and custom transport details.
 
 ### Pagination
 

--- a/examples/e2e.yml
+++ b/examples/e2e.yml
@@ -52,6 +52,9 @@ examples:
   examples/realtime/websocket_text.rb:
     status: covered
     expected_output: "[realtime] smoke test passed"
+  examples/realtime/websocket_transcription.rb:
+    status: excluded
+    reason: Requires caller-provided 24 kHz mono PCM16 speech audio and live Realtime transcription access.
   examples/picture.rb:
     status: covered
     minimum_output_bytes: 1

--- a/examples/realtime/README.md
+++ b/examples/realtime/README.md
@@ -1,8 +1,12 @@
-# Realtime WebSocket text example
+# Realtime WebSocket examples
 
-This directory contains one runnable example for the Phase 1 Realtime
-WebSocket surface. It creates a typed text session, sends one user message,
-streams assistant text, verifies a completed response, and exits.
+This directory contains runnable examples for the Realtime WebSocket surface:
+
+- `websocket_text.rb` creates a typed text session, sends one user message,
+  streams assistant text, verifies a completed response, and exits.
+- `websocket_transcription.rb` uploads raw 24 kHz mono PCM16 audio, explicitly
+  commits one input turn, streams transcription deltas, verifies the matching
+  completed transcript, and exits.
 
 Add the optional transport dependency and set an API key:
 
@@ -11,7 +15,7 @@ bundle add async-websocket
 export OPENAI_API_KEY="your-key"
 ```
 
-Run the example from the repository root:
+Run the text example from the repository root:
 
 ```sh
 bundle exec ruby examples/realtime/websocket_text.rb
@@ -29,6 +33,31 @@ Optional environment variables:
   echoed to diagnostic output.
 - `OPENAI_REALTIME_TIMEOUT` — overall example deadline in seconds; defaults to
   `30`.
+
+## Transcribe one committed audio turn
+
+Convert an audio file to the input format required by the Realtime API, then
+run the transcription example:
+
+```sh
+ffmpeg -i input.wav -f s16le -acodec pcm_s16le -ac 1 -ar 24000 speech.pcm
+bundle exec ruby examples/realtime/websocket_transcription.rb speech.pcm
+```
+
+The example defaults to `gpt-transcribe`, which is intended for an explicitly
+committed audio turn over a Realtime WebSocket. It correlates transcription
+events using `item_id` and treats an early close, failed transcription, empty
+completion, or completion for the wrong item as a failure.
+
+Optional environment variables:
+
+- `OPENAI_REALTIME_TRANSCRIPTION_MODEL` — defaults to `gpt-transcribe`.
+- `OPENAI_REALTIME_TIMEOUT` — overall example deadline in seconds; defaults to
+  `60`.
+
+This example intentionally reads a file and drains its result after commit. It
+does not claim continuous microphone captioning or concurrent reader/writer
+support; those require a separately reviewed lifecycle boundary.
 
 See the repository's [Realtime WebSocket guide](../../realtime.md) for the
 public connection API, custom transports, proxy behavior, and TLS setup.

--- a/examples/realtime/websocket_transcription.rb
+++ b/examples/realtime/websocket_transcription.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "timeout"
+require_relative "../../lib/openai"
+
+module OpenAI
+  module Examples
+    module Realtime
+      module WebSocketTranscription
+        # 200 ms of 24 kHz mono PCM16 audio.
+        CHUNK_BYTES = 9_600
+
+        module_function
+
+        def stream_transcript(connection, output: $stdout)
+          committed_item_id = nil
+          completed_transcript = nil
+          streamed_transcript = +""
+
+          connection.each do |event|
+            case event
+            when OpenAI::Realtime::SessionCreatedEvent
+              output.puts("[realtime] session.created")
+            when OpenAI::Realtime::SessionUpdatedEvent
+              output.puts("[realtime] session.updated")
+            when OpenAI::Realtime::InputAudioBufferCommittedEvent
+              committed_item_id = event.item_id
+              output.puts("[realtime] input_audio_buffer.committed item=#{event.item_id}")
+            when OpenAI::Realtime::ConversationItemInputAudioTranscriptionDeltaEvent
+              next unless committed_item_id == event.item_id
+
+              streamed_transcript << event.delta
+              output.print(event.delta)
+              output.flush
+            when OpenAI::Realtime::ConversationItemInputAudioTranscriptionCompletedEvent
+              next unless committed_item_id == event.item_id
+
+              transcript = event.transcript
+              raise "Realtime transcription completed without text" if transcript.empty?
+
+              if streamed_transcript.empty?
+                output.puts(transcript)
+              elsif streamed_transcript != transcript
+                output.puts
+                output.puts("[realtime] final transcript: #{transcript}")
+              else
+                output.puts
+              end
+              output.puts("[realtime] transcription.completed item=#{event.item_id}")
+              completed_transcript = transcript
+              break
+            when OpenAI::Realtime::ConversationItemInputAudioTranscriptionFailedEvent
+              next unless committed_item_id == event.item_id
+
+              raise "Realtime transcription failed."
+            when OpenAI::Realtime::RealtimeErrorEvent
+              raise "Realtime API error."
+            end
+          end
+
+          unless completed_transcript
+            raise "Realtime connection closed before the committed audio was transcribed"
+          end
+
+          completed_transcript
+        end
+
+        def run(client:, input:, model:, chunk_bytes: CHUNK_BYTES, output: $stdout)
+          unless chunk_bytes.is_a?(Integer) && chunk_bytes.positive?
+            raise ArgumentError, "chunk_bytes must be a positive integer"
+          end
+
+          input.binmode if input.respond_to?(:binmode)
+          first_chunk = input.read(chunk_bytes)
+          raise ArgumentError, "PCM input is empty" if first_chunk.nil? || first_chunk.empty?
+
+          session = {
+            type: :transcription,
+            audio: {
+              input: {
+                format: {type: :"audio/pcm", rate: 24_000},
+                transcription: {model: model},
+                turn_detection: nil
+              }
+            }
+          }
+
+          output.puts("[realtime] connecting with #{model}")
+          transcript = client.realtime.connect_transcription do |connection|
+            connection.session.update(**session)
+            connection.input_audio_buffer.append_bytes(first_chunk)
+            while (chunk = input.read(chunk_bytes))
+              break if chunk.empty?
+
+              connection.input_audio_buffer.append_bytes(chunk)
+            end
+            connection.input_audio_buffer.commit
+            stream_transcript(connection, output: output)
+          end
+          output.puts("[realtime] transcription smoke test passed")
+          transcript
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  input_path = ARGV.fetch(0) do
+    abort("Usage: bundle exec ruby examples/realtime/websocket_transcription.rb AUDIO.pcm")
+  end
+
+  File.open(input_path, "rb") do |input|
+    Timeout.timeout(Integer(ENV.fetch("OPENAI_REALTIME_TIMEOUT", "60"))) do
+      OpenAI::Examples::Realtime::WebSocketTranscription.run(
+        client: OpenAI::Client.new,
+        input: input,
+        model: ENV.fetch("OPENAI_REALTIME_TRANSCRIPTION_MODEL", "gpt-transcribe")
+      )
+    end
+  end
+end

--- a/lib/openai/helpers/realtime/connection.rb
+++ b/lib/openai/helpers/realtime/connection.rb
@@ -15,6 +15,9 @@ module OpenAI
       # @return [OpenAI::Realtime::ConnectionResources::Conversation]
       attr_reader :conversation
 
+      # @return [OpenAI::Realtime::ConnectionResources::InputAudioBuffer]
+      attr_reader :input_audio_buffer
+
       # @api private
       def initialize(socket:, url:)
         @socket = socket
@@ -24,6 +27,7 @@ module OpenAI
         @session = OpenAI::Realtime::ConnectionResources::Session.new(self)
         @response = OpenAI::Realtime::ConnectionResources::Response.new(self)
         @conversation = OpenAI::Realtime::ConnectionResources::Conversation.new(self)
+        @input_audio_buffer = OpenAI::Realtime::ConnectionResources::InputAudioBuffer.new(self)
       end
 
       # @return [URI::Generic]

--- a/lib/openai/helpers/realtime/connection_manager.rb
+++ b/lib/openai/helpers/realtime/connection_manager.rb
@@ -21,14 +21,16 @@ module OpenAI
       # @api private
       def initialize(
         client:,
-        model:,
+        query:,
         websocket_base_url:,
         transport:,
         request_options:,
         transport_options:
       )
         @client = client
-        @model = model
+        @query = query.to_h.to_h do |key, value|
+          [key.to_s.dup.freeze, value.to_s.dup.freeze]
+        end.freeze
         @websocket_base_url = websocket_base_url&.to_s&.dup&.freeze
         @transport = transport
         @request_options = request_options
@@ -59,7 +61,7 @@ module OpenAI
 
         @client.with_realtime_connection_request(
           path: "realtime",
-          query: {"model" => @model},
+          query: @query,
           websocket_base_url: @websocket_base_url,
           options: @request_options
         ) do |request, mark_handshake_completed|

--- a/lib/openai/helpers/realtime/connection_resources.rb
+++ b/lib/openai/helpers/realtime/connection_resources.rb
@@ -49,6 +49,30 @@ module OpenAI
         end
       end
 
+      class InputAudioBuffer < Base
+        def append(audio:, event_id: nil)
+          @connection.send_event(
+            compact_event(type: :"input_audio_buffer.append", audio: audio, event_id: event_id)
+          )
+        end
+
+        def append_bytes(bytes, event_id: nil)
+          append(audio: Base64.strict_encode64(bytes), event_id: event_id)
+        end
+
+        def commit(event_id: nil)
+          @connection.send_event(
+            compact_event(type: :"input_audio_buffer.commit", event_id: event_id)
+          )
+        end
+
+        def clear(event_id: nil)
+          @connection.send_event(
+            compact_event(type: :"input_audio_buffer.clear", event_id: event_id)
+          )
+        end
+      end
+
       class Conversation < Base
         # @return [OpenAI::Realtime::ConnectionResources::ConversationItems]
         attr_reader :items

--- a/lib/openai/helpers/realtime/resources/realtime_extension.rb
+++ b/lib/openai/helpers/realtime/resources/realtime_extension.rb
@@ -20,7 +20,29 @@ module OpenAI
 
           manager = OpenAI::Realtime::ConnectionManager.new(
             client: @client,
-            model: model,
+            query: {"model" => model},
+            websocket_base_url: websocket_base_url,
+            transport: transport,
+            request_options: request_options,
+            transport_options: transport_options
+          )
+          manager.open(&block)
+        end
+
+        # Open a dedicated server-side Realtime transcription WebSocket. The
+        # transcription model is selected in the subsequent session update.
+        def connect_transcription(
+          websocket_base_url: nil,
+          request_options: nil,
+          transport: nil,
+          transport_options: {},
+          &block
+        )
+          raise ArgumentError, "A block is required to open a Realtime WebSocket." unless block
+
+          manager = OpenAI::Realtime::ConnectionManager.new(
+            client: @client,
+            query: {"intent" => "transcription"},
             websocket_base_url: websocket_base_url,
             transport: transport,
             request_options: request_options,

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   ] + [
     "examples/mtls_custom_http_client.rb",
     "examples/realtime/README.md",
+    "examples/realtime/websocket_transcription.rb",
     "examples/realtime/websocket_text.rb"
   ]
   s.extra_rdoc_files = [

--- a/rbi/openai/helpers/realtime/connection.rbi
+++ b/rbi/openai/helpers/realtime/connection.rbi
@@ -36,6 +36,9 @@ module OpenAI
         sig { returns(OpenAI::Realtime::ConnectionResources::Conversation) }
         attr_reader :conversation
 
+        sig { returns(OpenAI::Realtime::ConnectionResources::InputAudioBuffer) }
+        attr_reader :input_audio_buffer
+
         # @api private
         sig { params(socket: T.untyped, url: URI::Generic).returns(T.attached_class) }
         def self.new(socket:, url:)

--- a/rbi/openai/helpers/realtime/connection_manager.rbi
+++ b/rbi/openai/helpers/realtime/connection_manager.rbi
@@ -8,7 +8,7 @@ module OpenAI
         sig do
           params(
             client: OpenAI::Client,
-            model: String,
+            query: T::Hash[String, String],
             websocket_base_url: T.nilable(String),
             transport: T.untyped,
             request_options: T.nilable(OpenAI::RequestOptions::OrHash),
@@ -17,7 +17,7 @@ module OpenAI
         end
         def self.new(
           client:,
-          model:,
+          query:,
           websocket_base_url:,
           transport:,
           request_options:,

--- a/rbi/openai/helpers/realtime/connection_resources.rbi
+++ b/rbi/openai/helpers/realtime/connection_resources.rbi
@@ -27,6 +27,24 @@ module OpenAI
           end
         end
 
+        class InputAudioBuffer < Base
+          sig { params(audio: String, event_id: T.nilable(String)).void }
+          def append(audio:, event_id: nil)
+          end
+
+          sig { params(bytes: String, event_id: T.nilable(String)).void }
+          def append_bytes(bytes, event_id: nil)
+          end
+
+          sig { params(event_id: T.nilable(String)).void }
+          def commit(event_id: nil)
+          end
+
+          sig { params(event_id: T.nilable(String)).void }
+          def clear(event_id: nil)
+          end
+        end
+
         class Conversation < Base
           # @api private
           sig { params(connection: OpenAI::Realtime::Connection).returns(T.attached_class) }

--- a/rbi/openai/helpers/realtime/extensions.rbi
+++ b/rbi/openai/helpers/realtime/extensions.rbi
@@ -102,6 +102,24 @@ module OpenAI
         &block
       )
       end
+
+      sig do
+        params(
+          websocket_base_url: T.nilable(String),
+          request_options: T.nilable(OpenAI::RequestOptions::OrHash),
+          transport: T.untyped,
+          transport_options: T::Hash[Symbol, T.untyped],
+          block: T.proc.params(connection: OpenAI::Realtime::Connection).returns(T.untyped)
+        ).returns(T.untyped)
+      end
+      def connect_transcription(
+        websocket_base_url: nil,
+        request_options: nil,
+        transport: nil,
+        transport_options: {},
+        &block
+      )
+      end
     end
   end
 end

--- a/realtime.md
+++ b/realtime.md
@@ -1,9 +1,9 @@
 # Realtime WebSockets
 
 The Ruby SDK provides a typed, block-scoped WebSocket client for server-side
-Realtime text sessions. The first phase deliberately stays at one cohesive
-boundary: authenticated WebSocket connection setup, protocol event validation,
-and deterministic connection cleanup.
+Realtime text sessions and committed-turn transcription. The implementation
+stays at one cohesive boundary: authenticated WebSocket connection setup,
+protocol event validation, deterministic cleanup, and synchronous event flow.
 
 ## Installation
 
@@ -64,12 +64,64 @@ internally:
 - `conversation.items.create(type:, role:, content:, ...)`
 - `conversation.items.retrieve(item_id:)` and `delete(item_id:)`
 - `response.create(...)` and `response.cancel(...)`
+- `input_audio_buffer.append(audio:)`, `append_bytes(bytes)`, `commit`, and
+  `clear`
 
 For lower-level protocol work, `send_event` accepts a generated client-event
 shape, while `receive`, `each`, and `parse_event` return generated server-event
 types. Invalid client events raise `ArgumentError` with a generic public
 message; the converter error remains available through `cause` for explicit
 inspection. `send_raw` and `receive_raw` are text-frame escape hatches.
+
+## Transcribe one committed audio turn
+
+Use `connect_transcription` for the dedicated transcription handshake. Select
+the model in a `type: :transcription` session update, append 24 kHz mono PCM16
+audio, and explicitly commit the buffered turn:
+
+```ruby
+File.open("speech.pcm", "rb") do |input|
+  client.realtime.connect_transcription do |connection|
+    connection.session.update(
+      type: :transcription,
+      audio: {
+        input: {
+          format: {type: :"audio/pcm", rate: 24_000},
+          transcription: {model: "gpt-transcribe"},
+          turn_detection: nil
+        }
+      }
+    )
+
+    while (chunk = input.read(9_600))
+      connection.input_audio_buffer.append_bytes(chunk)
+    end
+    connection.input_audio_buffer.commit
+
+    committed_item_id = nil
+    connection.each do |event|
+      case event
+      when OpenAI::Realtime::InputAudioBufferCommittedEvent
+        committed_item_id = event.item_id
+      when OpenAI::Realtime::ConversationItemInputAudioTranscriptionDeltaEvent
+        print(event.delta) if event.item_id == committed_item_id
+      when OpenAI::Realtime::ConversationItemInputAudioTranscriptionCompletedEvent
+        break if event.item_id == committed_item_id
+      when OpenAI::Realtime::ConversationItemInputAudioTranscriptionFailedEvent,
+           OpenAI::Realtime::RealtimeErrorEvent
+        raise "Realtime transcription failed."
+      end
+    end
+  end
+end
+```
+
+Correlate delta and completed events by `item_id`; completion ordering across
+different input turns is not guaranteed. The runnable
+[`websocket_transcription.rb`](examples/realtime/websocket_transcription.rb)
+example additionally rejects empty input and requires a matching non-empty
+completion. It defaults to `gpt-transcribe`, which is intended for committed
+turns over WebSockets.
 
 ## Event compatibility
 
@@ -197,10 +249,10 @@ handshake.
 
 ## Current scope
 
-This phase does not add WebRTC/SDP lifecycle helpers, SIP or sideband helpers,
-transcription or translation connections, audio/file/microphone flows, image
-input, function calling helpers, or MCP helpers. Existing generated HTTP
-resources remain generated-code-owned. New convenience APIs and examples for
-those workflows have different media, ownership, security, and lifecycle
-contracts and should be reviewed as separate follow-ups after the core
-WebSocket boundary is stable.
+This phase does not add continuous microphone capture, concurrent live
+captioning, response-audio playback, WebRTC/SDP lifecycle helpers, SIP or
+sideband helpers, translation connections, image input, function calling
+helpers, or MCP helpers. Existing generated HTTP resources remain
+generated-code-owned. New convenience APIs and examples for those workflows
+have different media, ownership, security, and lifecycle contracts and should
+be reviewed as separate follow-ups.

--- a/sig/openai/helpers/realtime/connection.rbs
+++ b/sig/openai/helpers/realtime/connection.rbs
@@ -16,6 +16,7 @@ module OpenAI
         attr_reader session: OpenAI::Realtime::ConnectionResources::Session
         attr_reader response: OpenAI::Realtime::ConnectionResources::Response
         attr_reader conversation: OpenAI::Realtime::ConnectionResources::Conversation
+        attr_reader input_audio_buffer: OpenAI::Realtime::ConnectionResources::InputAudioBuffer
 
         # @api private
         def initialize: (socket: untyped, url: URI::Generic) -> void

--- a/sig/openai/helpers/realtime/connection_manager.rbs
+++ b/sig/openai/helpers/realtime/connection_manager.rbs
@@ -5,7 +5,7 @@ module OpenAI
         # @api private
         def initialize: (
           client: OpenAI::Client,
-          model: String,
+          query: ::Hash[String, String],
           websocket_base_url: String?,
           transport: untyped,
           request_options: OpenAI::request_opts?,

--- a/sig/openai/helpers/realtime/connection_resources.rbs
+++ b/sig/openai/helpers/realtime/connection_resources.rbs
@@ -16,6 +16,13 @@ module OpenAI
           def cancel: (?response_id: String?, ?event_id: String?) -> nil
         end
 
+        class InputAudioBuffer < Base
+          def append: (audio: String, ?event_id: String?) -> nil
+          def append_bytes: (String bytes, ?event_id: String?) -> nil
+          def commit: (?event_id: String?) -> nil
+          def clear: (?event_id: String?) -> nil
+        end
+
         class Conversation < Base
           # @api private
           def initialize: (OpenAI::Realtime::Connection connection) -> void

--- a/sig/openai/helpers/realtime/extensions.rbs
+++ b/sig/openai/helpers/realtime/extensions.rbs
@@ -59,6 +59,13 @@ module OpenAI
         ?transport: untyped?,
         ?transport_options: ::Hash[Symbol, untyped]
       ) { (OpenAI::Realtime::Connection connection) -> top } -> top
+
+      def connect_transcription: (
+        ?websocket_base_url: String?,
+        ?request_options: OpenAI::request_opts?,
+        ?transport: untyped?,
+        ?transport_options: ::Hash[Symbol, untyped]
+      ) { (OpenAI::Realtime::Connection connection) -> top } -> top
     end
   end
 end

--- a/test/openai/gem_packaging_test.rb
+++ b/test/openai/gem_packaging_test.rb
@@ -21,6 +21,7 @@ class OpenAI::Test::GemPackagingTest < Minitest::Test
       package = Gem::Package.new(gem_file)
 
       assert_empty(relative_links - package.contents, "README links are missing from the built gem")
+      assert_includes(package.contents, "examples/realtime/websocket_transcription.rb")
       assert_includes(package.contents, "examples/realtime/websocket_text.rb")
 
       linked_guides = relative_links.select { File.extname(_1) == ".md" }

--- a/test/openai/realtime/connection_test.rb
+++ b/test/openai/realtime/connection_test.rb
@@ -91,6 +91,52 @@ class OpenAI::Test::RealtimeConnectionTest < Minitest::Test
     assert_predicate(socket, :closed?)
   end
 
+  def test_connect_transcription_uses_the_dedicated_handshake_intent
+    socket = FakeSocket.new
+    transport = FakeTransport.new(socket)
+
+    result = client.realtime.connect_transcription(transport: transport) do |connection|
+      assert_instance_of(OpenAI::Realtime::Connection, connection)
+      :block_result
+    end
+
+    assert_equal(:block_result, result)
+    assert_equal(
+      "wss://example.com/v1/realtime?intent=transcription",
+      transport.open_args.fetch(:url).to_s
+    )
+    assert_predicate(socket, :closed?)
+  end
+
+  def test_connect_transcription_requires_a_block
+    error = assert_raises(ArgumentError) do
+      client.realtime.connect_transcription
+    end
+
+    assert_equal("A block is required to open a Realtime WebSocket.", error.message)
+  end
+
+  def test_connection_manager_snapshots_handshake_query_strings
+    model = +"gpt-realtime-2.1"
+    transport = FakeTransport.new(FakeSocket.new)
+    manager = OpenAI::Realtime::ConnectionManager.new(
+      client: client,
+      query: {"model" => model},
+      websocket_base_url: nil,
+      transport: transport,
+      request_options: nil,
+      transport_options: {}
+    )
+
+    model.replace("attacker-controlled-model")
+    manager.open { |_connection| nil }
+
+    assert_equal(
+      "wss://example.com/v1/realtime?model=gpt-realtime-2.1",
+      transport.open_args.fetch(:url).to_s
+    )
+  end
+
   def test_proxy_authorization_never_reaches_the_origin_handshake
     socket = FakeSocket.new
     transport = FakeTransport.new(socket)
@@ -266,6 +312,82 @@ class OpenAI::Test::RealtimeConnectionTest < Minitest::Test
     refute(events.fetch(0).fetch(:session).key?(:event_id))
     assert_equal("Hello", events.fetch(1).dig(:item, :content, 0, :text))
     assert_equal("Be concise", events.fetch(2).dig(:response, :instructions))
+  end
+
+  def test_input_audio_buffer_helper_encodes_bytes_and_preserves_base64_input
+    socket = FakeSocket.new
+    transport = FakeTransport.new(socket)
+
+    client.realtime.connect_transcription(transport: transport) do |connection|
+      connection.input_audio_buffer.append(audio: "YWxyZWFkeS1lbmNvZGVk", event_id: "encoded_1")
+      connection.input_audio_buffer.append_bytes("\x00\xFF".b, event_id: "bytes_1")
+      connection.input_audio_buffer.commit(event_id: "commit_1")
+      connection.input_audio_buffer.clear(event_id: "clear_1")
+    end
+
+    events = socket.writes.map { JSON.parse(_1, symbolize_names: true) }
+    assert_equal(
+      [
+        :"input_audio_buffer.append",
+        :"input_audio_buffer.append",
+        :"input_audio_buffer.commit",
+        :"input_audio_buffer.clear"
+      ],
+      events.map { _1.fetch(:type).to_sym }
+    )
+    assert_equal("YWxyZWFkeS1lbmNvZGVk", events.fetch(0).fetch(:audio))
+    assert_equal("AP8=", events.fetch(1).fetch(:audio))
+    assert_equal(%w[encoded_1 bytes_1 commit_1 clear_1], events.map { _1.fetch(:event_id) })
+  end
+
+  def test_transcription_session_and_events_use_generated_types
+    socket = FakeSocket.new(
+      JSON.generate(
+        type: "conversation.item.input_audio_transcription.delta",
+        event_id: "event_delta",
+        item_id: "item_1",
+        content_index: 0,
+        delta: "Hello"
+      ),
+      JSON.generate(
+        type: "conversation.item.input_audio_transcription.completed",
+        event_id: "event_completed",
+        item_id: "item_1",
+        content_index: 0,
+        transcript: "Hello from Ruby.",
+        usage: {type: "tokens", input_tokens: 1, output_tokens: 1, total_tokens: 2}
+      )
+    )
+    transport = FakeTransport.new(socket)
+
+    events = client.realtime.connect_transcription(transport: transport) do |connection|
+      connection.session.update(
+        type: :transcription,
+        audio: {
+          input: {
+            format: {type: :"audio/pcm", rate: 24_000},
+            transcription: {model: :"gpt-live-transcribe"},
+            turn_detection: nil
+          }
+        }
+      )
+      [connection.receive, connection.receive]
+    end
+
+    session_event = JSON.parse(socket.writes.fetch(0), symbolize_names: true)
+    assert_equal(
+      "wss://example.com/v1/realtime?intent=transcription",
+      transport.open_args.fetch(:url).to_s
+    )
+    assert_equal(:transcription, session_event.dig(:session, :type).to_sym)
+    assert_equal(24_000, session_event.dig(:session, :audio, :input, :format, :rate))
+    assert_instance_of(OpenAI::Realtime::ConversationItemInputAudioTranscriptionDeltaEvent, events.fetch(0))
+    assert_instance_of(
+      OpenAI::Realtime::ConversationItemInputAudioTranscriptionCompletedEvent,
+      events.fetch(1)
+    )
+    assert_equal("item_1", events.fetch(0).item_id)
+    assert_equal("item_1", events.fetch(1).item_id)
   end
 
   def test_send_event_validates_the_generated_client_event_union

--- a/test/openai/realtime/websocket_transcription_example_test.rb
+++ b/test/openai/realtime/websocket_transcription_example_test.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+require_relative "../test_helper"
+require_relative "../../../examples/realtime/websocket_transcription"
+
+class OpenAI::Test::RealtimeWebSocketTranscriptionExampleTest < Minitest::Test
+  class RecordingSession
+    attr_reader :updates
+
+    def initialize = @updates = []
+    def update(**params) = @updates << params
+  end
+
+  class RecordingInputAudioBuffer
+    attr_reader :appends, :commits
+
+    def initialize
+      @appends = []
+      @commits = []
+    end
+
+    def append_bytes(bytes, event_id: nil) = @appends << {bytes: bytes, event_id: event_id}
+    def commit(event_id: nil) = @commits << {event_id: event_id}
+  end
+
+  class RecordingConnection
+    attr_reader :input_audio_buffer, :session
+
+    def initialize(events)
+      @events = events
+      @input_audio_buffer = RecordingInputAudioBuffer.new
+      @session = RecordingSession.new
+    end
+
+    def each(&block) = @events.each(&block)
+  end
+
+  class RecordingRealtime
+    attr_reader :connection_count
+
+    def initialize(connection)
+      @connection = connection
+      @connection_count = 0
+    end
+
+    def connect_transcription
+      @connection_count += 1
+      yield(@connection)
+    end
+  end
+
+  RecordingClient = Data.define(:realtime)
+
+  def test_example_streams_pcm_and_requires_a_completed_transcript_for_the_committed_item
+    connection = RecordingConnection.new(successful_events)
+    realtime = RecordingRealtime.new(connection)
+    output = StringIO.new
+
+    transcript = OpenAI::Examples::Realtime::WebSocketTranscription.run(
+      client: RecordingClient.new(realtime: realtime),
+      input: StringIO.new("abcdef".b),
+      model: "gpt-transcribe",
+      chunk_bytes: 2,
+      output: output
+    )
+
+    assert_equal("Hello from Ruby.", transcript)
+    assert_equal(1, realtime.connection_count)
+    assert_equal(%w[ab cd ef], connection.input_audio_buffer.appends.map { _1.fetch(:bytes) })
+    assert_equal([{event_id: nil}], connection.input_audio_buffer.commits)
+    assert_equal(:transcription, connection.session.updates.fetch(0).fetch(:type))
+    assert_equal(
+      {type: :"audio/pcm", rate: 24_000},
+      connection.session.updates.fetch(0).dig(:audio, :input, :format)
+    )
+    assert_equal(
+      {model: "gpt-transcribe"},
+      connection.session.updates.fetch(0).dig(:audio, :input, :transcription)
+    )
+    assert_nil(connection.session.updates.fetch(0).dig(:audio, :input, :turn_detection))
+    assert_includes(output.string, "Hello from Ruby.")
+    assert_includes(output.string, "item=item_1")
+    assert_includes(output.string, "transcription smoke test passed")
+  end
+
+  def test_example_rejects_empty_input_before_opening_a_connection
+    realtime = RecordingRealtime.new(RecordingConnection.new([]))
+
+    error = assert_raises(ArgumentError) do
+      OpenAI::Examples::Realtime::WebSocketTranscription.run(
+        client: RecordingClient.new(realtime: realtime),
+        input: StringIO.new("".b),
+        model: "gpt-transcribe",
+        output: StringIO.new
+      )
+    end
+
+    assert_equal("PCM input is empty", error.message)
+    assert_equal(0, realtime.connection_count)
+  end
+
+  def test_example_fails_closed_without_a_matching_completion
+    connection = RecordingConnection.new(
+      [
+        OpenAI::Realtime::InputAudioBufferCommittedEvent.new(
+          event_id: "event_committed",
+          item_id: "item_1"
+        ),
+        completed_event(item_id: "item_2")
+      ]
+    )
+
+    error = assert_raises(RuntimeError) do
+      OpenAI::Examples::Realtime::WebSocketTranscription.run(
+        client: RecordingClient.new(realtime: RecordingRealtime.new(connection)),
+        input: StringIO.new("pcm".b),
+        model: "gpt-transcribe",
+        output: StringIO.new
+      )
+    end
+
+    assert_equal("Realtime connection closed before the committed audio was transcribed", error.message)
+  end
+
+  def test_example_keeps_transcription_error_details_out_of_the_exception_message
+    customer_text = "private audio content in a service error"
+    failed = OpenAI::Realtime::ConversationItemInputAudioTranscriptionFailedEvent.new(
+      content_index: 0,
+      error: {message: customer_text, type: "transcription_error"},
+      event_id: "event_failed",
+      item_id: "item_1"
+    )
+    connection = RecordingConnection.new(
+      [
+        OpenAI::Realtime::InputAudioBufferCommittedEvent.new(
+          event_id: "event_committed",
+          item_id: "item_1"
+        ),
+        failed
+      ]
+    )
+
+    error = assert_raises(RuntimeError) do
+      OpenAI::Examples::Realtime::WebSocketTranscription.run(
+        client: RecordingClient.new(realtime: RecordingRealtime.new(connection)),
+        input: StringIO.new("pcm".b),
+        model: "gpt-transcribe",
+        output: StringIO.new
+      )
+    end
+
+    assert_equal("Realtime transcription failed.", error.message)
+    refute_includes(error.message, customer_text)
+  end
+
+  def test_example_prints_the_final_transcript_when_the_service_sends_no_deltas
+    connection = RecordingConnection.new(
+      [
+        OpenAI::Realtime::InputAudioBufferCommittedEvent.new(
+          event_id: "event_committed",
+          item_id: "item_1"
+        ),
+        completed_event(item_id: "item_1")
+      ]
+    )
+    output = StringIO.new
+
+    transcript = OpenAI::Examples::Realtime::WebSocketTranscription.run(
+      client: RecordingClient.new(realtime: RecordingRealtime.new(connection)),
+      input: StringIO.new("pcm".b),
+      model: "gpt-transcribe",
+      output: output
+    )
+
+    assert_equal("Hello from Ruby.", transcript)
+    assert_includes(output.string, "Hello from Ruby.")
+  end
+
+  private def successful_events
+    [
+      OpenAI::Realtime::SessionCreatedEvent.new(
+        event_id: "event_created",
+        session: {type: :transcription}
+      ),
+      OpenAI::Realtime::SessionUpdatedEvent.new(
+        event_id: "event_updated",
+        session: {
+          type: :transcription,
+          audio: {
+            input: {
+              format: {type: :"audio/pcm", rate: 24_000},
+              transcription: {model: :"gpt-transcribe"},
+              turn_detection: nil
+            }
+          }
+        }
+      ),
+      OpenAI::Realtime::InputAudioBufferCommittedEvent.new(
+        event_id: "event_committed",
+        item_id: "item_1"
+      ),
+      OpenAI::Realtime::ConversationItemInputAudioTranscriptionDeltaEvent.new(
+        content_index: 0,
+        delta: "Hello from Ruby.",
+        event_id: "event_delta",
+        item_id: "item_1"
+      ),
+      completed_event(item_id: "item_1")
+    ]
+  end
+
+  private def completed_event(item_id:)
+    OpenAI::Realtime::ConversationItemInputAudioTranscriptionCompletedEvent.new(
+      content_index: 0,
+      event_id: "event_completed",
+      item_id: item_id,
+      transcript: "Hello from Ruby.",
+      usage: {type: :duration, seconds: 0.25}
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- add a dedicated `client.realtime.connect_transcription` handshake using `intent=transcription`
- add Ruby-native `input_audio_buffer` helpers for API-ready Base64, raw bytes, commit, and clear
- add a packaged committed-turn transcription example using 24 kHz mono PCM16 and `gpt-transcribe`
- document event correlation by `item_id` and keep continuous microphone/concurrent live captioning explicitly deferred

## Design

This is the intentionally narrow Phase 2 follow-up to #443. The generated OpenAPI models already own the transcription session and event unions, so this PR changes no generated models or HTTP resources. It only layers custom WebSocket routing and Ruby helpers onto those generated types.

The example uploads one bounded file-backed turn, commits it explicitly, drains typed delta/completed events, and requires a non-empty completion for the committed item. WebRTC, SIP/sideband, translation, microphone capture, playback, VAD conversation loops, function/MCP/image workflows, and new HTTP resources remain out of scope.

## Validation

- Ruby 3.3.12: 892 tests / 4,525 assertions
- Ruby 3.4.10: 892 tests / 4,525 assertions
- Ruby 4.0.6: 892 tests / 4,525 assertions
- RuboCop: 2,670 files, no offenses
- Sorbet and 1,225 RBS files: clean
- gem packaging, example inventory, YARD build, and syntax checks: clean
- mandatory two-pass thermo-nuclear code-quality review: clean after hardening the internal handshake-query snapshot
- live service smoke: synthesized speech produced `session.created`, `session.updated`, a committed `item_id`, matching delta/completed events, and the expected transcript through the exact runnable example

Official protocol references:

- https://developers.openai.com/api/docs/guides/realtime-transcription
- https://developers.openai.com/api/docs/guides/realtime-websocket
