### PR TITLE
chore: remove Tapioca development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem "minitest-hooks"
   gem "minitest-proveit"
   gem "minitest-rg"
+  gem "sorbet-runtime"
   gem "webmock"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :development do
   gem "steep"
   gem "syntax_tree"
   gem "syntax_tree-rbs", github: "ruby-syntax-tree/syntax_tree-rbs", branch: "main"
-  gem "tapioca"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,6 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
-    benchmark (0.5.0)
     bigdecimal (4.1.2)
     cgi (0.5.1)
     concurrent-ruby (1.3.7)
@@ -87,7 +86,6 @@ GEM
       rexml
     csv (3.3.5)
     drb (2.2.3)
-    erubi (1.13.1)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -126,7 +124,6 @@ GEM
     minitest-rg (5.3.0)
       minitest (~> 5.0)
     mutex_m (0.3.0)
-    netrc (0.11.0)
     openssl (4.0.2)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -156,9 +153,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbi (0.3.7)
-      prism (~> 1.0)
-      rbs (>= 3.4.4)
     rbs (3.9.5)
       logger
     redcarpet (3.6.1)
@@ -182,20 +176,9 @@ GEM
     securerandom (0.4.1)
     sorbet (0.6.12690)
       sorbet-static (= 0.6.12690)
-    sorbet-runtime (0.6.12690)
     sorbet-static (0.6.12690-aarch64-linux)
     sorbet-static (0.6.12690-universal-darwin)
     sorbet-static (0.6.12690-x86_64-linux)
-    sorbet-static-and-runtime (0.6.12690)
-      sorbet (= 0.6.12690)
-      sorbet-runtime (= 0.6.12690)
-    spoom (1.6.3)
-      erubi (>= 1.10.0)
-      prism (>= 0.28.0)
-      rbi (>= 0.3.3)
-      rexml (>= 3.2.6)
-      sorbet-static-and-runtime (>= 0.5.10187)
-      thor (>= 0.19.2)
     steep (1.10.0)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -216,19 +199,8 @@ GEM
     strscan (3.1.5)
     syntax_tree (6.3.0)
       prettier_print (>= 1.2.0)
-    tapioca (0.16.11)
-      benchmark
-      bundler (>= 2.2.25)
-      netrc (>= 0.11.0)
-      parallel (>= 1.21.0)
-      rbi (~> 0.2)
-      sorbet-static-and-runtime (>= 0.5.11087)
-      spoom (>= 1.2.0)
-      thor (>= 1.2.0)
-      yard-sorbet
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
-    thor (1.4.0)
     traces (0.18.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -242,9 +214,6 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
     yard (0.9.44)
-    yard-sorbet (0.9.0)
-      sorbet-runtime
-      yard
 
 PLATFORMS
   aarch64-linux
@@ -274,7 +243,6 @@ DEPENDENCIES
   steep
   syntax_tree
   syntax_tree-rbs!
-  tapioca
   webmock
   webrick
   yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
     securerandom (0.4.1)
     sorbet (0.6.12690)
       sorbet-static (= 0.6.12690)
+    sorbet-runtime (0.6.12690)
     sorbet-static (0.6.12690-aarch64-linux)
     sorbet-static (0.6.12690-universal-darwin)
     sorbet-static (0.6.12690-x86_64-linux)
@@ -240,6 +241,7 @@ DEPENDENCIES
   redcarpet
   rubocop
   sorbet
+  sorbet-runtime
   steep
   syntax_tree
   syntax_tree-rbs!

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ require "rubocop/rake_task"
 require_relative "scripts/rubyfmt_policy"
 require_relative "scripts/rbs_format"
 
-tapioca = "sorbet/tapioca"
 examples = "examples"
 ignore_file = ".ignore"
 pkg = "pkg"
@@ -19,7 +18,7 @@ FILES_ENV = "FORMAT_FILE"
 
 CLEAN.push(*%w[.idea/ .ruby-lsp/ .yardoc/ doc/], *FileList["*.gem"], pkg, ignore_file)
 
-CLOBBER.push(*%w[sorbet/rbi/annotations/ sorbet/rbi/gems/], tapioca)
+CLOBBER.push(*%w[sorbet/rbi/annotations/ sorbet/rbi/gems/])
 
 multitask(:default) do
   sh(*%w[rake --tasks])
@@ -122,11 +121,8 @@ directory(pkg)
 
 desc("Typecheck `*.rbi`")
 multitask("typecheck:sorbet": examples) do
-  sh(*%w[srb typecheck --dir], examples)
-end
-
-directory(tapioca) do
-  sh(*%w[tapioca init])
+  # The shipped RBI directory is already listed in sorbet/config.
+  sh({"SRB_SKIP_GEM_RBIS" => "1"}, *%w[srb typecheck --dir], examples)
 end
 
 desc("Typecheck and validate everything")


### PR DESCRIPTION
## Summary

- remove the direct Tapioca development dependency and its tooling-only transitive closure
- declare the existing `sorbet-runtime` test requirement directly, retaining version `0.6.12690`
- remove the orphaned repository-only `sorbet/tapioca` directory task and clobber target
- preserve the runtime compatibility guard for downstream consumers that run Tapioca against the gem
- explicitly skip Sorbet's bundled-gem RBI discovery because this repository already typechecks its shipped `rbi/` directory

## Why

The repository ships and directly typechecks its RBI files, so it does not use Tapioca to generate repository signatures. The test suite does directly exercise runtime Sorbet conversion, which was previously available only through Tapioca's transitive dependency graph; this PR makes that requirement explicit.

The resulting dependency graph keeps 21 direct dependencies while replacing Tapioca with the actual test dependency, and reduces locked specs from 104 to 95.

Sorbet's launcher implicitly suppresses bundled-gem RBI discovery while Tapioca is present in the lockfile. Without an explicit replacement, removing Tapioca loads this gem's shipped RBIs twice. The scoped `SRB_SKIP_GEM_RBIS=1` setting preserves the existing typecheck behavior.

## Validation

- `bundle exec rake test TEST=test/openai/internal/type/array_of_sorbet_type_test.rb` — 1 run, 2 assertions, 0 failures
- `bundle exec rake test TEST=test/openai/load_order_test.rb` — 3 runs, 3 assertions, 0 failures
- `bundle check`
- `bundle exec rake typecheck:sorbet`
- `bundle exec rubocop Gemfile Rakefile`
- `bundle exec rake lint:rubyfmt`
- thermo-nuclear code quality review after the CI fix — no findings
