### PR TITLE
Remove runtime CGI dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development, :test do
   gem "async"
   gem "async-websocket"
   gem "aws-sdk-core", "~> 3"
+  gem "cgi"
   gem "minitest", "~> 5.27"
   gem "minitest-hooks"
   gem "minitest-proveit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ PATH
   remote: .
   specs:
     openai (0.80.0)
-      cgi
       connection_pool (>= 2.2.3)
       logger
 
@@ -225,6 +224,7 @@ DEPENDENCIES
   async
   async-websocket
   aws-sdk-core (~> 3)
+  cgi
   minitest (~> 5.27)
   minitest-hooks
   minitest-proveit

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -2,7 +2,6 @@
 
 # Standard libraries.
 require "English"
-require "cgi"
 require "date"
 require "erb"
 require "etc"

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -300,7 +300,24 @@ module OpenAI
         #
         # @return [Hash{String=>Array<String>}]
         def decode_query(query)
-          CGI.parse(query.to_s)
+          params = {}
+          query.to_s.split(/[&;]/).each do |pair|
+            key, value = pair.split("=", 2).map do |component|
+              # URI rejects malformed escapes, while CGI leaves them literal and stops at a trailing "%+".
+              escaped = component.gsub(/%(?![0-9a-fA-F]{2})/, "%25")
+              escaped = escaped.delete_suffix("+") + "%2B" if component.end_with?("%+")
+              decoded = URI.decode_www_form_component(escaped).force_encoding(Encoding::UTF_8)
+              decoded.valid_encoding? ? decoded : decoded.force_encoding(component.encoding)
+            end
+
+            next unless key
+
+            params[key] ||= []
+            params[key] << value if value
+          end
+
+          params.default = [].freeze
+          params
         end
 
         # @api private

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,5 @@
 dependencies:
   - English
-  - cgi
   - date
   - erb
   - etc

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
     "realtime.md",
     "examples/realtime/README.md"
   ]
-  s.add_dependency("cgi")
   s.add_dependency("connection_pool", ">= 2.2.3")
   s.add_dependency("logger")
 end

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -2,6 +2,8 @@
 
 require_relative "../test_helper"
 
+require "cgi"
+
 class OpenAI::Test::UtilDataHandlingTest < Minitest::Test
   def test_left_map
     assert_pattern do
@@ -131,6 +133,55 @@ class OpenAI::Test::UtilHeaderHandlingTest < Minitest::Test
 end
 
 class OpenAI::Test::UtilUriHandlingTest < Minitest::Test
+  def test_decoding_query
+    assert_equal(
+      {"name" => ["first last", "✓"], "path" => ["/v1/files"]},
+      OpenAI::Internal::Util.decode_query("name=first+last&name=%E2%9C%93&path=%2Fv1%2Ffiles")
+    )
+  end
+
+  def test_decoding_query_with_semicolon_separators_and_empty_segments
+    assert_equal(
+      {"first" => ["1"], "second" => ["2"]},
+      OpenAI::Internal::Util.decode_query("&&first=1;;second=2&")
+    )
+  end
+
+  def test_decoding_query_with_valueless_keys
+    assert_equal(
+      {"flag" => [], "empty" => [""]},
+      OpenAI::Internal::Util.decode_query("flag&empty=&flag")
+    )
+  end
+
+  def test_decoding_query_with_malformed_percent_escapes
+    assert_equal(
+      {"%" => ["100%"], "mixed" => ["A%GGB"], "tail" => ["%+"]},
+      OpenAI::Internal::Util.decode_query("%=100%&mixed=%41%GG%42&tail=%+")
+    )
+  end
+
+  def test_decoding_query_preserves_binary_and_invalid_utf8
+    binary = OpenAI::Internal::Util.decode_query("value=%FF".b).fetch("value").fetch(0)
+    invalid_utf8 = OpenAI::Internal::Util.decode_query("value=%FF").fetch("value").fetch(0)
+
+    assert_equal("\xFF".b, binary)
+    assert_equal(Encoding::BINARY, binary.encoding)
+    assert_equal("\xFF".b, invalid_utf8.b)
+    assert_equal(Encoding::UTF_8, invalid_utf8.encoding)
+    refute_predicate(invalid_utf8, :valid_encoding?)
+  end
+
+  def test_decoding_query_default
+    decoded = OpenAI::Internal::Util.decode_query(nil)
+    default = decoded["missing"]
+
+    assert_equal({}, decoded)
+    assert_equal([], default)
+    assert_predicate(default, :frozen?)
+    refute_includes(decoded, "missing")
+  end
+
   def test_parsing
     %w[
       http://example.com


### PR DESCRIPTION
## Summary

- replace `CGI.parse` in internal query decoding with a small `URI`-based implementation
- preserve duplicate keys, decoding, semicolon separators, valueless keys, empty segments, malformed percent escapes, binary/invalid UTF-8 bytes, and the frozen non-inserting hash default
- remove `cgi` from the gem runtime load/dependency/manifest graph while retaining it as a development/test dependency for existing multipart tests

## Consumer graph

The built gem's direct runtime dependencies drop from four to three:

- before: `base64`, `cgi`, `connection_pool`, `logger`
- after: `base64`, `connection_pool`, `logger`

## Validation

- `bundle check`
- focused util, client options, path-parameter query, and path-encoding tests: 60 runs / 272 assertions
- package test: 1 run / 8 assertions
- built-gem runtime dependency inspection
- Sorbet and RBS validation
- RuboCop, rubyfmt, RBS formatting, and suppression-directive checks
- full non-live suite excluding one sandbox-specific Realtime proxy test: 926 runs / 4,893 assertions / 0 failures / 0 errors
- 1,111,111 exhaustive query-parser differential cases against `CGI.parse`
- 500,000 randomized byte-query differential cases across UTF-8, binary, US-ASCII, ISO-8859-1, and Shift_JIS

The complete local runner consistently reaches 927 runs / 4,893 assertions with only `RealtimeNetworkInvariantsTest#test_http_proxy_uses_connect_and_isolates_proxy_and_origin_credentials` erroring before the local proxy accepts a connection in this sandbox. The six neighboring network-invariant tests pass; CI remains authoritative for the full supported environment and Ruby 3.3/3.4/4.0 matrix.