### PR TITLE
ci: Add dependency cooldown to Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 gemspec
 


### PR DESCRIPTION
Supported as of 4.0.13: https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html