### PR TITLE
docs: add Realtime voice turn example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ end
 ### Realtime WebSockets
 
 The SDK supports block-scoped, typed Realtime WebSocket sessions for
-server-side text and committed-turn transcription workflows. Add the optional
-`async-websocket` gem, then use `client.realtime.connect`:
+server-side text, committed-turn transcription, and one-turn voice workflows.
+Add the optional `async-websocket` gem, then use `client.realtime.connect`:
 
 ```ruby
 client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
@@ -74,8 +74,8 @@ end
 ```
 
 See the [Realtime WebSocket guide](realtime.md) and the runnable
-[text and transcription examples](examples/realtime/README.md) for lifecycle,
-authentication, proxy, TLS, and custom transport details.
+[text, transcription, and voice examples](examples/realtime/README.md) for
+lifecycle, authentication, proxy, TLS, and custom transport details.
 
 ### Pagination
 

--- a/examples/e2e.yml
+++ b/examples/e2e.yml
@@ -57,7 +57,7 @@ examples:
     reason: Requires caller-provided 24 kHz mono PCM16 speech audio and live Realtime transcription access.
   examples/realtime/websocket_voice_turn.rb:
     status: excluded
-    reason: Requires caller-provided 24 kHz mono PCM16 speech audio, an output path, and live Realtime audio access.
+    reason: Requires caller-provided 24 kHz mono PCM16 speech audio, a PCM response sink, and live Realtime audio access.
   examples/picture.rb:
     status: covered
     minimum_output_bytes: 1

--- a/examples/e2e.yml
+++ b/examples/e2e.yml
@@ -55,6 +55,9 @@ examples:
   examples/realtime/websocket_transcription.rb:
     status: excluded
     reason: Requires caller-provided 24 kHz mono PCM16 speech audio and live Realtime transcription access.
+  examples/realtime/websocket_voice_turn.rb:
+    status: excluded
+    reason: Requires caller-provided 24 kHz mono PCM16 speech audio, an output path, and live Realtime audio access.
   examples/picture.rb:
     status: covered
     minimum_output_bytes: 1

--- a/examples/realtime/README.md
+++ b/examples/realtime/README.md
@@ -7,6 +7,9 @@ This directory contains runnable examples for the Realtime WebSocket surface:
 - `websocket_transcription.rb` uploads raw 24 kHz mono PCM16 audio, explicitly
   commits one input turn, streams transcription deltas, verifies the matching
   completed transcript, and exits.
+- `websocket_voice_turn.rb` uploads one raw 24 kHz mono PCM16 turn, explicitly
+  commits it, streams the assistant's audio transcript, saves the PCM response,
+  verifies a completed response, and exits.
 
 Add the optional transport dependency and set an API key:
 
@@ -58,6 +61,34 @@ Optional environment variables:
 This example intentionally reads a file and drains its result after commit. It
 does not claim continuous microphone captioning or concurrent reader/writer
 support; those require a separately reviewed lifecycle boundary.
+
+## Send one voice turn and save the response
+
+Convert an audio file to 24 kHz mono PCM16, run the voice-turn example, then
+play the raw response:
+
+```sh
+ffmpeg -i input.wav -f s16le -acodec pcm_s16le -ac 1 -ar 24000 input.pcm
+bundle exec ruby examples/realtime/websocket_voice_turn.rb input.pcm response.pcm
+ffplay -f s16le -ar 24000 -ac 1 response.pcm
+```
+
+The output path must not already exist. This prevents accidental truncation,
+including when the input and output paths refer to the same file. A successful
+run prints the assistant transcript, writes non-empty response audio, observes
+`response.done status=completed`, and prints
+`[realtime] voice turn smoke test passed`.
+
+Optional environment variables:
+
+- `OPENAI_REALTIME_MODEL` — defaults to `gpt-realtime-2.1`.
+- `OPENAI_REALTIME_VOICE` — defaults to `marin`.
+- `OPENAI_REALTIME_TIMEOUT` — overall example deadline in seconds; defaults to
+  `60`.
+
+This is an explicit, committed file turn. It does not capture a microphone,
+play audio while it arrives, or claim full-duplex conversation support; those
+require a separately reviewed concurrency and device-lifecycle boundary.
 
 See the repository's [Realtime WebSocket guide](../../realtime.md) for the
 public connection API, custom transports, proxy behavior, and TLS setup.

--- a/examples/realtime/README.md
+++ b/examples/realtime/README.md
@@ -8,8 +8,8 @@ This directory contains runnable examples for the Realtime WebSocket surface:
   commits one input turn, streams transcription deltas, verifies the matching
   completed transcript, and exits.
 - `websocket_voice_turn.rb` uploads one raw 24 kHz mono PCM16 turn, explicitly
-  commits it, collects the assistant's streamed audio transcript, saves the PCM
-  response, verifies a completed response, and exits.
+  commits it, streams the assistant's PCM response to standard output, returns
+  its transcript to embedded callers, verifies a completed response, and exits.
 
 Add the optional transport dependency and set an API key:
 
@@ -62,30 +62,30 @@ This example intentionally reads a file and drains its result after commit. It
 does not claim continuous microphone captioning or concurrent reader/writer
 support; those require a separately reviewed lifecycle boundary.
 
-## Send one voice turn and save the response
+## Send one voice turn and play the response
 
-Convert an audio file to 24 kHz mono PCM16, run the voice-turn example, then
-play the raw response:
+Convert an audio file to 24 kHz mono PCM16, stream it through the voice-turn
+example, and play the response as it arrives:
 
 ```sh
-ffmpeg -i input.wav -f s16le -acodec pcm_s16le -ac 1 -ar 24000 input.pcm
-bundle exec ruby examples/realtime/websocket_voice_turn.rb input.pcm response.pcm
-ffplay -f s16le -ar 24000 -ac 1 response.pcm
+ffmpeg -v error -i input.wav -f s16le -acodec pcm_s16le -ac 1 -ar 24000 - \
+  | bundle exec ruby examples/realtime/websocket_voice_turn.rb \
+  | ffplay -v error -f s16le -ar 24000 -ac 1 -
 ```
 
-The output path must not already exist. This prevents accidental truncation,
-including when the input and output paths refer to the same file. The example
-stages audio privately and publishes the path only after success, so a failed
-or timed-out run leaves no partial response behind and the command can be
-retried. Before connecting, it verifies that the output filesystem supports
-the atomic hard-link operation used for no-clobber publication. It fails closed
-on Windows because Ruby's portable file-mode API cannot verify owner-only NTFS
-ACLs. `WebSocketVoiceTurn.run` returns the assistant transcript explicitly;
-diagnostic output never includes it. The executable boundary also suppresses
-payload-bearing parser causes from malformed protocol events. A successful run
-writes non-empty response audio, observes `response.done status=completed`,
-publishes the requested file, and only then prints
-`[realtime] voice turn smoke test passed`.
+The executable reads raw PCM from standard input, writes only response PCM to
+standard output, and sends metadata-only diagnostics to standard error.
+`WebSocketVoiceTurn.run_with_timeout` returns the assistant transcript to
+embedded callers without printing it. Its single deadline covers the initial
+input read, network turn, and response stream. The boundary also suppresses
+path details from operating-system I/O errors and payload-bearing parser causes
+from malformed protocol events. A successful run writes non-empty response
+audio, observes `response.done status=completed`, and then prints
+`[realtime] voice turn smoke test passed` to standard error.
+
+The example intentionally does not own output filenames, overwrite policy, or
+filesystem durability. If you redirect its standard output to a file, those
+semantics belong to your shell or application.
 
 Optional environment variables:
 

--- a/examples/realtime/README.md
+++ b/examples/realtime/README.md
@@ -77,7 +77,10 @@ The output path must not already exist. This prevents accidental truncation,
 including when the input and output paths refer to the same file. The example
 stages audio privately and publishes the path only after success, so a failed
 or timed-out run leaves no partial response behind and the command can be
-retried. `WebSocketVoiceTurn.run` returns the assistant transcript explicitly;
+retried. Before connecting, it verifies that the output filesystem supports
+the atomic hard-link operation used for no-clobber publication. It fails closed
+on Windows because Ruby's portable file-mode API cannot verify owner-only NTFS
+ACLs. `WebSocketVoiceTurn.run` returns the assistant transcript explicitly;
 diagnostic output never includes it. The executable boundary also suppresses
 payload-bearing parser causes from malformed protocol events. A successful run
 writes non-empty response audio, observes `response.done status=completed`,

--- a/examples/realtime/README.md
+++ b/examples/realtime/README.md
@@ -8,8 +8,8 @@ This directory contains runnable examples for the Realtime WebSocket surface:
   commits one input turn, streams transcription deltas, verifies the matching
   completed transcript, and exits.
 - `websocket_voice_turn.rb` uploads one raw 24 kHz mono PCM16 turn, explicitly
-  commits it, streams the assistant's audio transcript, saves the PCM response,
-  verifies a completed response, and exits.
+  commits it, collects the assistant's streamed audio transcript, saves the PCM
+  response, verifies a completed response, and exits.
 
 Add the optional transport dependency and set an API key:
 
@@ -74,9 +74,12 @@ ffplay -f s16le -ar 24000 -ac 1 response.pcm
 ```
 
 The output path must not already exist. This prevents accidental truncation,
-including when the input and output paths refer to the same file. A successful
-run prints the assistant transcript, writes non-empty response audio, observes
-`response.done status=completed`, and prints
+including when the input and output paths refer to the same file. The example
+stages audio privately and publishes the path only after success, so a failed
+or timed-out run leaves no partial response behind and the command can be
+retried. `WebSocketVoiceTurn.run` returns the assistant transcript explicitly;
+diagnostic output never includes it. A successful run writes non-empty response
+audio, observes `response.done status=completed`, and prints
 `[realtime] voice turn smoke test passed`.
 
 Optional environment variables:

--- a/examples/realtime/README.md
+++ b/examples/realtime/README.md
@@ -78,8 +78,10 @@ including when the input and output paths refer to the same file. The example
 stages audio privately and publishes the path only after success, so a failed
 or timed-out run leaves no partial response behind and the command can be
 retried. `WebSocketVoiceTurn.run` returns the assistant transcript explicitly;
-diagnostic output never includes it. A successful run writes non-empty response
-audio, observes `response.done status=completed`, and prints
+diagnostic output never includes it. The executable boundary also suppresses
+payload-bearing parser causes from malformed protocol events. A successful run
+writes non-empty response audio, observes `response.done status=completed`,
+publishes the requested file, and only then prints
 `[realtime] voice turn smoke test passed`.
 
 Optional environment variables:

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "tempfile"
 require "timeout"
 
 require_relative "../../lib/openai"
@@ -18,7 +19,6 @@ module OpenAI
         def stream_response(connection, audio_output:, output: $stdout)
           audio_bytes = 0
           transcript = +""
-          started_transcript = false
           completed = false
 
           connection.each do |event|
@@ -32,22 +32,10 @@ module OpenAI
             when OpenAI::Realtime::ResponseAudioTranscriptDeltaEvent
               next if event.delta.empty?
 
-              output.print("[assistant] ") unless started_transcript
-              started_transcript = true
               transcript << event.delta
-              output.print(event.delta)
-              output.flush
             when OpenAI::Realtime::ResponseAudioTranscriptDoneEvent
               next if event.transcript.empty? || event.transcript == transcript
 
-              if started_transcript
-                output.puts
-                output.puts("[realtime] final transcript: #{event.transcript}")
-              else
-                output.puts("[assistant] #{event.transcript}")
-              end
-
-              started_transcript = false
               transcript.replace(event.transcript)
             when OpenAI::Realtime::ResponseAudioDeltaEvent
               begin
@@ -60,7 +48,6 @@ module OpenAI
               audio_output.flush
               audio_bytes += bytes.bytesize
             when OpenAI::Realtime::ResponseDoneEvent
-              output.puts if started_transcript
               status = event.response.status
               raise "Realtime response did not complete." unless status == :completed
               raise "Realtime response completed without audio output" if audio_bytes.zero?
@@ -125,16 +112,25 @@ module OpenAI
         end
 
         def open_output(path)
-          file = begin
-            File.open(path, File::WRONLY | File::CREAT | File::EXCL | File::BINARY, 0o600)
-          rescue Errno::EEXIST
+          begin
+            File.lstat(path)
+          rescue Errno::ENOENT
+            # The destination is available.
+          else
             raise ArgumentError, "output path must not already exist"
           end
 
-          begin
+          directory = File.dirname(path)
+          Tempfile.create([".openai-realtime-", ".tmp"], directory, mode: File::BINARY, perm: 0o600) do |file|
             yield(file)
-          ensure
-            file.close
+            file.flush
+            file.fsync
+
+            begin
+              File.link(file.path, path)
+            rescue Errno::EEXIST
+              raise ArgumentError, "output path must not already exist"
+            end
           end
         end
 

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "base64"
 require "tempfile"
 require "tmpdir"
 require "timeout"
@@ -40,7 +39,7 @@ module OpenAI
               transcript.replace(event.transcript)
             when OpenAI::Realtime::ResponseAudioDeltaEvent
               begin
-                bytes = Base64.strict_decode64(event.delta)
+                bytes = event.delta.unpack1("m0")
               rescue ArgumentError
                 raise "Realtime returned invalid audio data."
               end
@@ -94,7 +93,7 @@ module OpenAI
           }
 
           output.puts("[realtime] connecting with #{model}")
-          transcript = client.realtime.connect(model: model) do |connection|
+          client.realtime.connect(model: model) do |connection|
             connection.session.update(**session)
             connection.input_audio_buffer.append_bytes(first_chunk)
             while (chunk = input.read(chunk_bytes))
@@ -107,9 +106,36 @@ module OpenAI
             connection.response.create
             stream_response(connection, audio_output: audio_output, output: output)
           end
+        end
+
+        def run_to_file(
+          client:,
+          input_path:,
+          output_path:,
+          model:,
+          voice:,
+          timeout_seconds:,
+          output: $stdout
+        )
+          transcript = File.open(input_path, "rb") do |input|
+            open_output(output_path) do |audio_output|
+              Timeout.timeout(timeout_seconds) do
+                run(
+                  client: client,
+                  input: input,
+                  audio_output: audio_output,
+                  model: model,
+                  voice: voice,
+                  output: output
+                )
+              end
+            end
+          end
 
           output.puts("[realtime] voice turn smoke test passed")
           transcript
+        rescue OpenAI::Errors::RealtimeProtocolError
+          raise RuntimeError, "Realtime protocol error.", cause: nil
         end
 
         def open_output(path)
@@ -134,7 +160,7 @@ module OpenAI
           Dir.mktmpdir(".openai-realtime-", directory) do |staging_directory|
             File.chmod(0o700, staging_directory)
             Tempfile.create(["response-", ".tmp"], staging_directory, mode: File::BINARY, perm: 0o600) do |file|
-              yield(file)
+              result = yield(file)
               file.flush
               file.fsync
               raise "staged output changed before publication" unless File.identical?(file.path, file)
@@ -144,6 +170,8 @@ module OpenAI
               rescue Errno::EEXIST
                 raise ArgumentError, "output path must not already exist"
               end
+
+              result
             end
           end
         end
@@ -166,17 +194,12 @@ if $PROGRAM_NAME == __FILE__
     )
   end
 
-  File.open(input_path, "rb") do |input|
-    OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(output_path) do |audio_output|
-      Timeout.timeout(Integer(ENV.fetch("OPENAI_REALTIME_TIMEOUT", "60"))) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run(
-          client: OpenAI::Client.new,
-          input: input,
-          audio_output: audio_output,
-          model: ENV.fetch("OPENAI_REALTIME_MODEL", "gpt-realtime-2.1"),
-          voice: ENV.fetch("OPENAI_REALTIME_VOICE", "marin")
-        )
-      end
-    end
-  end
+  OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+    client: OpenAI::Client.new,
+    input_path: input_path,
+    output_path: output_path,
+    model: ENV.fetch("OPENAI_REALTIME_MODEL", "gpt-realtime-2.1"),
+    voice: ENV.fetch("OPENAI_REALTIME_VOICE", "marin"),
+    timeout_seconds: Integer(ENV.fetch("OPENAI_REALTIME_TIMEOUT", "60"))
+  )
 end

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -3,6 +3,7 @@
 
 require "base64"
 require "tempfile"
+require "tmpdir"
 require "timeout"
 
 require_relative "../../lib/openai"
@@ -112,24 +113,37 @@ module OpenAI
         end
 
         def open_output(path)
+          directory = File.realpath(File.dirname(path))
+          directory_stat = File.stat(directory)
+          if (directory_stat.mode & 0o022).positive? && !directory_stat.sticky?
+            raise(
+              ArgumentError,
+              "output directory must not be writable by other users unless it has the sticky bit set"
+            )
+          end
+
+          output_path = File.join(directory, File.basename(path))
           begin
-            File.lstat(path)
+            File.lstat(output_path)
           rescue Errno::ENOENT
             # The destination is available.
           else
             raise ArgumentError, "output path must not already exist"
           end
 
-          directory = File.dirname(path)
-          Tempfile.create([".openai-realtime-", ".tmp"], directory, mode: File::BINARY, perm: 0o600) do |file|
-            yield(file)
-            file.flush
-            file.fsync
+          Dir.mktmpdir(".openai-realtime-", directory) do |staging_directory|
+            File.chmod(0o700, staging_directory)
+            Tempfile.create(["response-", ".tmp"], staging_directory, mode: File::BINARY, perm: 0o600) do |file|
+              yield(file)
+              file.flush
+              file.fsync
+              raise "staged output changed before publication" unless File.identical?(file.path, file)
 
-            begin
-              File.link(file.path, path)
-            rescue Errno::EEXIST
-              raise ArgumentError, "output path must not already exist"
+              begin
+                File.link(file.path, output_path)
+              rescue Errno::EEXIST
+                raise ArgumentError, "output path must not already exist"
+              end
             end
           end
         end

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -1,0 +1,172 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "base64"
+require "timeout"
+
+require_relative "../../lib/openai"
+
+module OpenAI
+  module Examples
+    module Realtime
+      module WebSocketVoiceTurn
+        # 200 ms of 24 kHz mono PCM16 audio.
+        CHUNK_BYTES = 9_600
+
+        module_function
+
+        def stream_response(connection, audio_output:, output: $stdout)
+          audio_bytes = 0
+          transcript = +""
+          started_transcript = false
+          completed = false
+
+          connection.each do |event|
+            case event
+            when OpenAI::Realtime::SessionCreatedEvent
+              output.puts("[realtime] session.created")
+            when OpenAI::Realtime::SessionUpdatedEvent
+              output.puts("[realtime] session.updated")
+            when OpenAI::Realtime::InputAudioBufferCommittedEvent
+              output.puts("[realtime] input_audio_buffer.committed item=#{event.item_id}")
+            when OpenAI::Realtime::ResponseAudioTranscriptDeltaEvent
+              next if event.delta.empty?
+
+              output.print("[assistant] ") unless started_transcript
+              started_transcript = true
+              transcript << event.delta
+              output.print(event.delta)
+              output.flush
+            when OpenAI::Realtime::ResponseAudioTranscriptDoneEvent
+              next if event.transcript.empty? || event.transcript == transcript
+
+              if started_transcript
+                output.puts
+                output.puts("[realtime] final transcript: #{event.transcript}")
+              else
+                output.puts("[assistant] #{event.transcript}")
+              end
+
+              started_transcript = false
+              transcript.replace(event.transcript)
+            when OpenAI::Realtime::ResponseAudioDeltaEvent
+              begin
+                bytes = Base64.strict_decode64(event.delta)
+              rescue ArgumentError
+                raise "Realtime returned invalid audio data."
+              end
+
+              audio_output.write(bytes)
+              audio_output.flush
+              audio_bytes += bytes.bytesize
+            when OpenAI::Realtime::ResponseDoneEvent
+              output.puts if started_transcript
+              status = event.response.status
+              raise "Realtime response did not complete." unless status == :completed
+              raise "Realtime response completed without audio output" if audio_bytes.zero?
+              raise "Realtime response completed without an audio transcript" if transcript.empty?
+
+              output.puts("[realtime] response.done status=completed audio_bytes=#{audio_bytes}")
+              completed = true
+              break
+            when OpenAI::Realtime::RealtimeErrorEvent
+              raise "Realtime API error."
+            end
+          end
+
+          raise "Realtime connection closed before response.done" unless completed
+
+          transcript
+        end
+
+        def run(client:, input:, audio_output:, model:, voice:, chunk_bytes: CHUNK_BYTES, output: $stdout)
+          unless chunk_bytes.is_a?(Integer) && chunk_bytes.positive?
+            raise ArgumentError, "chunk_bytes must be a positive integer"
+          end
+
+          input.binmode if input.respond_to?(:binmode)
+          audio_output.binmode if audio_output.respond_to?(:binmode)
+          first_chunk = input.read(chunk_bytes)
+          raise ArgumentError, "PCM input is empty" if first_chunk.nil? || first_chunk.empty?
+
+          session = {
+            type: :realtime,
+            output_modalities: [:audio],
+            instructions: "Respond briefly in a natural speaking voice.",
+            audio: {
+              input: {
+                format: {type: :"audio/pcm", rate: 24_000},
+                turn_detection: nil
+              },
+              output: {
+                format: {type: :"audio/pcm", rate: 24_000},
+                voice: voice
+              }
+            }
+          }
+
+          output.puts("[realtime] connecting with #{model}")
+          transcript = client.realtime.connect(model: model) do |connection|
+            connection.session.update(**session)
+            connection.input_audio_buffer.append_bytes(first_chunk)
+            while (chunk = input.read(chunk_bytes))
+              break if chunk.empty?
+
+              connection.input_audio_buffer.append_bytes(chunk)
+            end
+
+            connection.input_audio_buffer.commit
+            connection.response.create
+            stream_response(connection, audio_output: audio_output, output: output)
+          end
+
+          output.puts("[realtime] voice turn smoke test passed")
+          transcript
+        end
+
+        def open_output(path)
+          file = begin
+            File.open(path, File::WRONLY | File::CREAT | File::EXCL | File::BINARY, 0o600)
+          rescue Errno::EEXIST
+            raise ArgumentError, "output path must not already exist"
+          end
+
+          begin
+            yield(file)
+          ensure
+            file.close
+          end
+        end
+
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  input_path = ARGV.fetch(0) do
+    abort(
+      "Usage: bundle exec ruby examples/realtime/websocket_voice_turn.rb INPUT.pcm OUTPUT.pcm"
+    )
+  end
+
+  output_path = ARGV.fetch(1) do
+    abort(
+      "Usage: bundle exec ruby examples/realtime/websocket_voice_turn.rb INPUT.pcm OUTPUT.pcm"
+    )
+  end
+
+  File.open(input_path, "rb") do |input|
+    OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(output_path) do |audio_output|
+      Timeout.timeout(Integer(ENV.fetch("OPENAI_REALTIME_TIMEOUT", "60"))) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run(
+          client: OpenAI::Client.new,
+          input: input,
+          audio_output: audio_output,
+          model: ENV.fetch("OPENAI_REALTIME_MODEL", "gpt-realtime-2.1"),
+          voice: ENV.fetch("OPENAI_REALTIME_VOICE", "marin")
+        )
+      end
+    end
+  end
+end

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "tempfile"
-require "tmpdir"
 require "timeout"
 
 require_relative "../../lib/openai"
@@ -108,102 +106,32 @@ module OpenAI
           end
         end
 
-        def run_to_file(
+        def run_with_timeout(
           client:,
-          input_path:,
-          output_path:,
+          input:,
+          audio_output:,
           model:,
           voice:,
           timeout_seconds:,
-          output: $stdout
+          output: $stderr
         )
-          transcript = File.open(input_path, "rb") do |input|
-            open_output(output_path) do |audio_output|
-              Timeout.timeout(timeout_seconds) do
-                run(
-                  client: client,
-                  input: input,
-                  audio_output: audio_output,
-                  model: model,
-                  voice: voice,
-                  output: output
-                )
-              end
-            end
+          transcript = Timeout.timeout(timeout_seconds) do
+            run(
+              client: client,
+              input: input,
+              audio_output: audio_output,
+              model: model,
+              voice: voice,
+              output: output
+            )
           end
 
           output.puts("[realtime] voice turn smoke test passed")
           transcript
         rescue OpenAI::Errors::RealtimeProtocolError
           raise RuntimeError, "Realtime protocol error.", cause: nil
-        end
-
-        def open_output(path)
-          if Gem.win_platform?
-            raise(
-              ArgumentError,
-              "secure voice output is unavailable on Windows because Ruby cannot verify owner-only ACLs"
-            )
-          end
-
-          directory = File.realpath(File.dirname(path))
-          directory_stat = File.stat(directory)
-          if (directory_stat.mode & 0o022).positive? && !directory_stat.sticky?
-            raise(
-              ArgumentError,
-              "output directory must not be writable by other users unless it has the sticky bit set"
-            )
-          end
-
-          output_path = File.join(directory, File.basename(path))
-          begin
-            File.lstat(output_path)
-          rescue Errno::ENOENT
-            # The destination is available.
-          else
-            raise ArgumentError, "output path must not already exist"
-          end
-
-          Dir.mktmpdir(".openai-realtime-", directory) do |staging_directory|
-            File.chmod(0o700, staging_directory)
-            Tempfile.create(["response-", ".tmp"], staging_directory, mode: File::BINARY, perm: 0o600) do |file|
-              verify_hard_link_support!(source_path: file.path, directory: directory)
-              result = yield(file)
-              file.flush
-              file.fsync
-              raise "staged output changed before publication" unless File.identical?(file.path, file)
-
-              begin
-                File.link(file.path, output_path)
-              rescue Errno::EEXIST
-                raise ArgumentError, "output path must not already exist"
-              end
-
-              result
-            end
-          end
-        end
-
-        def verify_hard_link_support!(source_path:, directory:)
-          Tempfile.create([".openai-realtime-link-", ".tmp"], directory, perm: 0o600) do |probe|
-            probe_path = probe.path
-            probe.close
-            File.unlink(probe_path)
-            linked = false
-
-            begin
-              File.link(source_path, probe_path)
-              linked = true
-            rescue NotImplementedError, SystemCallError
-              raise(
-                ArgumentError,
-                "output filesystem must support atomic no-clobber hard links",
-                cause: nil
-              )
-            ensure
-              File.unlink(probe_path) if linked
-            end
-          end
+        rescue SystemCallError
+          raise RuntimeError, "Realtime stream I/O error.", cause: nil
         end
 
       end
@@ -212,24 +140,13 @@ module OpenAI
 end
 
 if $PROGRAM_NAME == __FILE__
-  input_path = ARGV.fetch(0) do
-    abort(
-      "Usage: bundle exec ruby examples/realtime/websocket_voice_turn.rb INPUT.pcm OUTPUT.pcm"
-    )
-  end
-
-  output_path = ARGV.fetch(1) do
-    abort(
-      "Usage: bundle exec ruby examples/realtime/websocket_voice_turn.rb INPUT.pcm OUTPUT.pcm"
-    )
-  end
-
-  OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+  OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_with_timeout(
     client: OpenAI::Client.new,
-    input_path: input_path,
-    output_path: output_path,
+    input: $stdin,
+    audio_output: $stdout,
     model: ENV.fetch("OPENAI_REALTIME_MODEL", "gpt-realtime-2.1"),
     voice: ENV.fetch("OPENAI_REALTIME_VOICE", "marin"),
-    timeout_seconds: Integer(ENV.fetch("OPENAI_REALTIME_TIMEOUT", "60"))
+    timeout_seconds: Integer(ENV.fetch("OPENAI_REALTIME_TIMEOUT", "60")),
+    output: $stderr
   )
 end

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -34,7 +34,7 @@ module OpenAI
 
               transcript << event.delta
             when OpenAI::Realtime::ResponseAudioTranscriptDoneEvent
-              next if event.transcript.empty? || event.transcript == transcript
+              next if event.transcript == transcript
 
               transcript.replace(event.transcript)
             when OpenAI::Realtime::ResponseAudioDeltaEvent

--- a/examples/realtime/websocket_voice_turn.rb
+++ b/examples/realtime/websocket_voice_turn.rb
@@ -139,6 +139,13 @@ module OpenAI
         end
 
         def open_output(path)
+          if Gem.win_platform?
+            raise(
+              ArgumentError,
+              "secure voice output is unavailable on Windows because Ruby cannot verify owner-only ACLs"
+            )
+          end
+
           directory = File.realpath(File.dirname(path))
           directory_stat = File.stat(directory)
           if (directory_stat.mode & 0o022).positive? && !directory_stat.sticky?
@@ -160,6 +167,7 @@ module OpenAI
           Dir.mktmpdir(".openai-realtime-", directory) do |staging_directory|
             File.chmod(0o700, staging_directory)
             Tempfile.create(["response-", ".tmp"], staging_directory, mode: File::BINARY, perm: 0o600) do |file|
+              verify_hard_link_support!(source_path: file.path, directory: directory)
               result = yield(file)
               file.flush
               file.fsync
@@ -172,6 +180,28 @@ module OpenAI
               end
 
               result
+            end
+          end
+        end
+
+        def verify_hard_link_support!(source_path:, directory:)
+          Tempfile.create([".openai-realtime-link-", ".tmp"], directory, perm: 0o600) do |probe|
+            probe_path = probe.path
+            probe.close
+            File.unlink(probe_path)
+            linked = false
+
+            begin
+              File.link(source_path, probe_path)
+              linked = true
+            rescue NotImplementedError, SystemCallError
+              raise(
+                ArgumentError,
+                "output filesystem must support atomic no-clobber hard links",
+                cause: nil
+              )
+            ensure
+              File.unlink(probe_path) if linked
             end
           end
         end

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |s|
       "examples/mtls_custom_http_client.rb",
       "examples/realtime/README.md",
       "examples/realtime/websocket_transcription.rb",
-      "examples/realtime/websocket_text.rb"
+      "examples/realtime/websocket_text.rb",
+      "examples/realtime/websocket_voice_turn.rb"
     ]
   s.extra_rdoc_files = [
     "README.md",

--- a/realtime.md
+++ b/realtime.md
@@ -182,8 +182,11 @@ timeout leaves no partial response behind. The staging directory is owner-only,
 and the example rejects group- or world-writable output directories without a
 sticky bit rather than risk publishing a substituted pathname. It writes raw
 24 kHz mono PCM16 so callers can play or convert the file without container
-buffering. At its executable boundary, malformed protocol events become a
-generic exception without the payload-bearing parser error as a retained cause.
+buffering. Before connecting, it verifies that the output filesystem supports
+atomic hard-link publication; it fails closed on Windows because Ruby cannot
+portably verify owner-only NTFS ACLs. At its executable boundary, malformed
+protocol events become a generic exception without the payload-bearing parser
+error as a retained cause.
 
 ## Event compatibility
 

--- a/realtime.md
+++ b/realtime.md
@@ -133,6 +133,8 @@ client owns the turn boundary, then call `response.create` after `commit`:
 ```ruby
 require "base64"
 
+transcript = +""
+
 client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
   connection.session.update(
     type: :realtime,
@@ -160,7 +162,7 @@ client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
     when OpenAI::Realtime::ResponseAudioDeltaEvent
       audio_output.write(Base64.strict_decode64(event.delta))
     when OpenAI::Realtime::ResponseAudioTranscriptDeltaEvent
-      print(event.delta)
+      transcript << event.delta
     when OpenAI::Realtime::ResponseDoneEvent
       raise "Realtime response failed." unless event.response.status == :completed
       break
@@ -175,8 +177,11 @@ The runnable
 [`websocket_voice_turn.rb`](examples/realtime/websocket_voice_turn.rb) example
 checks the complete lifecycle: non-empty input, explicit commit, streamed audio
 and transcript, a successful terminal response, binary output, and an output
-path that does not already exist. It writes raw 24 kHz mono PCM16 so callers can
-play or convert the file without container buffering.
+path that does not already exist. It returns the transcript to its caller while
+keeping diagnostics metadata-only. Audio is staged privately and published at
+the requested path only after the complete turn succeeds, so a failure or
+timeout leaves no partial response behind. It writes raw 24 kHz mono PCM16 so
+callers can play or convert the file without container buffering.
 
 ## Event compatibility
 

--- a/realtime.md
+++ b/realtime.md
@@ -131,8 +131,6 @@ stream PCM response audio plus its transcript. Disable turn detection when the
 client owns the turn boundary, then call `response.create` after `commit`:
 
 ```ruby
-require "base64"
-
 transcript = +""
 
 client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
@@ -160,7 +158,7 @@ client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
   connection.each do |event|
     case event
     when OpenAI::Realtime::ResponseAudioDeltaEvent
-      audio_output.write(Base64.strict_decode64(event.delta))
+      audio_output.write(event.delta.unpack1("m0"))
     when OpenAI::Realtime::ResponseAudioTranscriptDeltaEvent
       transcript << event.delta
     when OpenAI::Realtime::ResponseDoneEvent
@@ -184,7 +182,8 @@ timeout leaves no partial response behind. The staging directory is owner-only,
 and the example rejects group- or world-writable output directories without a
 sticky bit rather than risk publishing a substituted pathname. It writes raw
 24 kHz mono PCM16 so callers can play or convert the file without container
-buffering.
+buffering. At its executable boundary, malformed protocol events become a
+generic exception without the payload-bearing parser error as a retained cause.
 
 ## Event compatibility
 

--- a/realtime.md
+++ b/realtime.md
@@ -180,8 +180,11 @@ and transcript, a successful terminal response, binary output, and an output
 path that does not already exist. It returns the transcript to its caller while
 keeping diagnostics metadata-only. Audio is staged privately and published at
 the requested path only after the complete turn succeeds, so a failure or
-timeout leaves no partial response behind. It writes raw 24 kHz mono PCM16 so
-callers can play or convert the file without container buffering.
+timeout leaves no partial response behind. The staging directory is owner-only,
+and the example rejects group- or world-writable output directories without a
+sticky bit rather than risk publishing a substituted pathname. It writes raw
+24 kHz mono PCM16 so callers can play or convert the file without container
+buffering.
 
 ## Event compatibility
 

--- a/realtime.md
+++ b/realtime.md
@@ -124,7 +124,7 @@ example additionally rejects empty input and requires a matching non-empty
 completion. It defaults to `gpt-transcribe`, which is intended for committed
 turns over WebSockets.
 
-## Send one voice turn and save the spoken response
+## Send one voice turn and stream the spoken response
 
 A normal Realtime session can accept an explicitly committed PCM turn and
 stream PCM response audio plus its transcript. Disable turn detection when the
@@ -174,19 +174,16 @@ end
 The runnable
 [`websocket_voice_turn.rb`](examples/realtime/websocket_voice_turn.rb) example
 checks the complete lifecycle: non-empty input, explicit commit, streamed audio
-and transcript, a successful terminal response, binary output, and an output
-path that does not already exist. It returns the transcript to its caller while
-keeping diagnostics metadata-only. Audio is staged privately and published at
-the requested path only after the complete turn succeeds, so a failure or
-timeout leaves no partial response behind. The staging directory is owner-only,
-and the example rejects group- or world-writable output directories without a
-sticky bit rather than risk publishing a substituted pathname. It writes raw
-24 kHz mono PCM16 so callers can play or convert the file without container
-buffering. Before connecting, it verifies that the output filesystem supports
-atomic hard-link publication; it fails closed on Windows because Ruby cannot
-portably verify owner-only NTFS ACLs. At its executable boundary, malformed
-protocol events become a generic exception without the payload-bearing parser
-error as a retained cause.
+and transcript, a successful terminal response, and binary output. The
+executable reads raw PCM from standard input, writes response PCM to standard
+output, and keeps metadata-only diagnostics on standard error. Its single
+deadline begins before the initial input read and covers the complete network
+turn. Embedded callers receive the transcript as the return value. At the
+executable boundary, operating-system I/O errors and malformed protocol events
+become generic exceptions without sensitive paths, payloads, or retained
+causes. The example deliberately leaves output filenames, overwrite policy,
+and filesystem durability to the caller rather than claiming a portable secure
+file-publication contract.
 
 ## Event compatibility
 

--- a/realtime.md
+++ b/realtime.md
@@ -1,9 +1,10 @@
 # Realtime WebSockets
 
 The Ruby SDK provides a typed, block-scoped WebSocket client for server-side
-Realtime text sessions and committed-turn transcription. The implementation
-stays at one cohesive boundary: authenticated WebSocket connection setup,
-protocol event validation, deterministic cleanup, and synchronous event flow.
+Realtime text sessions, committed-turn transcription, and one-turn voice
+workflows. The implementation stays at one cohesive boundary: authenticated
+WebSocket connection setup, protocol event validation, deterministic cleanup,
+and synchronous event flow.
 
 ## Installation
 
@@ -122,6 +123,60 @@ different input turns is not guaranteed. The runnable
 example additionally rejects empty input and requires a matching non-empty
 completion. It defaults to `gpt-transcribe`, which is intended for committed
 turns over WebSockets.
+
+## Send one voice turn and save the spoken response
+
+A normal Realtime session can accept an explicitly committed PCM turn and
+stream PCM response audio plus its transcript. Disable turn detection when the
+client owns the turn boundary, then call `response.create` after `commit`:
+
+```ruby
+require "base64"
+
+client.realtime.connect(model: "gpt-realtime-2.1") do |connection|
+  connection.session.update(
+    type: :realtime,
+    output_modalities: [:audio],
+    audio: {
+      input: {
+        format: {type: :"audio/pcm", rate: 24_000},
+        turn_detection: nil
+      },
+      output: {
+        format: {type: :"audio/pcm", rate: 24_000},
+        voice: :marin
+      }
+    }
+  )
+
+  while (chunk = input.read(9_600))
+    connection.input_audio_buffer.append_bytes(chunk)
+  end
+  connection.input_audio_buffer.commit
+  connection.response.create
+
+  connection.each do |event|
+    case event
+    when OpenAI::Realtime::ResponseAudioDeltaEvent
+      audio_output.write(Base64.strict_decode64(event.delta))
+    when OpenAI::Realtime::ResponseAudioTranscriptDeltaEvent
+      print(event.delta)
+    when OpenAI::Realtime::ResponseDoneEvent
+      raise "Realtime response failed." unless event.response.status == :completed
+      break
+    when OpenAI::Realtime::RealtimeErrorEvent
+      raise "Realtime API error."
+    end
+  end
+end
+```
+
+The runnable
+[`websocket_voice_turn.rb`](examples/realtime/websocket_voice_turn.rb) example
+checks the complete lifecycle: non-empty input, explicit commit, streamed audio
+and transcript, a successful terminal response, binary output, and an output
+path that does not already exist. It writes raw 24 kHz mono PCM16 so callers can
+play or convert the file without container buffering.
 
 ## Event compatibility
 
@@ -250,7 +305,7 @@ handshake.
 ## Current scope
 
 This phase does not add continuous microphone capture, concurrent live
-captioning, response-audio playback, WebRTC/SDP lifecycle helpers, SIP or
+captioning, live response-audio playback, WebRTC/SDP lifecycle helpers, SIP or
 sideband helpers, translation connections, image input, function calling
 helpers, or MCP helpers. Existing generated HTTP resources remain
 generated-code-owned. New convenience APIs and examples for those workflows

--- a/test/openai/gem_packaging_test.rb
+++ b/test/openai/gem_packaging_test.rb
@@ -25,6 +25,11 @@ class OpenAI::Test::GemPackagingTest < Minitest::Test
       assert_includes(package.contents, "examples/realtime/websocket_text.rb")
       assert_includes(package.contents, "examples/realtime/websocket_voice_turn.rb")
 
+      package.extract_files(directory, "examples/realtime/websocket_voice_turn.rb")
+      voice_turn_source = File.read(File.join(directory, "examples/realtime/websocket_voice_turn.rb"))
+      refute_includes(voice_turn_source, "require \"base64\"")
+      refute_match(/\bBase64\./, voice_turn_source)
+
       linked_guides = relative_links.select { File.extname(_1) == ".md" }
       assert_empty(linked_guides - package.spec.extra_rdoc_files, "README guides are missing from RDoc")
     end

--- a/test/openai/gem_packaging_test.rb
+++ b/test/openai/gem_packaging_test.rb
@@ -23,6 +23,7 @@ class OpenAI::Test::GemPackagingTest < Minitest::Test
       assert_empty(relative_links - package.contents, "README links are missing from the built gem")
       assert_includes(package.contents, "examples/realtime/websocket_transcription.rb")
       assert_includes(package.contents, "examples/realtime/websocket_text.rb")
+      assert_includes(package.contents, "examples/realtime/websocket_voice_turn.rb")
 
       linked_guides = relative_links.select { File.extname(_1) == ".md" }
       assert_empty(linked_guides - package.spec.extra_rdoc_files, "README guides are missing from RDoc")

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -221,6 +221,31 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     end
   end
 
+  def test_output_file_rejects_symlink_and_hardlink_destinations
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      target = File.join(directory, "existing.pcm")
+      File.binwrite(target, "keep me")
+      destinations = [
+        File.join(directory, "response-symlink.pcm"),
+        File.join(directory, "response-hardlink.pcm")
+      ]
+      File.symlink(target, destinations.fetch(0))
+      File.link(target, destinations.fetch(1))
+
+      destinations.each do |path|
+        error = assert_raises(ArgumentError) do
+          OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) { |_file| nil }
+        end
+
+        assert_equal("output path must not already exist", error.message)
+      end
+
+      assert_equal("keep me", File.binread(target))
+      assert_predicate(File.lstat(destinations.fetch(0)), :symlink?)
+      assert(File.identical?(target, destinations.fetch(1)))
+    end
+  end
+
   def test_output_file_does_not_relabel_errors_from_the_caller_block
     Dir.mktmpdir("openai-realtime-voice") do |directory|
       path = File.join(directory, "response.pcm")
@@ -278,10 +303,69 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
       OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
         file.write("complete audio")
         refute_path_exists(path)
+
+        staging_directory = File.dirname(file.path)
+        refute_equal(directory, staging_directory)
+        assert_equal(0o700, File.stat(staging_directory).mode & 0o777)
       end
 
       assert_equal("complete audio", File.binread(path))
+      assert_equal(0o600, File.stat(path).mode & 0o777)
       assert_equal(["response.pcm"], Dir.children(directory))
+    end
+  end
+
+  def test_output_file_rejects_a_replaceable_staging_path
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      File.chmod(0o770, directory)
+      path = File.join(directory, "response.pcm")
+
+      error = assert_raises(ArgumentError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+          file.write("private audio")
+          File.unlink(file.path)
+          File.binwrite(file.path, "attacker-controlled audio")
+        end
+      end
+
+      assert_equal(
+        "output directory must not be writable by other users unless it has the sticky bit set",
+        error.message
+      )
+      refute_path_exists(path)
+      assert_empty(Dir.children(directory))
+    end
+  end
+
+  def test_output_file_allows_a_sticky_shared_directory
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      File.chmod(0o1777, directory)
+      path = File.join(directory, "response.pcm")
+
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+        file.write("complete audio")
+      end
+
+      assert_equal("complete audio", File.binread(path))
+      assert_equal(0o600, File.stat(path).mode & 0o777)
+    end
+  end
+
+  def test_output_file_does_not_publish_a_substituted_private_staging_path
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+
+      error = assert_raises(RuntimeError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+          file.write("private audio")
+          File.unlink(file.path)
+          File.binwrite(file.path, "attacker-controlled audio")
+        end
+      end
+
+      assert_equal("staged output changed before publication", error.message)
+      refute_path_exists(path)
+      assert_empty(Dir.children(directory))
     end
   end
 

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -99,7 +99,7 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
       session.dig(:audio, :output, :format)
     )
     assert_equal(:marin, session.dig(:audio, :output, :voice))
-    assert_includes(diagnostics.string, "Hello from Ruby.")
+    refute_includes(diagnostics.string, "Hello from Ruby.")
     assert_includes(diagnostics.string, "response.done status=completed")
     assert_includes(diagnostics.string, "voice turn smoke test passed")
   end
@@ -173,7 +173,7 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     )
 
     assert_equal("Final words.", transcript)
-    assert_includes(diagnostics.string, "Final words.")
+    refute_includes(diagnostics.string, "Final words.")
   end
 
   def test_example_keeps_service_error_details_out_of_the_exception_message
@@ -232,6 +232,73 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
       end
 
       assert_includes(error.message, "raised by caller")
+      refute_path_exists(path)
+    end
+  end
+
+  def test_output_file_is_not_published_when_the_run_fails
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+
+      error = assert_raises(RuntimeError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+          file.write("partial audio")
+          refute_path_exists(path)
+          raise "voice turn failed"
+        end
+      end
+
+      assert_equal("voice turn failed", error.message)
+      refute_path_exists(path)
+      assert_empty(Dir.children(directory))
+    end
+  end
+
+  def test_output_file_is_not_published_when_the_run_times_out
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+
+      assert_raises(Timeout::Error) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+          file.write("partial audio")
+          refute_path_exists(path)
+          raise Timeout::Error, "execution expired"
+        end
+      end
+
+      refute_path_exists(path)
+      assert_empty(Dir.children(directory))
+    end
+  end
+
+  def test_output_file_is_published_after_a_successful_run
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+        file.write("complete audio")
+        refute_path_exists(path)
+      end
+
+      assert_equal("complete audio", File.binread(path))
+      assert_equal(["response.pcm"], Dir.children(directory))
+    end
+  end
+
+  def test_output_file_does_not_replace_a_destination_created_during_the_run
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+
+      error = assert_raises(ArgumentError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
+          file.write("complete audio")
+          File.binwrite(path, "other owner")
+        end
+      end
+
+      assert_equal("output path must not already exist", error.message)
+      assert_equal("other owner", File.binread(path))
+      assert_equal(["response.pcm"], Dir.children(directory))
     end
   end
 

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "base64"
 require "stringio"
 require "tmpdir"
 
@@ -47,17 +46,31 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     def each(&block) = @events.each(&block)
   end
 
+  class ProtocolFailureConnection < RecordingConnection
+    def initialize(error)
+      super([])
+      @error = error
+    end
+
+    def each
+      raise @error
+    end
+  end
+
   class RecordingRealtime
     attr_reader :models
 
-    def initialize(connection)
+    def initialize(connection, after_connect: nil)
+      @after_connect = after_connect
       @connection = connection
       @models = []
     end
 
     def connect(model:)
       @models << model
-      yield(@connection)
+      result = yield(@connection)
+      @after_connect&.call
+      result
     end
   end
 
@@ -101,7 +114,7 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     assert_equal(:marin, session.dig(:audio, :output, :voice))
     refute_includes(diagnostics.string, "Hello from Ruby.")
     assert_includes(diagnostics.string, "response.done status=completed")
-    assert_includes(diagnostics.string, "voice turn smoke test passed")
+    refute_includes(diagnostics.string, "voice turn smoke test passed")
   end
 
   def test_example_rejects_empty_input_before_connecting
@@ -205,6 +218,93 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     error = assert_raises(RuntimeError) { run_with_events([event]) }
 
     assert_equal("Realtime returned invalid audio data.", error.message)
+  end
+
+  def test_file_boundary_suppresses_protocol_error_data_and_cause
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      input_path = File.join(directory, "input.pcm")
+      output_path = File.join(directory, "response.pcm")
+      File.binwrite(input_path, "pcm")
+      customer_data = "private malformed frame content"
+      protocol_error = OpenAI::Errors::RealtimeProtocolError.new(
+        data: customer_data,
+        cause: JSON::ParserError.new(customer_data)
+      )
+      realtime = RecordingRealtime.new(ProtocolFailureConnection.new(protocol_error))
+      diagnostics = StringIO.new
+
+      error = assert_raises(RuntimeError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+          client: RecordingClient.new(realtime: realtime),
+          input_path: input_path,
+          output_path: output_path,
+          model: "gpt-realtime-2.1",
+          voice: :marin,
+          timeout_seconds: 1,
+          output: diagnostics
+        )
+      end
+
+      assert_instance_of(RuntimeError, error)
+      assert_equal("Realtime protocol error.", error.message)
+      assert_nil(error.cause)
+      refute_includes(error.full_message, customer_data)
+      refute_includes(diagnostics.string, customer_data)
+      refute_path_exists(output_path)
+    end
+  end
+
+  def test_file_boundary_reports_success_only_after_output_publication
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      input_path = File.join(directory, "input.pcm")
+      output_path = File.join(directory, "response.pcm")
+      File.binwrite(input_path, "pcm")
+      realtime = RecordingRealtime.new(
+        RecordingConnection.new(successful_events),
+        after_connect: -> { File.binwrite(output_path, "other owner") }
+      )
+      diagnostics = StringIO.new
+
+      error = assert_raises(ArgumentError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+          client: RecordingClient.new(realtime: realtime),
+          input_path: input_path,
+          output_path: output_path,
+          model: "gpt-realtime-2.1",
+          voice: :marin,
+          timeout_seconds: 1,
+          output: diagnostics
+        )
+      end
+
+      assert_equal("output path must not already exist", error.message)
+      assert_equal("other owner", File.binread(output_path))
+      refute_includes(diagnostics.string, "voice turn smoke test passed")
+    end
+  end
+
+  def test_file_boundary_publishes_output_before_reporting_success
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      input_path = File.join(directory, "input.pcm")
+      output_path = File.join(directory, "response.pcm")
+      File.binwrite(input_path, "pcm")
+      realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
+      diagnostics = StringIO.new
+
+      transcript = OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+        client: RecordingClient.new(realtime: realtime),
+        input_path: input_path,
+        output_path: output_path,
+        model: "gpt-realtime-2.1",
+        voice: :marin,
+        timeout_seconds: 1,
+        output: diagnostics
+      )
+
+      assert_equal("Hello from Ruby.", transcript)
+      assert_equal("voice-response".b, File.binread(output_path))
+      assert_equal("[realtime] voice turn smoke test passed\n", diagnostics.string.lines.last)
+    end
   end
 
   def test_output_file_must_not_already_exist
@@ -421,7 +521,7 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
   private def audio_delta(bytes)
     OpenAI::Realtime::ResponseAudioDeltaEvent.new(
       content_index: 0,
-      delta: Base64.strict_encode64(bytes),
+      delta: [bytes].pack("m0"),
       event_id: "event_audio",
       item_id: "item_1",
       output_index: 0,

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -337,6 +337,76 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     end
   end
 
+  def test_file_boundary_rejects_windows_before_connecting
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      input_path = File.join(directory, "input.pcm")
+      output_path = File.join(directory, "response.pcm")
+      File.binwrite(input_path, "pcm")
+      realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
+      test_thread = Thread.current
+      win_platform = Gem.method(:win_platform?)
+      platform_check = -> { Thread.current.equal?(test_thread) ? true : win_platform.call }
+
+      error = Gem.stub(:win_platform?, platform_check) do
+        assert_raises(ArgumentError) do
+          OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+            client: RecordingClient.new(realtime: realtime),
+            input_path: input_path,
+            output_path: output_path,
+            model: "gpt-realtime-2.1",
+            voice: :marin,
+            timeout_seconds: 1,
+            output: StringIO.new
+          )
+        end
+      end
+
+      assert_equal(
+        "secure voice output is unavailable on Windows because Ruby cannot verify owner-only ACLs",
+        error.message
+      )
+      assert_empty(realtime.models)
+      refute_path_exists(output_path)
+    end
+  end
+
+  def test_file_boundary_rejects_filesystems_without_hard_links_before_connecting
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      input_path = File.join(directory, "input.pcm")
+      output_path = File.join(directory, "response.pcm")
+      File.binwrite(input_path, "pcm")
+      realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
+      test_thread = Thread.current
+      create_link = File.method(:link)
+      unsupported_link = lambda do |*args|
+        raise Errno::ENOTSUP if Thread.current.equal?(test_thread)
+
+        create_link.call(*args)
+      end
+
+      error = File.stub(:link, unsupported_link) do
+        assert_raises(ArgumentError) do
+          OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+            client: RecordingClient.new(realtime: realtime),
+            input_path: input_path,
+            output_path: output_path,
+            model: "gpt-realtime-2.1",
+            voice: :marin,
+            timeout_seconds: 1,
+            output: StringIO.new
+          )
+        end
+      end
+
+      assert_equal(
+        "output filesystem must support atomic no-clobber hard links",
+        error.message
+      )
+      assert_empty(realtime.models)
+      refute_path_exists(output_path)
+    end
+  end
+
   def test_output_file_must_not_already_exist
     Dir.mktmpdir("openai-realtime-voice") do |directory|
       path = File.join(directory, "response.pcm")

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require "base64"
+require "stringio"
+require "tmpdir"
+
+require_relative "../test_helper"
+require_relative "../../../examples/realtime/websocket_voice_turn"
+
+class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
+  class RecordingSession
+    attr_reader :updates
+
+    def initialize = @updates = []
+    def update(**params) = @updates << params
+  end
+
+  class RecordingInputAudioBuffer
+    attr_reader :appends, :commits
+
+    def initialize
+      @appends = []
+      @commits = []
+    end
+
+    def append_bytes(bytes, event_id: nil) = @appends << {bytes: bytes, event_id: event_id}
+    def commit(event_id: nil) = @commits << {event_id: event_id}
+  end
+
+  class RecordingResponse
+    attr_reader :creates
+
+    def initialize = @creates = []
+    def create(**params) = @creates << params
+  end
+
+  class RecordingConnection
+    attr_reader :input_audio_buffer, :response, :session
+
+    def initialize(events)
+      @events = events
+      @input_audio_buffer = RecordingInputAudioBuffer.new
+      @response = RecordingResponse.new
+      @session = RecordingSession.new
+    end
+
+    def each(&block) = @events.each(&block)
+  end
+
+  class RecordingRealtime
+    attr_reader :models
+
+    def initialize(connection)
+      @connection = connection
+      @models = []
+    end
+
+    def connect(model:)
+      @models << model
+      yield(@connection)
+    end
+  end
+
+  RecordingClient = Data.define(:realtime)
+
+  def test_example_streams_one_committed_voice_turn
+    connection = RecordingConnection.new(successful_events)
+    realtime = RecordingRealtime.new(connection)
+    audio_output = StringIO.new("".b)
+    diagnostics = StringIO.new
+
+    transcript = OpenAI::Examples::Realtime::WebSocketVoiceTurn.run(
+      client: RecordingClient.new(realtime: realtime),
+      input: StringIO.new("abcdef".b),
+      audio_output: audio_output,
+      model: "gpt-realtime-2.1",
+      voice: :marin,
+      chunk_bytes: 2,
+      output: diagnostics
+    )
+
+    assert_equal("Hello from Ruby.", transcript)
+    assert_equal("voice-response".b, audio_output.string)
+    assert_equal(["gpt-realtime-2.1"], realtime.models)
+    assert_equal(%w[ab cd ef], connection.input_audio_buffer.appends.map { _1.fetch(:bytes) })
+    assert_equal([{event_id: nil}], connection.input_audio_buffer.commits)
+    assert_equal([{}], connection.response.creates)
+
+    session = connection.session.updates.fetch(0)
+    assert_equal(:realtime, session.fetch(:type))
+    assert_equal([:audio], session.fetch(:output_modalities))
+    assert_equal(
+      {type: :"audio/pcm", rate: 24_000},
+      session.dig(:audio, :input, :format)
+    )
+    assert_nil(session.dig(:audio, :input, :turn_detection))
+    assert_equal(
+      {type: :"audio/pcm", rate: 24_000},
+      session.dig(:audio, :output, :format)
+    )
+    assert_equal(:marin, session.dig(:audio, :output, :voice))
+    assert_includes(diagnostics.string, "Hello from Ruby.")
+    assert_includes(diagnostics.string, "response.done status=completed")
+    assert_includes(diagnostics.string, "voice turn smoke test passed")
+  end
+
+  def test_example_rejects_empty_input_before_connecting
+    realtime = RecordingRealtime.new(RecordingConnection.new([]))
+
+    error = assert_raises(ArgumentError) do
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.run(
+        client: RecordingClient.new(realtime: realtime),
+        input: StringIO.new("".b),
+        audio_output: StringIO.new("".b),
+        model: "gpt-realtime-2.1",
+        voice: :marin,
+        output: StringIO.new
+      )
+    end
+
+    assert_equal("PCM input is empty", error.message)
+    assert_empty(realtime.models)
+  end
+
+  def test_example_requires_a_completed_response
+    error = assert_raises(RuntimeError) do
+      run_with_events([audio_delta("audio"), response_done(status: :cancelled)])
+    end
+
+    assert_equal("Realtime response did not complete.", error.message)
+  end
+
+  def test_example_requires_audio_output
+    error = assert_raises(RuntimeError) do
+      run_with_events([transcript_delta("Hello"), response_done])
+    end
+
+    assert_equal("Realtime response completed without audio output", error.message)
+  end
+
+  def test_example_requires_an_audio_transcript
+    error = assert_raises(RuntimeError) do
+      run_with_events([audio_delta("audio"), response_done])
+    end
+
+    assert_equal(
+      "Realtime response completed without an audio transcript",
+      error.message
+    )
+  end
+
+  def test_example_requires_response_done
+    error = assert_raises(RuntimeError) do
+      run_with_events([audio_delta("audio")])
+    end
+
+    assert_equal("Realtime connection closed before response.done", error.message)
+  end
+
+  def test_example_uses_the_final_transcript_when_no_deltas_arrive
+    diagnostics = StringIO.new
+    transcript = OpenAI::Examples::Realtime::WebSocketVoiceTurn.run(
+      client: RecordingClient.new(
+        realtime: RecordingRealtime.new(
+          RecordingConnection.new([audio_delta("audio"), transcript_done("Final words."), response_done])
+        )
+      ),
+      input: StringIO.new("pcm".b),
+      audio_output: StringIO.new("".b),
+      model: "gpt-realtime-2.1",
+      voice: :marin,
+      output: diagnostics
+    )
+
+    assert_equal("Final words.", transcript)
+    assert_includes(diagnostics.string, "Final words.")
+  end
+
+  def test_example_keeps_service_error_details_out_of_the_exception_message
+    customer_text = "private audio content echoed by the service"
+    event = OpenAI::Realtime::RealtimeErrorEvent.new(
+      event_id: "event_error",
+      error: OpenAI::Realtime::RealtimeError.new(
+        message: customer_text,
+        type: "invalid_request_error"
+      )
+    )
+
+    error = assert_raises(RuntimeError) { run_with_events([event]) }
+
+    assert_equal("Realtime API error.", error.message)
+    refute_includes(error.message, customer_text)
+  end
+
+  def test_example_rejects_invalid_base64_audio
+    event = OpenAI::Realtime::ResponseAudioDeltaEvent.new(
+      content_index: 0,
+      delta: "not base64!",
+      event_id: "event_audio",
+      item_id: "item_1",
+      output_index: 0,
+      response_id: "response_1"
+    )
+
+    error = assert_raises(RuntimeError) { run_with_events([event]) }
+
+    assert_equal("Realtime returned invalid audio data.", error.message)
+  end
+
+  def test_output_file_must_not_already_exist
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+      File.binwrite(path, "keep me")
+
+      error = assert_raises(ArgumentError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) { |_file| nil }
+      end
+
+      assert_equal("output path must not already exist", error.message)
+      assert_equal("keep me", File.binread(path))
+    end
+  end
+
+  def test_output_file_does_not_relabel_errors_from_the_caller_block
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      path = File.join(directory, "response.pcm")
+
+      error = assert_raises(Errno::EEXIST) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |_file|
+          raise Errno::EEXIST, "raised by caller"
+        end
+      end
+
+      assert_includes(error.message, "raised by caller")
+    end
+  end
+
+  private def run_with_events(events)
+    OpenAI::Examples::Realtime::WebSocketVoiceTurn.run(
+      client: RecordingClient.new(realtime: RecordingRealtime.new(RecordingConnection.new(events))),
+      input: StringIO.new("pcm".b),
+      audio_output: StringIO.new("".b),
+      model: "gpt-realtime-2.1",
+      voice: :marin,
+      output: StringIO.new
+    )
+  end
+
+  private def successful_events
+    [
+      OpenAI::Realtime::SessionCreatedEvent.new(
+        event_id: "event_created",
+        session: {type: :realtime}
+      ),
+      OpenAI::Realtime::SessionUpdatedEvent.new(
+        event_id: "event_updated",
+        session: {type: :realtime, output_modalities: [:audio]}
+      ),
+      OpenAI::Realtime::InputAudioBufferCommittedEvent.new(
+        event_id: "event_committed",
+        item_id: "item_1"
+      ),
+      transcript_delta("Hello from Ruby."),
+      audio_delta("voice-"),
+      audio_delta("response"),
+      response_done
+    ]
+  end
+
+  private def audio_delta(bytes)
+    OpenAI::Realtime::ResponseAudioDeltaEvent.new(
+      content_index: 0,
+      delta: Base64.strict_encode64(bytes),
+      event_id: "event_audio",
+      item_id: "item_1",
+      output_index: 0,
+      response_id: "response_1"
+    )
+  end
+
+  private def transcript_delta(text)
+    OpenAI::Realtime::ResponseAudioTranscriptDeltaEvent.new(
+      content_index: 0,
+      delta: text,
+      event_id: "event_transcript",
+      item_id: "item_1",
+      output_index: 0,
+      response_id: "response_1"
+    )
+  end
+
+  private def transcript_done(text)
+    OpenAI::Realtime::ResponseAudioTranscriptDoneEvent.new(
+      content_index: 0,
+      event_id: "event_transcript_done",
+      item_id: "item_1",
+      output_index: 0,
+      response_id: "response_1",
+      transcript: text
+    )
+  end
+
+  private def response_done(status: :completed)
+    OpenAI::Realtime::ResponseDoneEvent.new(
+      event_id: "event_done",
+      response: OpenAI::Realtime::RealtimeResponse.new(
+        id: "response_1",
+        status: status,
+        output: []
+      )
+    )
+  end
+end

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "stringio"
-require "tmpdir"
 
 require_relative "../test_helper"
 require_relative "../../../examples/realtime/websocket_voice_turn"
@@ -57,20 +56,30 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     end
   end
 
+  class BlockingInput
+    def binmode = self
+    def read(_bytes) = sleep(60)
+  end
+
+  class SystemCallFailureInput
+    def binmode = self
+
+    def read(_bytes)
+      raise Errno::ENOENT, "private-customer-audio.pcm"
+    end
+  end
+
   class RecordingRealtime
     attr_reader :models
 
-    def initialize(connection, after_connect: nil)
-      @after_connect = after_connect
+    def initialize(connection)
       @connection = connection
       @models = []
     end
 
     def connect(model:)
       @models << model
-      result = yield(@connection)
-      @after_connect&.call
-      result
+      yield(@connection)
     end
   end
 
@@ -189,34 +198,31 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     refute_includes(diagnostics.string, "Final words.")
   end
 
-  def test_file_boundary_rejects_an_empty_authoritative_transcript
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      input_path = File.join(directory, "input.pcm")
-      output_path = File.join(directory, "response.pcm")
-      File.binwrite(input_path, "pcm")
-      events = [
-        transcript_delta("Stale streamed words."),
-        transcript_done(""),
-        audio_delta("audio"),
-        response_done
-      ]
-      realtime = RecordingRealtime.new(RecordingConnection.new(events))
+  def test_stream_boundary_rejects_an_empty_authoritative_transcript
+    events = [
+      transcript_delta("Stale streamed words."),
+      transcript_done(""),
+      audio_delta("audio"),
+      response_done
+    ]
+    diagnostics = StringIO.new
 
-      error = assert_raises(RuntimeError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
-          client: RecordingClient.new(realtime: realtime),
-          input_path: input_path,
-          output_path: output_path,
-          model: "gpt-realtime-2.1",
-          voice: :marin,
-          timeout_seconds: 1,
-          output: StringIO.new
-        )
-      end
-
-      assert_equal("Realtime response completed without an audio transcript", error.message)
-      refute_path_exists(output_path)
+    error = assert_raises(RuntimeError) do
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_with_timeout(
+        client: RecordingClient.new(
+          realtime: RecordingRealtime.new(RecordingConnection.new(events))
+        ),
+        input: StringIO.new("pcm".b),
+        audio_output: StringIO.new("".b),
+        model: "gpt-realtime-2.1",
+        voice: :marin,
+        timeout_seconds: 1,
+        output: diagnostics
+      )
     end
+
+    assert_equal("Realtime response completed without an audio transcript", error.message)
+    refute_includes(diagnostics.string, "voice turn smoke test passed")
   end
 
   def test_example_keeps_service_error_details_out_of_the_exception_message
@@ -250,340 +256,97 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     assert_equal("Realtime returned invalid audio data.", error.message)
   end
 
-  def test_file_boundary_suppresses_protocol_error_data_and_cause
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      input_path = File.join(directory, "input.pcm")
-      output_path = File.join(directory, "response.pcm")
-      File.binwrite(input_path, "pcm")
-      customer_data = "private malformed frame content"
-      protocol_error = OpenAI::Errors::RealtimeProtocolError.new(
-        data: customer_data,
-        cause: JSON::ParserError.new(customer_data)
-      )
-      realtime = RecordingRealtime.new(ProtocolFailureConnection.new(protocol_error))
-      diagnostics = StringIO.new
+  def test_stream_boundary_streams_audio_and_returns_transcript
+    realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
+    audio_output = StringIO.new("".b)
+    transcript = nil
 
-      error = assert_raises(RuntimeError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
-          client: RecordingClient.new(realtime: realtime),
-          input_path: input_path,
-          output_path: output_path,
-          model: "gpt-realtime-2.1",
-          voice: :marin,
-          timeout_seconds: 1,
-          output: diagnostics
-        )
-      end
-
-      assert_instance_of(RuntimeError, error)
-      assert_equal("Realtime protocol error.", error.message)
-      assert_nil(error.cause)
-      refute_includes(error.full_message, customer_data)
-      refute_includes(diagnostics.string, customer_data)
-      refute_path_exists(output_path)
-    end
-  end
-
-  def test_file_boundary_reports_success_only_after_output_publication
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      input_path = File.join(directory, "input.pcm")
-      output_path = File.join(directory, "response.pcm")
-      File.binwrite(input_path, "pcm")
-      realtime = RecordingRealtime.new(
-        RecordingConnection.new(successful_events),
-        after_connect: -> { File.binwrite(output_path, "other owner") }
-      )
-      diagnostics = StringIO.new
-
-      error = assert_raises(ArgumentError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
-          client: RecordingClient.new(realtime: realtime),
-          input_path: input_path,
-          output_path: output_path,
-          model: "gpt-realtime-2.1",
-          voice: :marin,
-          timeout_seconds: 1,
-          output: diagnostics
-        )
-      end
-
-      assert_equal("output path must not already exist", error.message)
-      assert_equal("other owner", File.binread(output_path))
-      refute_includes(diagnostics.string, "voice turn smoke test passed")
-    end
-  end
-
-  def test_file_boundary_publishes_output_before_reporting_success
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      input_path = File.join(directory, "input.pcm")
-      output_path = File.join(directory, "response.pcm")
-      File.binwrite(input_path, "pcm")
-      realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
-      diagnostics = StringIO.new
-
-      transcript = OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+    stdout, stderr = capture_io do
+      transcript = OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_with_timeout(
         client: RecordingClient.new(realtime: realtime),
-        input_path: input_path,
-        output_path: output_path,
+        input: StringIO.new("pcm".b),
+        audio_output: audio_output,
+        model: "gpt-realtime-2.1",
+        voice: :marin,
+        timeout_seconds: 1
+      )
+    end
+
+    assert_equal("Hello from Ruby.", transcript)
+    assert_equal("voice-response".b, audio_output.string)
+    assert_empty(stdout)
+    assert_equal("[realtime] voice turn smoke test passed\n", stderr.lines.last)
+    refute_includes(stderr, transcript)
+  end
+
+  def test_stream_boundary_deadline_covers_the_initial_input_read
+    realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
+    diagnostics = StringIO.new
+
+    assert_raises(Timeout::Error) do
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_with_timeout(
+        client: RecordingClient.new(realtime: realtime),
+        input: BlockingInput.new,
+        audio_output: StringIO.new("".b),
+        model: "gpt-realtime-2.1",
+        voice: :marin,
+        timeout_seconds: 0.05,
+        output: diagnostics
+      )
+    end
+
+    assert_empty(realtime.models)
+    refute_includes(diagnostics.string, "voice turn smoke test passed")
+  end
+
+  def test_stream_boundary_suppresses_protocol_error_data_and_cause
+    customer_data = "private malformed frame content"
+    protocol_error = OpenAI::Errors::RealtimeProtocolError.new(
+      data: customer_data,
+      cause: JSON::ParserError.new(customer_data)
+    )
+    realtime = RecordingRealtime.new(ProtocolFailureConnection.new(protocol_error))
+    diagnostics = StringIO.new
+
+    error = assert_raises(RuntimeError) do
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_with_timeout(
+        client: RecordingClient.new(realtime: realtime),
+        input: StringIO.new("pcm".b),
+        audio_output: StringIO.new("".b),
         model: "gpt-realtime-2.1",
         voice: :marin,
         timeout_seconds: 1,
         output: diagnostics
       )
-
-      assert_equal("Hello from Ruby.", transcript)
-      assert_equal("voice-response".b, File.binread(output_path))
-      assert_equal("[realtime] voice turn smoke test passed\n", diagnostics.string.lines.last)
     end
+
+    assert_instance_of(RuntimeError, error)
+    assert_equal("Realtime protocol error.", error.message)
+    assert_nil(error.cause)
+    refute_includes(error.full_message, customer_data)
+    refute_includes(diagnostics.string, customer_data)
   end
 
-  def test_file_boundary_rejects_windows_before_connecting
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      input_path = File.join(directory, "input.pcm")
-      output_path = File.join(directory, "response.pcm")
-      File.binwrite(input_path, "pcm")
-      realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
-      test_thread = Thread.current
-      win_platform = Gem.method(:win_platform?)
-      platform_check = -> { Thread.current.equal?(test_thread) ? true : win_platform.call }
+  def test_stream_boundary_suppresses_system_call_error_details
+    customer_path = "private-customer-audio.pcm"
+    realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
 
-      error = Gem.stub(:win_platform?, platform_check) do
-        assert_raises(ArgumentError) do
-          OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
-            client: RecordingClient.new(realtime: realtime),
-            input_path: input_path,
-            output_path: output_path,
-            model: "gpt-realtime-2.1",
-            voice: :marin,
-            timeout_seconds: 1,
-            output: StringIO.new
-          )
-        end
-      end
-
-      assert_equal(
-        "secure voice output is unavailable on Windows because Ruby cannot verify owner-only ACLs",
-        error.message
+    error = assert_raises(RuntimeError) do
+      OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_with_timeout(
+        client: RecordingClient.new(realtime: realtime),
+        input: SystemCallFailureInput.new,
+        audio_output: StringIO.new("".b),
+        model: "gpt-realtime-2.1",
+        voice: :marin,
+        timeout_seconds: 1,
+        output: StringIO.new
       )
-      assert_empty(realtime.models)
-      refute_path_exists(output_path)
     end
-  end
 
-  def test_file_boundary_rejects_filesystems_without_hard_links_before_connecting
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      input_path = File.join(directory, "input.pcm")
-      output_path = File.join(directory, "response.pcm")
-      File.binwrite(input_path, "pcm")
-      realtime = RecordingRealtime.new(RecordingConnection.new(successful_events))
-      test_thread = Thread.current
-      create_link = File.method(:link)
-      unsupported_link = lambda do |*args|
-        raise Errno::ENOTSUP if Thread.current.equal?(test_thread)
-
-        create_link.call(*args)
-      end
-
-      error = File.stub(:link, unsupported_link) do
-        assert_raises(ArgumentError) do
-          OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
-            client: RecordingClient.new(realtime: realtime),
-            input_path: input_path,
-            output_path: output_path,
-            model: "gpt-realtime-2.1",
-            voice: :marin,
-            timeout_seconds: 1,
-            output: StringIO.new
-          )
-        end
-      end
-
-      assert_equal(
-        "output filesystem must support atomic no-clobber hard links",
-        error.message
-      )
-      assert_empty(realtime.models)
-      refute_path_exists(output_path)
-    end
-  end
-
-  def test_output_file_must_not_already_exist
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-      File.binwrite(path, "keep me")
-
-      error = assert_raises(ArgumentError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) { |_file| nil }
-      end
-
-      assert_equal("output path must not already exist", error.message)
-      assert_equal("keep me", File.binread(path))
-    end
-  end
-
-  def test_output_file_rejects_symlink_and_hardlink_destinations
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      target = File.join(directory, "existing.pcm")
-      File.binwrite(target, "keep me")
-      destinations = [
-        File.join(directory, "response-symlink.pcm"),
-        File.join(directory, "response-hardlink.pcm")
-      ]
-      File.symlink(target, destinations.fetch(0))
-      File.link(target, destinations.fetch(1))
-
-      destinations.each do |path|
-        error = assert_raises(ArgumentError) do
-          OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) { |_file| nil }
-        end
-
-        assert_equal("output path must not already exist", error.message)
-      end
-
-      assert_equal("keep me", File.binread(target))
-      assert_predicate(File.lstat(destinations.fetch(0)), :symlink?)
-      assert(File.identical?(target, destinations.fetch(1)))
-    end
-  end
-
-  def test_output_file_does_not_relabel_errors_from_the_caller_block
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-
-      error = assert_raises(Errno::EEXIST) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |_file|
-          raise Errno::EEXIST, "raised by caller"
-        end
-      end
-
-      assert_includes(error.message, "raised by caller")
-      refute_path_exists(path)
-    end
-  end
-
-  def test_output_file_is_not_published_when_the_run_fails
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-
-      error = assert_raises(RuntimeError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-          file.write("partial audio")
-          refute_path_exists(path)
-          raise "voice turn failed"
-        end
-      end
-
-      assert_equal("voice turn failed", error.message)
-      refute_path_exists(path)
-      assert_empty(Dir.children(directory))
-    end
-  end
-
-  def test_output_file_is_not_published_when_the_run_times_out
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-
-      assert_raises(Timeout::Error) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-          file.write("partial audio")
-          refute_path_exists(path)
-          raise Timeout::Error, "execution expired"
-        end
-      end
-
-      refute_path_exists(path)
-      assert_empty(Dir.children(directory))
-    end
-  end
-
-  def test_output_file_is_published_after_a_successful_run
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-
-      OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-        file.write("complete audio")
-        refute_path_exists(path)
-
-        staging_directory = File.dirname(file.path)
-        refute_equal(directory, staging_directory)
-        assert_equal(0o700, File.stat(staging_directory).mode & 0o777)
-      end
-
-      assert_equal("complete audio", File.binread(path))
-      assert_equal(0o600, File.stat(path).mode & 0o777)
-      assert_equal(["response.pcm"], Dir.children(directory))
-    end
-  end
-
-  def test_output_file_rejects_a_replaceable_staging_path
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      File.chmod(0o770, directory)
-      path = File.join(directory, "response.pcm")
-
-      error = assert_raises(ArgumentError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-          file.write("private audio")
-          File.unlink(file.path)
-          File.binwrite(file.path, "attacker-controlled audio")
-        end
-      end
-
-      assert_equal(
-        "output directory must not be writable by other users unless it has the sticky bit set",
-        error.message
-      )
-      refute_path_exists(path)
-      assert_empty(Dir.children(directory))
-    end
-  end
-
-  def test_output_file_allows_a_sticky_shared_directory
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      File.chmod(0o1777, directory)
-      path = File.join(directory, "response.pcm")
-
-      OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-        file.write("complete audio")
-      end
-
-      assert_equal("complete audio", File.binread(path))
-      assert_equal(0o600, File.stat(path).mode & 0o777)
-    end
-  end
-
-  def test_output_file_does_not_publish_a_substituted_private_staging_path
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-
-      error = assert_raises(RuntimeError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-          file.write("private audio")
-          File.unlink(file.path)
-          File.binwrite(file.path, "attacker-controlled audio")
-        end
-      end
-
-      assert_equal("staged output changed before publication", error.message)
-      refute_path_exists(path)
-      assert_empty(Dir.children(directory))
-    end
-  end
-
-  def test_output_file_does_not_replace_a_destination_created_during_the_run
-    Dir.mktmpdir("openai-realtime-voice") do |directory|
-      path = File.join(directory, "response.pcm")
-
-      error = assert_raises(ArgumentError) do
-        OpenAI::Examples::Realtime::WebSocketVoiceTurn.open_output(path) do |file|
-          file.write("complete audio")
-          File.binwrite(path, "other owner")
-        end
-      end
-
-      assert_equal("output path must not already exist", error.message)
-      assert_equal("other owner", File.binread(path))
-      assert_equal(["response.pcm"], Dir.children(directory))
-    end
+    assert_equal("Realtime stream I/O error.", error.message)
+    assert_nil(error.cause)
+    refute_includes(error.full_message, customer_path)
+    assert_empty(realtime.models)
   end
 
   private def run_with_events(events)

--- a/test/openai/realtime/websocket_voice_turn_example_test.rb
+++ b/test/openai/realtime/websocket_voice_turn_example_test.rb
@@ -189,6 +189,36 @@ class OpenAI::Test::RealtimeWebSocketVoiceTurnExampleTest < Minitest::Test
     refute_includes(diagnostics.string, "Final words.")
   end
 
+  def test_file_boundary_rejects_an_empty_authoritative_transcript
+    Dir.mktmpdir("openai-realtime-voice") do |directory|
+      input_path = File.join(directory, "input.pcm")
+      output_path = File.join(directory, "response.pcm")
+      File.binwrite(input_path, "pcm")
+      events = [
+        transcript_delta("Stale streamed words."),
+        transcript_done(""),
+        audio_delta("audio"),
+        response_done
+      ]
+      realtime = RecordingRealtime.new(RecordingConnection.new(events))
+
+      error = assert_raises(RuntimeError) do
+        OpenAI::Examples::Realtime::WebSocketVoiceTurn.run_to_file(
+          client: RecordingClient.new(realtime: realtime),
+          input_path: input_path,
+          output_path: output_path,
+          model: "gpt-realtime-2.1",
+          voice: :marin,
+          timeout_seconds: 1,
+          output: StringIO.new
+        )
+      end
+
+      assert_equal("Realtime response completed without an audio transcript", error.message)
+      refute_path_exists(output_path)
+    end
+  end
+
   def test_example_keeps_service_error_details_out_of_the_exception_message
     customer_text = "private audio content echoed by the service"
     event = OpenAI::Realtime::RealtimeErrorEvent.new(


### PR DESCRIPTION
## Summary

- add a packaged Realtime WebSocket example for one explicitly committed PCM voice turn
- stream the assistant audio transcript while saving raw 24 kHz mono PCM16 response audio
- document conversion, playback, lifecycle guarantees, and deliberately deferred full-duplex/device work
- cover success, terminal failures, invalid audio, transcript completion, safe binary output creation, packaging, and inventory

## Scope

This is an example and documentation slice over the merged Realtime public API. It changes no production SDK runtime, generated model, generated resource, RBI, or RBS surface. Continuous microphone capture, live playback, full-duplex orchestration, WebRTC, SIP/sideband, translation, function/MCP, and image workflows remain deferred.

## Validation

- live OpenAI smoke: session created and updated, input committed, assistant transcript streamed, completed response observed, and 211,200 PCM bytes written
- FFmpeg successfully decoded the saved 24 kHz mono PCM16 response
- Ruby 3.3.12, 3.4.10, and 4.0.6: 921 tests / 4,869 assertions each, zero failures or errors, one existing skip
- Sorbet, RBS, RuboCop, rubyfmt, example inventory, gem packaging, syntax, and YARD build passed
- two-pass thermo-nuclear review completed; both findings were fixed with regressions