### PR TITLE
fix: remove runtime base64 dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ PATH
   remote: .
   specs:
     openai (0.80.0)
-      base64
       cgi
       connection_pool (>= 2.2.3)
       logger

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -2,7 +2,6 @@
 
 # Standard libraries.
 require "English"
-require "base64"
 require "cgi"
 require "date"
 require "erb"

--- a/lib/openai/helpers/realtime/connection_resources.rb
+++ b/lib/openai/helpers/realtime/connection_resources.rb
@@ -58,7 +58,7 @@ module OpenAI
         end
 
         def append_bytes(bytes, event_id: nil)
-          append(audio: Base64.strict_encode64(bytes), event_id: event_id)
+          append(audio: [bytes].pack("m0"), event_id: event_id)
         end
 
         def commit(event_id: nil)

--- a/lib/openai/helpers/realtime/transports/async_websocket.rb
+++ b/lib/openai/helpers/realtime/transports/async_websocket.rb
@@ -276,7 +276,7 @@ module OpenAI
 
           user = URI::RFC2396_PARSER.unescape(proxy.user)
           password = URI::RFC2396_PARSER.unescape(proxy.password.to_s)
-          {"proxy-authorization" => "Basic #{Base64.strict_encode64("#{user}:#{password}")}"}
+          {"proxy-authorization" => "Basic #{["#{user}:#{password}"].pack("m0")}"}
         end
 
         private def trace_safe_headers(headers)

--- a/lib/openai/resources/webhooks.rb
+++ b/lib/openai/resources/webhooks.rb
@@ -97,7 +97,7 @@ module OpenAI
 
         # Decode the secret if it starts with whsec_
         decoded_secret = if webhook_secret.start_with?("whsec_")
-          Base64.strict_decode64(webhook_secret[6..])
+          webhook_secret[6..].unpack1("m0")
         else
           webhook_secret
         end
@@ -108,11 +108,7 @@ module OpenAI
         signed_payload = "#{webhook_id}.#{timestamp_header}.#{payload}"
 
         # Compute HMAC-SHA256 signature
-        expected_signature = Base64
-          .encode64(
-            OpenSSL::HMAC.digest("sha256", decoded_secret, signed_payload)
-          )
-          .strip
+        expected_signature = [OpenSSL::HMAC.digest("sha256", decoded_secret, signed_payload)].pack("m0")
 
         # Accept if any signature matches using timing-safe comparison
         return if signatures.any? { |signature| OpenSSL.secure_compare(expected_signature, signature) }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,5 @@
 dependencies:
   - English
-  - base64
   - cgi
   - date
   - erb

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
     "realtime.md",
     "examples/realtime/README.md"
   ]
-  s.add_dependency("base64")
   s.add_dependency("cgi")
   s.add_dependency("connection_pool", ">= 2.2.3")
   s.add_dependency("logger")

--- a/test/openai/resources/webhooks_test.rb
+++ b/test/openai/resources/webhooks_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
-require "base64"
 require "openssl"
 require "stringio"
 
@@ -72,12 +71,29 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
   end
 
   def test_unwrap_accepts_base64_encoded_webhook_secrets
-    signing_key = "binary\x00webhook secret"
-    webhook_secret = "whsec_#{Base64.strict_encode64(signing_key)}"
+    signing_key = "binary\x00\xFF\x80webhook secret".b
+    webhook_secret = "whsec_YmluYXJ5AP+Ad2ViaG9vayBzZWNyZXQ="
 
     event = @webhook_service.unwrap(@test_payload, signed_headers(signing_key), webhook_secret)
 
     assert_equal("evt_685c059ae3a481909bdc86819b066fb6", event.id)
+  end
+
+  def test_unwrap_accepts_padded_base64_encoded_webhook_secrets
+    signing_key = "f"
+    webhook_secret = "whsec_Zg=="
+
+    event = @webhook_service.unwrap(@test_payload, signed_headers(signing_key), webhook_secret)
+
+    assert_equal("evt_685c059ae3a481909bdc86819b066fb6", event.id)
+  end
+
+  def test_unwrap_rejects_malformed_base64_padding
+    %w[whsec_Zg= whsec_Zg=== whsec_Zg whsec_Zm9v=].each do |webhook_secret|
+      assert_raises(ArgumentError, "expected #{webhook_secret.inspect} to be rejected") do
+        @webhook_service.unwrap(@test_payload, signed_headers("f"), webhook_secret)
+      end
+    end
   end
 
   def test_verify_signature_with_missing_headers
@@ -262,12 +278,16 @@ class OpenAI::Test::Resources::WebhooksTest < OpenAI::Test::ResourceTest
 
   def signed_headers(signing_key)
     signed_payload = "#{@webhook_id}.#{@fixed_timestamp}.#{@test_payload}"
-    signature = Base64.strict_encode64(OpenSSL::HMAC.digest("sha256", signing_key, signed_payload))
+    signature = encode64(OpenSSL::HMAC.digest("sha256", signing_key, signed_payload))
 
     {
       "webhook-signature" => "v1,#{signature}",
       "webhook-timestamp" => @fixed_timestamp,
       "webhook-id" => @webhook_id
     }
+  end
+
+  def encode64(bytes)
+    [bytes].pack("m0")
   end
 end


### PR DESCRIPTION
## Summary

- replace runtime Base64 decoding and encoding with Ruby `unpack1("m0")` and `pack("m0")` primitives
- remove the `base64` runtime dependency, top-level require, manifest declaration, and direct lockfile edge
- preserve strict malformed-secret rejection, padded and binary webhook secrets, exact webhook signatures, Realtime audio encoding, and proxy authorization output

## Why

Ruby's Base64 helpers are thin wrappers around the same pack/unpack directives used here. Depending on the separate `base64` gem only for these operations adds an unnecessary runtime consumer dependency. The published gem now has three direct runtime dependencies instead of four (`cgi`, `connection_pool`, and `logger`).

## Validation

- `bundle check`
- `bundle exec ruby -Itest test/openai/resources/webhooks_test.rb` — 19 tests, 45 assertions
- `bundle exec ruby -Itest test/openai/realtime/connection_test.rb` — 31 tests, 219 assertions
- `bundle exec ruby -Itest test/openai/realtime/network_invariants_test.rb` — 7 tests, 38 assertions
- `bundle exec rake build:gem`
- `bundle exec ruby -Itest test/openai/gem_packaging_test.rb` — 1 test, 8 assertions
- `bundle exec rake typecheck:sorbet`
- `STEEP_JOBS=8 bundle exec rake validate:rbs` — 1,236 RBS files
- mock-backed `bundle exec rake test` — 923 tests, 4,897 assertions, 0 failures, 0 errors, 1 skip
