### PR TITLE
Keep example E2E artifacts metadata-only

### DIFF
--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: examples-e2e-${{ github.run_id }}
-          path: ${{ runner.temp }}/examples-e2e
+          path: |
+            ${{ runner.temp }}/examples-e2e/report.json
+            ${{ runner.temp }}/examples-e2e/summary.md
           if-no-files-found: warn
           retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,11 +123,11 @@ which makes no API requests:
 $ bundle exec rake test:examples:inventory
 ```
 
-Failed live examples currently include captured stdout and stderr in their
-reports, and the live CI workflow uploads those reports even on failure. Do not
-run the live suite or workflow until captured output and reports redact or omit
-credentials, customer data, and other sensitive prompts, model responses, or
-uploaded files. Only run the suite after those safeguards are in place:
+Live reports include example paths, pass/fail status, timing, and structural
+failure diagnostics. Existing stdout/stderr report fields remain present but are
+always null. Captured output and exception messages are omitted from JSON
+reports, Markdown summaries, and the explicitly selected CI artifacts. Running
+the live suite still makes real API requests:
 
 ```bash
 $ bundle exec rake test:examples:e2e

--- a/scripts/examples-e2e.rb
+++ b/scripts/examples-e2e.rb
@@ -43,8 +43,8 @@ module OpenAIExamplesE2E
             successful: result.success,
             duration_seconds: result.duration_seconds,
             error: result.error,
-            stdout: result.success ? nil : result.stdout,
-            stderr: result.success ? nil : result.stderr
+            stdout: nil,
+            stderr: nil
           }
         end,
         exclusions: excluded_examples.to_h { [_1.path, _1.reason] }
@@ -244,7 +244,7 @@ module OpenAIExamplesE2E
         duration_seconds: duration.round(2),
         stdout: truncate(stdout_value),
         stderr: truncate(stderr_value),
-        error: "runner error: #{e.class}: #{e.message}"
+        error: "runner error: #{e.class}"
       )
     end
 
@@ -264,7 +264,7 @@ module OpenAIExamplesE2E
       return "example timed out after #{@timeout} seconds" if timed_out
       return "example exited with status #{status.exitstatus}" unless status.success?
       if example.expected_output && !output.include?(example.expected_output)
-        return "expected output not found: #{example.expected_output}"
+        return "expected output not found"
       end
 
       if example.minimum_output_bytes && output.bytesize < example.minimum_output_bytes

--- a/test/scripts/examples_e2e_test.rb
+++ b/test/scripts/examples_e2e_test.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "minitest/mock"
+require "open3"
 require "pathname"
+require "rbconfig"
 require "tmpdir"
 require "yaml"
 
@@ -44,6 +47,322 @@ class ExamplesE2EInventoryTest < Minitest::Test
       )
 
       yield(OpenAIExamplesE2E::Inventory.new(root: root, manifest_path: manifest_path))
+    end
+  end
+end
+
+class ExamplesE2EReportSecurityTest < Minitest::Test
+  MODEL_RESPONSE = "FAKE_PRIVATE_MODEL_RESPONSE"
+  ACCESS_TOKEN = "fake-access-token-example"
+  SIGNED_URL = "https://example.test/download?sig=fake-signed-url-secret"
+  EXCEPTION_BODY = "FAKE_PRIVATE_EXCEPTION_BODY"
+
+  def test_failed_subprocess_streams_never_enter_report_representations
+    with_example(source: sensitive_failing_example) do |root, example|
+      result = OpenAIExamplesE2E::Executor.new(root: root, timeout: 5).call(example)
+      report = report_for(result)
+      serialized_result = report.to_h.fetch(:results).fetch(0)
+
+      refute(result.success)
+      assert_equal("example exited with status 7", result.error)
+      assert_includes(result.stdout, MODEL_RESPONSE)
+      assert_includes(result.stdout, ACCESS_TOKEN)
+      assert_includes(result.stdout, SIGNED_URL)
+      assert_includes(result.stderr, EXCEPTION_BODY)
+      assert_nil(serialized_result.fetch(:stdout))
+      assert_nil(serialized_result.fetch(:stderr))
+      assert_kind_of(Numeric, serialized_result.fetch(:duration_seconds))
+      assert_reports_exclude(report, MODEL_RESPONSE, ACCESS_TOKEN, SIGNED_URL, EXCEPTION_BODY)
+    end
+  end
+
+  def test_result_constructor_and_report_preserve_legacy_field_contract
+    assert_equal(
+      %i[path success duration_seconds stdout stderr error],
+      OpenAIExamplesE2E::Result.members
+    )
+    result = OpenAIExamplesE2E::Result.new(
+      path: "examples/example.rb",
+      success: false,
+      duration_seconds: 0.25,
+      stdout: MODEL_RESPONSE,
+      stderr: SIGNED_URL,
+      error: "example exited with status 7"
+    )
+
+    assert_equal(MODEL_RESPONSE, result.stdout)
+    assert_equal(SIGNED_URL, result.stderr)
+    serialized_result = report_for(result).to_h.fetch(:results).fetch(0)
+    assert_equal(%i[path successful duration_seconds error stdout stderr], serialized_result.keys)
+    assert_nil(serialized_result.fetch(:stdout))
+    assert_nil(serialized_result.fetch(:stderr))
+    assert_reports_exclude(report_for(result), MODEL_RESPONSE, SIGNED_URL)
+  end
+
+  def test_successful_subprocess_streams_never_enter_report_representations
+    source = <<~RUBY
+      puts #{MODEL_RESPONSE.dump}
+      warn #{SIGNED_URL.dump}
+    RUBY
+
+    with_example(source: source, expected_output: MODEL_RESPONSE) do |root, example|
+      result = OpenAIExamplesE2E::Executor.new(root: root, timeout: 5).call(example)
+      report = report_for(result)
+
+      assert(result.success)
+      assert_nil(result.error)
+      assert_equal("#{MODEL_RESPONSE}\n", result.stdout)
+      assert_equal("#{SIGNED_URL}\n", result.stderr)
+      assert_reports_exclude(report, MODEL_RESPONSE, SIGNED_URL)
+      assert_includes(report.to_markdown, "| `examples/example.rb` | passed |")
+    end
+  end
+
+  def test_executor_preserves_stream_truncation_without_serializing_output
+    output = ("x" * OpenAIExamplesE2E::Executor::MAX_CAPTURED_CHARACTERS) + MODEL_RESPONSE
+
+    with_example(source: "print #{output.dump}\n", expected_output: MODEL_RESPONSE) do |root, example|
+      result = OpenAIExamplesE2E::Executor.new(root: root, timeout: 5).call(example)
+
+      assert(result.success)
+      assert_match(/\A\.\.\. output truncated \.\.\.\n/, result.stdout)
+      assert(result.stdout.end_with?(MODEL_RESPONSE))
+      assert_reports_exclude(report_for(result), MODEL_RESPONSE)
+    end
+  end
+
+  def test_missing_expected_output_never_enters_failure_diagnostics
+    with_example(source: "puts 'ordinary output'\n", expected_output: MODEL_RESPONSE) do |root, example|
+      result = OpenAIExamplesE2E::Executor.new(root: root, timeout: 5).call(example)
+
+      assert_equal("expected output not found", result.error)
+      assert_reports_exclude(report_for(result), MODEL_RESPONSE)
+    end
+  end
+
+  def test_runner_exception_messages_never_enter_failure_diagnostics
+    with_example(source: "puts 'ordinary output'\n") do |root, example|
+      failing_path = lambda do |*_arguments|
+        raise RuntimeError, "#{EXCEPTION_BODY} #{ACCESS_TOKEN} #{SIGNED_URL}"
+      end
+
+      result = root.stub(:join, failing_path) do
+        OpenAIExamplesE2E::Executor.new(root: root, timeout: 5).call(example)
+      end
+
+      assert_equal("runner error: RuntimeError", result.error)
+      assert_reports_exclude(report_for(result), EXCEPTION_BODY, ACCESS_TOKEN, SIGNED_URL)
+    end
+  end
+
+  def test_output_size_failures_retain_only_structural_diagnostics
+    with_example(source: "print #{MODEL_RESPONSE.dump}\n") do |root, example|
+      example = example.with(expected_output: nil, minimum_output_bytes: 100)
+      result = OpenAIExamplesE2E::Executor.new(root: root, timeout: 5).call(example)
+
+      assert_equal("expected at least 100 output bytes, got #{MODEL_RESPONSE.bytesize}", result.error)
+      assert_equal(MODEL_RESPONSE, result.stdout)
+      assert_reports_exclude(report_for(result), MODEL_RESPONSE)
+    end
+  end
+
+  def test_written_reports_and_github_step_summary_exclude_sensitive_output
+    with_example(source: sensitive_failing_example) do |root, _example|
+      report_directory = root.join("artifacts")
+      step_summary = root.join("github-step-summary.md")
+      output, error_output, status = run_cli(
+        root: root,
+        report_directory: report_directory,
+        step_summary: step_summary
+      )
+
+      assert_equal(1, status.exitstatus, error_output)
+
+      artifact_paths = report_directory.children.sort
+      assert_equal(%w[report.json summary.md], artifact_paths.map { _1.basename.to_s })
+      [*artifact_paths, step_summary].each do |path|
+        [MODEL_RESPONSE, ACCESS_TOKEN, SIGNED_URL, EXCEPTION_BODY].each do |sensitive_value|
+          refute_includes(path.read, sensitive_value, "#{path.basename} exposed sensitive example output")
+        end
+      end
+
+      report = JSON.parse(report_directory.join("report.json").read)
+      assert_equal(%w[inventory successful results exclusions], report.keys)
+      assert_equal({"covered" => 1, "excluded" => 0, "total" => 1, "percentage" => 100.0}, report["inventory"])
+      refute(report["successful"])
+      serialized_result = report.fetch("results").fetch(0)
+      assert_equal(%w[path successful duration_seconds error stdout stderr], serialized_result.keys)
+      assert_equal("example exited with status 7", serialized_result.fetch("error"))
+      assert_nil(serialized_result.fetch("stdout"))
+      assert_nil(serialized_result.fetch("stderr"))
+      assert_includes(output, "FAILED: example exited with status 7")
+      [MODEL_RESPONSE, ACCESS_TOKEN, SIGNED_URL, EXCEPTION_BODY].each do |sensitive_value|
+        refute_includes(output, sensitive_value, "runner output exposed sensitive example output")
+      end
+    end
+  end
+
+  def test_successful_cli_preserves_exit_status_report_names_and_schema
+    with_example(source: "puts 'expected output'\n") do |root, _example|
+      report_directory = root.join("artifacts")
+      output, error_output, status = run_cli(
+        root: root,
+        report_directory: report_directory,
+        arguments: ["--timeout", "5"]
+      )
+
+      assert_equal(0, status.exitstatus, error_output)
+      assert_includes(output, "passed")
+      assert_equal(%w[report.json summary.md], report_directory.children.sort.map { _1.basename.to_s })
+      report = JSON.parse(report_directory.join("report.json").read)
+      assert(report.fetch("successful"))
+      serialized_result = report.fetch("results").fetch(0)
+      assert_equal(%w[path successful duration_seconds error stdout stderr], serialized_result.keys)
+      assert_nil(serialized_result.fetch("error"))
+      assert_nil(serialized_result.fetch("stdout"))
+      assert_nil(serialized_result.fetch("stderr"))
+    end
+  end
+
+  def test_inventory_only_cli_runs_without_api_key_and_preserves_report_schema
+    with_example(source: "puts 'expected output'\n") do |root, _example|
+      report_directory = root.join("artifacts")
+      output, error_output, status = run_cli(
+        root: root,
+        report_directory: report_directory,
+        arguments: ["--inventory-only"],
+        api_key: nil
+      )
+
+      assert_equal(0, status.exitstatus, error_output)
+      refute_includes(output, "==> examples/example.rb")
+      report = JSON.parse(report_directory.join("report.json").read)
+      assert_equal(%w[inventory successful results exclusions], report.keys)
+      assert_equal([], report.fetch("results"))
+      assert(report.fetch("successful"))
+      assert_includes(report_directory.join("summary.md").read, "100.00% exercised (1/1 examples)")
+    end
+  end
+
+  def test_live_cli_without_api_key_preserves_configuration_failure
+    with_example(source: "puts 'expected output'\n") do |root, _example|
+      report_directory = root.join("artifacts")
+      _output, error_output, status = run_cli(root: root, report_directory: report_directory, api_key: nil)
+
+      assert_equal(1, status.exitstatus)
+      assert_includes(error_output, "ERROR: OPENAI_API_KEY is required to run live example tests")
+      refute(report_directory.exist?)
+    end
+  end
+
+  def test_invalid_cli_argument_preserves_parse_failure
+    with_example(source: "puts 'expected output'\n") do |root, _example|
+      report_directory = root.join("artifacts")
+      _output, error_output, status = run_cli(
+        root: root,
+        report_directory: report_directory,
+        arguments: ["--unknown-option"]
+      )
+
+      assert_equal(1, status.exitstatus)
+      assert_includes(error_output, "ERROR: invalid option: --unknown-option")
+      refute(report_directory.exist?)
+    end
+  end
+
+  def test_workflow_uploads_only_allowlisted_report_files
+    workflow_path = File.expand_path("../../.github/workflows/examples-e2e.yml", __dir__)
+    workflow = YAML.safe_load_file(workflow_path, aliases: false)
+    job = workflow.fetch("jobs").fetch("examples-e2e")
+    upload_step = job.fetch("steps").find { _1["name"] == "Upload example result reports" }
+
+    assert_equal(
+      ["${{ runner.temp }}/examples-e2e/report.json", "${{ runner.temp }}/examples-e2e/summary.md"],
+      upload_step.fetch("with").fetch("path").lines.map(&:strip)
+    )
+    assert_equal("${{ always() }}", upload_step.fetch("if"))
+    assert_equal(14, upload_step.fetch("with").fetch("retention-days"))
+    job.fetch("steps").filter_map { _1["uses"] }.each do |action|
+      assert_match(%r{@[0-9a-f]{40}\z}, action)
+    end
+
+    assert_equal({}, workflow.fetch("permissions"))
+    assert_equal({"contents" => "read"}, job.fetch("permissions"))
+    assert_equal("ci", job.fetch("environment"))
+    assert_includes(job.fetch("if"), "github.ref == 'refs/heads/main'")
+    assert_includes(job.fetch("if"), "github.repository == 'openai/openai-ruby'")
+    assert_equal(false, job.fetch("steps").fetch(0).fetch("with").fetch("persist-credentials"))
+  end
+
+  private
+
+  def sensitive_failing_example
+    <<~RUBY
+      puts "model response: #{MODEL_RESPONSE}"
+      puts "Authorization: Bearer #{ACCESS_TOKEN}"
+      puts #{SIGNED_URL.dump}
+      warn "RuntimeError: #{EXCEPTION_BODY}"
+      exit 7
+    RUBY
+  end
+
+  def with_example(source:, expected_output: "expected output")
+    Dir.mktmpdir("openai-examples-e2e-security-test") do |directory|
+      root = Pathname(directory)
+      example_path = root.join("examples/example.rb")
+      example_path.dirname.mkpath
+      example_path.write(source)
+      root.join("examples/e2e.yml").write(
+        YAML.dump(
+          "version" => 1,
+          "examples" => {
+            "examples/example.rb" => {"status" => "covered", "expected_output" => expected_output}
+          }
+        )
+      )
+
+      example = OpenAIExamplesE2E::Example.new(
+        path: "examples/example.rb",
+        status: "covered",
+        expected_output: expected_output,
+        minimum_output_bytes: nil,
+        reason: nil
+      )
+      yield(root, example)
+    end
+  end
+
+  def report_for(result)
+    inventory = OpenAIExamplesE2E::InventorySummary.new(
+      covered: 1,
+      excluded: 0,
+      total: 1,
+      percentage: 100.0
+    )
+    OpenAIExamplesE2E::Report.new(inventory: inventory, results: [result], excluded_examples: [])
+  end
+
+  def run_cli(root:, report_directory:, arguments: [], step_summary: nil, api_key: "sk-fake-examples-e2e-test")
+    runner_path = File.expand_path("../../scripts/examples-e2e.rb", __dir__)
+    Open3.capture3(
+      {"OPENAI_API_KEY" => api_key, "GITHUB_STEP_SUMMARY" => step_summary&.to_s},
+      RbConfig.ruby,
+      "-r",
+      runner_path,
+      "-e",
+      "exit(OpenAIExamplesE2E::CLI.new(root: ARGV.shift).run(ARGV))",
+      root.to_s,
+      "--report-dir",
+      report_directory.to_s,
+      *arguments
+    )
+  end
+
+  def assert_reports_exclude(report, *sensitive_values)
+    {"JSON" => JSON.generate(report.to_h), "Markdown" => report.to_markdown}.each do |format, contents|
+      sensitive_values.each do |sensitive_value|
+        refute_includes(contents, sensitive_value, "#{format} report exposed sensitive example output")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Keep example E2E reports metadata-only while preserving the existing JSON field names, CLI behavior, report filenames, and in-memory result contract.
- Omit subprocess output and untrusted failure-message bodies from JSON reports, Markdown summaries, workflow artifacts, and runner logs.
- Upload only the two expected report files without changing the workflow trigger, protected environment, action pins, permissions, or retention.
- Add focused coverage for report compatibility, artifact contents, failure paths, truncation, and Ruby 3.3/3.4/4.0 support.

## Validation
- `mise exec ruby@4.0.6 -- bundle exec rake test` (936 tests, 5,071 assertions; one intentionally disabled live Bedrock test skipped)
- `mise exec ruby@4.0.6 -- bundle exec rake lint` (2,700 Ruby files and 1,236 RBS files)
- `mise exec ruby@3.3.12 -- bundle exec ruby test/scripts/examples_e2e_test.rb`
- `mise exec ruby@3.4.10 -- bundle exec ruby test/scripts/examples_e2e_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/examples_e2e_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec rake test:examples:inventory`