### PR TITLE
fix: isolate union coercion state

### DIFF
--- a/lib/openai/internal/type/converter.rb
+++ b/lib/openai/internal/type/converter.rb
@@ -270,6 +270,26 @@ module OpenAI
 
           # @api private
           #
+          # Coerces a value while isolating its error from sibling coercions.
+          #
+          # @param target [OpenAI::Internal::Type::Converter, Class]
+          #
+          # @param value [Object]
+          #
+          # @param state [Hash{Symbol=>Object}]
+          #
+          # @return [Array(Object, StandardError, nil)]
+          def coerce_with_error(target, value, state:)
+            previous_error = state.fetch(:error)
+            state[:error] = nil
+            coerced = coerce(target, value, state: state)
+            [coerced, state.fetch(:error)]
+          ensure
+            state[:error] = previous_error
+          end
+
+          # @api private
+          #
           # @param target [OpenAI::Internal::Type::Converter, Class]
           #
           # @param value [Object]
@@ -313,7 +333,7 @@ module OpenAI
               translate_names: T::Boolean,
               strictness: T::Boolean,
               exactness: {yes: Integer, no: Integer, maybe: Integer},
-              error: T::Class[StandardError],
+              error: T.nilable(StandardError),
               branched: Integer
             }
           end

--- a/lib/openai/internal/type/union.rb
+++ b/lib/openai/internal/type/union.rb
@@ -159,11 +159,12 @@ module OpenAI
         #
         # @return [Object]
         def coerce(value, state:)
+          strictness = state.fetch(:strictness)
+          previous_error = state.fetch(:error)
           if (target = resolve_variant(value))
             return OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
           end
 
-          strictness = state.fetch(:strictness)
           exactness = state.fetch(:exactness)
 
           alternatives = []
@@ -172,14 +173,16 @@ module OpenAI
             exact = state[:exactness] = {yes: 0, no: 0, maybe: 0}
             state[:branched] += 1
 
-            coerced = OpenAI::Internal::Type::Converter.coerce(target, value, state: state)
+            coerced, error =
+              OpenAI::Internal::Type::Converter.coerce_with_error(target, value, state: state)
             yes, no, maybe = exact.values
             if (no + maybe).zero? || (!strictness && yes.positive?)
               exact.each { exactness[_1] += _2 }
               state[:exactness] = exactness
+              state[:error] = error || previous_error
               return coerced
             elsif maybe.positive?
-              alternatives << [[-yes, -maybe, no], exact, coerced]
+              alternatives << [[-yes, -maybe, no], exact, coerced, error]
             end
           end
 
@@ -188,8 +191,9 @@ module OpenAI
             exactness[:no] += 1
             state[:error] = ArgumentError.new("no matching variant for #{value.inspect}")
             value
-          in [[_, exact, coerced], *]
+          in [[_, exact, coerced, error], *]
             exact.each { exactness[_1] += _2 }
+            state[:error] = error || previous_error
             coerced
           end
             .tap { state[:exactness] = exactness }

--- a/rbi/openai/internal/type/converter.rbi
+++ b/rbi/openai/internal/type/converter.rbi
@@ -22,7 +22,7 @@ module OpenAI
                 no: Integer,
                 maybe: Integer
               },
-              error: T::Class[StandardError],
+              error: T.nilable(StandardError),
               branched: Integer
             }
           end
@@ -180,6 +180,17 @@ module OpenAI
             # See implementation below for more details.
             state: OpenAI::Internal::Type::Converter.new_coerce_state
           )
+          end
+
+          # @api private
+          sig do
+            params(
+              target: OpenAI::Internal::Type::Converter::Input,
+              value: T.anything,
+              state: OpenAI::Internal::Type::Converter::CoerceState
+            ).returns([T.anything, T.nilable(StandardError)])
+          end
+          def self.coerce_with_error(target, value, state:)
           end
 
           # @api private

--- a/sig/openai/internal/type/converter.rbs
+++ b/sig/openai/internal/type/converter.rbs
@@ -11,7 +11,7 @@ module OpenAI
             translate_names: bool,
             strictness: bool,
             exactness: { yes: Integer, no: Integer, maybe: Integer },
-            error: Class,
+            error: StandardError?,
             branched: Integer
           }
 
@@ -65,6 +65,12 @@ module OpenAI
           top value,
           ?state: OpenAI::Internal::Type::Converter::coerce_state
         ) -> top
+
+        def self.coerce_with_error: (
+          OpenAI::Internal::Type::Converter::input target,
+          top value,
+          state: OpenAI::Internal::Type::Converter::coerce_state
+        ) -> [top, StandardError?]
 
         def self.dump: (
           OpenAI::Internal::Type::Converter::input target,

--- a/test/openai/internal/type/union_state_test.rb
+++ b/test/openai/internal/type/union_state_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::UnionStateTest < Minitest::Test
+  module FailedFirstUnion
+    extend OpenAI::Internal::Type::Union
+
+    variant Integer
+    variant const: :inf
+  end
+
+  module FailedLastUnion
+    extend OpenAI::Internal::Type::Union
+
+    variant const: :inf
+    variant Integer
+  end
+
+  class TaggedValue < OpenAI::Internal::Type::BaseModel
+    required :type, const: :tagged
+  end
+
+  module DiscriminatedUnion
+    extend OpenAI::Internal::Type::Union
+
+    discriminator :type
+    variant :tagged, TaggedValue
+  end
+
+  class InexactIntegerValue < OpenAI::Internal::Type::BaseModel
+    required :value, Integer
+  end
+
+  class ExactStringValue < OpenAI::Internal::Type::BaseModel
+    required :value, String
+  end
+
+  module RankedValueUnion
+    extend OpenAI::Internal::Type::Union
+
+    variant InexactIntegerValue
+    variant ExactStringValue
+  end
+
+  class PartiallyInvalidValue < OpenAI::Internal::Type::BaseModel
+    required :coerced, Integer
+    required :invalid, Integer
+  end
+
+  module SelectedErrorUnion
+    extend OpenAI::Internal::Type::Union
+
+    variant PartiallyInvalidValue
+    variant Float
+  end
+
+  def test_coerce_with_error_isolates_each_attempt
+    previous_error = RuntimeError.new("previous")
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    state[:error] = previous_error
+
+    value, error = OpenAI::Internal::Type::Converter.coerce_with_error(Integer, "one", state: state)
+
+    assert_equal("one", value)
+    assert_instance_of(ArgumentError, error)
+    assert_same(previous_error, state.fetch(:error))
+
+    value, error = OpenAI::Internal::Type::Converter.coerce_with_error(Integer, "1", state: state)
+
+    assert_equal(1, value)
+    assert_nil(error)
+    assert_same(previous_error, state.fetch(:error))
+  end
+
+  def test_rejected_variant_errors_do_not_poison_the_selected_variant
+    cases = [
+      [FailedFirstUnion, :inf, :inf],
+      [FailedFirstUnion, "inf", :inf],
+      [FailedLastUnion, "other", "other"]
+    ]
+
+    cases.each do |target, input, expected|
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+      assert_equal(expected, OpenAI::Internal::Type::Converter.coerce(target, input, state: state))
+      assert_nil(state.fetch(:error))
+    end
+  end
+
+  def test_successful_union_preserves_an_error_from_its_parent
+    previous_error = RuntimeError.new("previous")
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    state[:error] = previous_error
+
+    coerced = OpenAI::Internal::Type::Converter.coerce(FailedFirstUnion, :inf, state: state)
+
+    assert_equal(:inf, coerced)
+    assert_same(previous_error, state.fetch(:error))
+  end
+
+  def test_selected_variant_preserves_its_own_error
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    state[:error] = RuntimeError.new("previous")
+
+    coerced = OpenAI::Internal::Type::Converter.coerce(
+      SelectedErrorUnion,
+      {coerced: "1", invalid: "invalid"},
+      state: state
+    )
+
+    assert_instance_of(PartiallyInvalidValue, coerced)
+    assert_instance_of(ArgumentError, state.fetch(:error))
+    assert_match(/invalid/, state.fetch(:error).message)
+  end
+
+  def test_discriminated_coercion_preserves_strictness
+    discriminators = [
+      {type: :tagged},
+      {type: "tagged"},
+      {"type" => :tagged},
+      {"type" => "tagged"}
+    ]
+
+    discriminators.each do |input|
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+      OpenAI::Internal::Type::Converter.coerce(DiscriminatedUnion, input, state: state)
+      selected = OpenAI::Internal::Type::Converter.coerce(
+        RankedValueUnion,
+        {value: "1"},
+        state: state
+      )
+
+      assert_equal(true, state.fetch(:strictness))
+      assert_instance_of(ExactStringValue, selected)
+      assert_nil(state.fetch(:error))
+    end
+  end
+end

--- a/test/openai/models/realtime/realtime_session_create_request_test.rb
+++ b/test/openai/models/realtime/realtime_session_create_request_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Models::Realtime::RealtimeSessionCreateRequestTest < Minitest::Test
+  def test_max_output_tokens_inf_ignores_rejected_integer_errors
+    [:inf, "inf"].each do |input|
+      request = OpenAI::Realtime::RealtimeSessionCreateRequest.new(max_output_tokens: input)
+
+      assert_same(input, request.max_output_tokens)
+      assert_same(input, request[:max_output_tokens])
+      assert_same(input, request.to_h.fetch(:max_output_tokens))
+
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+      parsed = OpenAI::Internal::Type::Converter.coerce(
+        OpenAI::Realtime::RealtimeSessionCreateRequest,
+        {type: "realtime", max_output_tokens: input},
+        state: state
+      )
+
+      assert_equal(:inf, parsed.max_output_tokens)
+      assert_equal(:inf, parsed[:max_output_tokens])
+      assert_nil(state.fetch(:error))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- isolate conversion errors between union variant attempts so rejected variants cannot poison the selected result
- preserve the incoming strictness state across the discriminated-union fast path
- preserve a pre-existing parent error unless the selected variant reports a more specific error
- add runtime regression coverage plus a representative Realtime generated-model contract test

Addresses the first and third follow-up behaviors in #376. This intentionally does not close the tracking issue.

## Root cause

Union alternatives shared `state[:error]`, so an error from a rejected variant survived into a later successful match. The discriminated fast path also returned before capturing `state[:strictness]`, while the method's `ensure` still restored that uninitialized local.

The fix adds an internal, typed converter helper that isolates each attempt's error, then commits only the chosen variant's error. Strictness is captured before discriminator resolution.

## Generated-code ownership

No Castiron generator or generated model changes are required. The behavior belongs to SDK-owned internal coercion plumbing; the Realtime model is used only as representative regression coverage. Raw request values remain caller-owned, while parsed response materialization still normalizes `"inf"` / `:inf` to `:inf`.

## Validation

- focused regressions: 37 runs, 367 assertions, 0 failures/errors
- full suite: 834 runs, 4,176 assertions, 0 failures/errors, 1 skip
- Sorbet: no errors
- RBS: 1,219 files valid
- RuboCop: 2,648 files inspected, no offenses
- generated directive validation: passed
- `git diff --check`: passed

Note: `./scripts/test` exits 1 after the green suite because its cleanup trap attempts to kill an already-exited mock-server PID (`kill: No such process`).