### PR TITLE
fix: Validate multipart file content types

### DIFF
--- a/lib/openai/file_part.rb
+++ b/lib/openai/file_part.rb
@@ -2,7 +2,7 @@
 
 module OpenAI
   class FilePart
-    # HTTP media types contain ASCII tokens and optional token or quoted-string parameters.
+    # HTTP media types contain ASCII tokens and possibly empty parameter slots.
     # Quoted values may contain horizontal whitespace and non-ASCII header bytes, but
     # never CR, LF, NUL, other forbidden control bytes, or an unescaped quote.
     #
@@ -15,13 +15,15 @@ module OpenAI
       [!#$%&'*+\-.^_`|~0-9A-Za-z]+
       (?:
         [\x20\t]*;[\x20\t]*
-        [!#$%&'*+\-.^_`|~0-9A-Za-z]+
-        [\x20\t]*=[\x20\t]*
         (?:
           [!#$%&'*+\-.^_`|~0-9A-Za-z]+
-          |
-          "(?:[\x20\t\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\[\x20\t\x21-\x7E\x80-\xFF])*"
-        )
+          [\x20\t]*=[\x20\t]*
+          (?:
+            [!#$%&'*+\-.^_`|~0-9A-Za-z]+
+            |
+            "(?:[\x20\t\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\[\x20\t\x21-\x7E\x80-\xFF])*"
+          )
+        )?
       )*
       [\x20\t]*
       \z

--- a/lib/openai/file_part.rb
+++ b/lib/openai/file_part.rb
@@ -2,11 +2,43 @@
 
 module OpenAI
   class FilePart
+    # HTTP media types contain ASCII tokens and optional token or quoted-string parameters.
+    # Quoted values may contain horizontal whitespace and non-ASCII header bytes, but
+    # never CR, LF, NUL, other forbidden control bytes, or an unescaped quote.
+    #
+    # @api private
+    # @type [Regexp]
+    MEDIA_TYPE = %r{
+      \A
+      [!#$%&'*+\-.^_`|~0-9A-Za-z]+
+      /
+      [!#$%&'*+\-.^_`|~0-9A-Za-z]+
+      (?:
+        [\x20\t]*;[\x20\t]*
+        [!#$%&'*+\-.^_`|~0-9A-Za-z]+
+        [\x20\t]*=[\x20\t]*
+        (?:
+          [!#$%&'*+\-.^_`|~0-9A-Za-z]+
+          |
+          "(?:[\x20\t\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\[\x20\t\x21-\x7E\x80-\xFF])*"
+        )
+      )*
+      [\x20\t]*
+      \z
+    }nx
+    private_constant :MEDIA_TYPE
+
     # @return [Pathname, StringIO, IO, String]
     attr_reader :content
 
     # @return [String, nil]
-    attr_reader :content_type
+    # @raise [ArgumentError] if the content type is not a valid MIME media type
+    def content_type
+      return if @content_type.nil?
+      return @content_type if @content_type.is_a?(String) && MEDIA_TYPE.match?(@content_type.b)
+
+      raise ArgumentError, "`content_type` must be a valid MIME media type"
+    end
 
     # @return [String, nil]
     attr_reader :filename
@@ -62,7 +94,12 @@ module OpenAI
     # @param content [Pathname, StringIO, IO, String]
     # @param filename [Pathname, String, nil]
     # @param content_type [String, nil]
+    # @raise [ArgumentError] if the content type is not a valid MIME media type
     def initialize(content, filename: nil, content_type: nil)
+      unless content_type.nil? || (content_type.is_a?(String) && MEDIA_TYPE.match?(content_type.b))
+        raise ArgumentError, "`content_type` must be a valid MIME media type"
+      end
+
       @content_type = content_type
       @filename = case [filename, (@content = content)]
       in [String | Pathname, _]

--- a/lib/openai/file_part.rb
+++ b/lib/openai/file_part.rb
@@ -30,16 +30,26 @@ module OpenAI
     }nx
     private_constant :MEDIA_TYPE
 
+    # Validate an effective media type before it is written to multipart headers.
+    #
+    # @api private
+    # @param content_type [String, nil]
+    # @return [String, nil]
+    # @raise [ArgumentError] if the content type is not a valid MIME media type
+    def self.validate_content_type(content_type)
+      return if content_type.nil?
+      return content_type if content_type.is_a?(String) && MEDIA_TYPE.match?(content_type.b)
+
+      raise ArgumentError, "`content_type` must be a valid MIME media type"
+    end
+
     # @return [Pathname, StringIO, IO, String]
     attr_reader :content
 
     # @return [String, nil]
     # @raise [ArgumentError] if the content type is not a valid MIME media type
     def content_type
-      return if @content_type.nil?
-      return @content_type if @content_type.is_a?(String) && MEDIA_TYPE.match?(@content_type.b)
-
-      raise ArgumentError, "`content_type` must be a valid MIME media type"
+      OpenAI::FilePart.validate_content_type(@content_type)
     end
 
     # @return [String, nil]
@@ -98,10 +108,7 @@ module OpenAI
     # @param content_type [String, nil]
     # @raise [ArgumentError] if the content type is not a valid MIME media type
     def initialize(content, filename: nil, content_type: nil)
-      unless content_type.nil? || (content_type.is_a?(String) && MEDIA_TYPE.match?(content_type.b))
-        raise ArgumentError, "`content_type` must be a valid MIME media type"
-      end
-
+      OpenAI::FilePart.validate_content_type(content_type)
       @content_type = content_type
       @filename = case [filename, (@content = content)]
       in [String | Pathname, _]

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -498,7 +498,7 @@ module OpenAI
               y,
               val: val.content,
               closing: closing,
-              content_type: val.content_type
+              content_type: OpenAI::FilePart.validate_content_type(val.content_type)
             )
           in Pathname
             y << format(content_line, content_type || "application/octet-stream")

--- a/rbi/openai/file_part.rbi
+++ b/rbi/openai/file_part.rbi
@@ -2,6 +2,11 @@
 
 module OpenAI
   class FilePart
+    # @api private
+    sig { params(content_type: T.nilable(String)).returns(T.nilable(String)) }
+    def self.validate_content_type(content_type)
+    end
+
     sig { returns(T.any(Pathname, StringIO, IO, String)) }
     attr_reader :content
 

--- a/sig/openai/file_part.rbs
+++ b/sig/openai/file_part.rbs
@@ -1,5 +1,8 @@
 module OpenAI
   class FilePart
+    # @api private
+    def self.validate_content_type: (String? content_type) -> String?
+
     attr_reader content: Pathname | StringIO | IO | String
 
     attr_reader content_type: String?

--- a/test/openai/file_part_test.rb
+++ b/test/openai/file_part_test.rb
@@ -234,7 +234,10 @@ class OpenAI::Test::FilePartTest < Minitest::Test
       content_types = [
         "text/plain; name=before#{byte.chr}after",
         "text/plain; name=\"before#{byte.chr}after\"",
-        "text/plain; name=\"before\\#{byte.chr}after\""
+        "text/plain; name=\"before\\#{byte.chr}after\"",
+        "text/plain;#{byte.chr}",
+        "text/plain;;#{byte.chr}charset=UTF-8",
+        "text/plain; ;#{byte.chr};charset=UTF-8"
       ]
 
       content_types.each do |content_type|
@@ -256,7 +259,6 @@ class OpenAI::Test::FilePartTest < Minitest::Test
       "text /plain",
       "text/plain header",
       "text/plain: header",
-      "text/plain;",
       "text/plain; charset",
       "text/plain; =UTF-8",
       "text/plain; charset=",
@@ -298,6 +300,24 @@ class OpenAI::Test::FilePartTest < Minitest::Test
     end
 
     assert_nil(OpenAI::FilePart.new("contents").content_type)
+  end
+
+  def test_content_type_preserves_empty_parameter_slots
+    valid = [
+      "text/plain;",
+      "text/plain;;charset=UTF-8",
+      "text/plain; ; charset=UTF-8; ",
+      "text/plain;\t;\tcharset=UTF-8;\t;",
+      "text/plain; charset=UTF-8;;format=flowed;",
+      "text/plain; ; title=\"report; final.txt\"; ;"
+    ]
+
+    valid.each do |content_type|
+      file = OpenAI::FilePart.new("contents", content_type: content_type)
+
+      assert_equal(content_type, file.content_type)
+      assert_equal(content_type, file.with_content(Pathname("replacement")).content_type)
+    end
   end
 
   def test_content_type_revalidates_metadata_mutated_after_construction

--- a/test/openai/file_part_test.rb
+++ b/test/openai/file_part_test.rb
@@ -139,4 +139,191 @@ class OpenAI::Test::FilePartTest < Minitest::Test
       assert_equal(original.filename, copy.filename)
     end
   end
+
+  def test_public_constructor_and_accessor_contracts_remain_unchanged
+    assert_equal(
+      [[:req, :content], [:key, :filename], [:key, :content_type]],
+      OpenAI::FilePart.instance_method(:initialize).parameters
+    )
+    assert(OpenAI::FilePart.private_method_defined?(:initialize))
+
+    [:content, :content_type, :filename, :with_content].each do |name|
+      assert(OpenAI::FilePart.public_method_defined?(name), "#{name} must remain public")
+    end
+
+    [:content=, :content_type=].each do |name|
+      assert(OpenAI::FilePart.protected_method_defined?(name), "#{name} must remain protected")
+    end
+  end
+
+  def test_constructor_preserves_file_inputs_and_filename_derivation
+    io = File.open(__FILE__, "rb")
+    pathname = Pathname(__FILE__)
+    string_io = StringIO.new("contents")
+    inputs = {
+      "contents" => nil,
+      string_io => nil,
+      io => File.basename(io.to_path),
+      pathname => pathname.basename.to_path
+    }
+
+    inputs.each do |content, filename|
+      file = OpenAI::FilePart.new(content)
+
+      assert_same(content, file.content)
+      if filename.nil?
+        assert_nil(file.filename)
+      else
+        assert_equal(filename, file.filename)
+      end
+
+      assert_nil(file.content_type)
+    end
+
+    explicit = OpenAI::FilePart.new(string_io, filename: Pathname("nested/custom.txt"))
+    assert_equal("custom.txt", explicit.filename)
+
+  ensure
+    io&.close
+  end
+
+  def test_constructor_does_not_call_overridden_accessors_before_initialization
+    subclass = Class.new(OpenAI::FilePart) do
+      def content_type
+        raise "content was not initialized" if content.nil?
+
+        super
+      end
+    end
+
+    file = subclass.new("contents", filename: "safe.txt", content_type: "text/plain")
+
+    assert_equal("contents", file.content)
+    assert_equal("safe.txt", file.filename)
+    assert_equal("text/plain", file.content_type)
+  end
+
+  def test_content_type_rejects_multipart_header_injection_for_every_file_input
+    io = File.open(__FILE__, "rb")
+    inputs = ["contents", StringIO.new("contents"), io, Pathname(__FILE__)]
+    content_types = [
+      "text/plain\r\nX-Injected: yes",
+      "text/plain\nX-Injected: yes",
+      "text/plain\rX-Injected: yes",
+      "text/plain\r\n\r\ninjected-body"
+    ]
+
+    inputs.each do |input|
+      content_types.each do |content_type|
+        error = assert_raises(ArgumentError, "#{input.class}: #{content_type.inspect}") do
+          OpenAI::FilePart.new(input, filename: "safe.txt", content_type: content_type)
+        end
+
+        assert_match("valid MIME media type", error.message)
+      end
+    end
+
+  ensure
+    io&.close
+  end
+
+  def test_content_type_rejects_every_forbidden_ascii_control_character
+    forbidden = (0..31).reject { _1 == 9 }.append(127)
+
+    forbidden.each do |byte|
+      content_types = [
+        "text/plain; name=before#{byte.chr}after",
+        "text/plain; name=\"before#{byte.chr}after\"",
+        "text/plain; name=\"before\\#{byte.chr}after\""
+      ]
+
+      content_types.each do |content_type|
+        assert_raises(ArgumentError, "control byte #{byte}: #{content_type.inspect}") do
+          OpenAI::FilePart.new("contents", content_type: content_type)
+        end
+      end
+    end
+  end
+
+  def test_content_type_requires_a_complete_media_type_and_valid_parameters
+    invalid = [
+      "",
+      "text",
+      "/plain",
+      "text/",
+      "text/plain/extra",
+      " text/plain",
+      "text /plain",
+      "text/plain header",
+      "text/plain: header",
+      "text/plain;",
+      "text/plain; charset",
+      "text/plain; =UTF-8",
+      "text/plain; charset=",
+      "text/plain; charset=two words",
+      "text/plain; charset=UT\tF-8",
+      "text/plain; name=\"unterminated",
+      "text/plain; name=\"closed\"trailing"
+    ]
+
+    invalid.each do |content_type|
+      assert_raises(ArgumentError, content_type.inspect) do
+        OpenAI::FilePart.new("contents", content_type: content_type)
+      end
+    end
+  end
+
+  def test_content_type_preserves_valid_media_types_and_parameters
+    valid = [
+      "text/plain",
+      "TEXT/PLAIN",
+      "application/vnd.openai.result+json",
+      "application/x-custom_type.v2",
+      "multipart/form-data; boundary=----safe-boundary",
+      "text/plain; charset=UTF-8; format=flowed",
+      "text/plain;\tcharset = \tUTF-8\t",
+      "text/plain; name=\"report; final.txt\"; title=\"draft \\\"one\\\"\"",
+      "text/plain; title=\"caf\u00e9\"",
+      "text/plain; title=\"\"",
+      "text/plain; title=\"a\tb\"",
+      "text/plain; filename*=UTF-8''report%20final.txt",
+      "Text/Plain; CHARSET=Utf-8 \t"
+    ]
+
+    valid.each do |content_type|
+      file = OpenAI::FilePart.new("contents", content_type: content_type)
+
+      assert_equal(content_type, file.content_type)
+      assert_equal(content_type, file.with_content(Pathname("replacement")).content_type)
+    end
+
+    assert_nil(OpenAI::FilePart.new("contents").content_type)
+  end
+
+  def test_content_type_revalidates_metadata_mutated_after_construction
+    content_type = +"text/plain"
+    file = OpenAI::FilePart.new("contents", content_type: content_type)
+
+    content_type << "\r\nX-Injected: yes"
+
+    assert_raises(ArgumentError) { file.content_type }
+    assert_raises(ArgumentError) { file.with_content(Pathname("replacement")) }
+  end
+
+  def test_content_type_preserves_string_identity_and_safe_mutation
+    content_type = +"text/plain"
+    file = OpenAI::FilePart.new("contents", content_type: content_type)
+
+    assert_same(content_type, file.content_type)
+
+    content_type.replace("application/json; charset=UTF-8")
+    assert_same(content_type, file.content_type)
+    assert_equal("application/json; charset=UTF-8", file.content_type)
+
+    frozen_content_type = "image/jpeg".freeze
+    frozen_file = OpenAI::FilePart.new("contents", content_type: frozen_content_type)
+
+    assert_same(frozen_content_type, frozen_file.content_type)
+    assert_equal("image/jpeg", frozen_file.freeze.content_type)
+  end
 end

--- a/test/openai/internal/multipart_content_type_test.rb
+++ b/test/openai/internal/multipart_content_type_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
+  def test_direct_uploads_and_upload_parts_reject_mutated_mime_header_injection
+    inputs = {
+      "String" => -> { "contents" },
+      "StringIO" => -> { StringIO.new("contents") },
+      "IO" => -> { File.open(__FILE__, "rb") },
+      "pathless IO" => -> { pathless_io },
+      "Pathname" => -> { Pathname(__FILE__) }
+    }
+    payloads = ["text/plain\r\nX-Injected: yes", "text/plain\r\n\r\ninjected-body"]
+
+    inputs.each do |input_name, input_factory|
+      [:files, :upload_parts].each do |endpoint|
+        payloads.each do |payload|
+          input = input_factory.call
+          content_type = +"text/plain"
+          file = OpenAI::FilePart.new(input, filename: "safe.txt", content_type: content_type)
+          content_type.replace(payload)
+          chunks = []
+
+          assert_raises(ArgumentError, "#{endpoint} #{input_name}: #{payload.inspect}") do
+            body = multipart_upload_body(file, endpoint: endpoint)
+            _headers, stream = OpenAI::Internal::Util.encode_content(
+              {"content-type" => "multipart/form-data"},
+              body
+            )
+            stream.each { chunks << _1 }
+          end
+
+          refute_includes(chunks.join, "\r\nX-Injected:")
+          refute_includes(chunks.join, "\r\n\r\ninjected-body")
+        ensure
+          input&.close if input.is_a?(IO) && !input.closed?
+        end
+      end
+    end
+  end
+
+  def test_direct_uploads_and_upload_parts_preserve_parameterized_content_types
+    content_type = "text/plain; charset=UTF-8; name=\"report; final.txt\""
+
+    [:files, :upload_parts].each do |endpoint|
+      file = OpenAI::FilePart.new(
+        StringIO.new("contents"),
+        filename: "a \"b\"\r\nEvil: 1.md",
+        content_type: content_type
+      )
+      body = multipart_upload_body(file, endpoint: endpoint)
+      _headers, stream = OpenAI::Internal::Util.encode_content(
+        {"content-type" => "multipart/form-data"},
+        body
+      )
+      encoded = stream.to_a.join
+
+      assert_includes(encoded, "Content-Type: #{content_type}\r\n\r\ncontents")
+      assert_includes(encoded, "filename=\"a \\\"b\\\"Evil: 1.md\"")
+      refute_includes(encoded, "\r\nEvil:")
+    end
+  end
+
+  def test_uploads_preserve_default_media_types_and_raw_or_wrapped_filenames
+    inputs = {
+      "String" => [-> { "contents" }, "text/plain"],
+      "StringIO" => [-> { StringIO.new("contents") }, "application/octet-stream"],
+      "IO" => [-> { File.open(__FILE__, "rb") }, "application/octet-stream"],
+      "pathless IO" => [-> { pathless_io }, "application/octet-stream"],
+      "Pathname" => [-> { Pathname(__FILE__) }, "application/octet-stream"]
+    }
+
+    inputs.each do |input_name, (input_factory, expected_content_type)|
+      [:files, :upload_parts].each do |endpoint|
+        [false, true].each do |wrapped|
+          input = input_factory.call
+          file = wrapped ? OpenAI::FilePart.new(input) : input
+          body = multipart_upload_body(file, endpoint: endpoint)
+          _headers, stream = OpenAI::Internal::Util.encode_content(
+            {"content-type" => "multipart/form-data"},
+            body
+          )
+          encoded = stream.to_a.join
+          field = endpoint == :files ? "file" : "data"
+          disposition = "Content-Disposition: form-data; name=\"#{field}\""
+          filename = expected_filename(input, wrapped: wrapped)
+          disposition += "; filename=\"#{filename}\"" unless filename.nil?
+
+          assert_includes(
+            encoded,
+            "#{disposition}\r\nContent-Type: #{expected_content_type}\r\n\r\n",
+            "#{endpoint} #{input_name} wrapped=#{wrapped}"
+          )
+        ensure
+          input&.close if input.is_a?(IO) && !input.closed?
+        end
+      end
+    end
+  end
+
+  private def multipart_upload_body(file, endpoint:)
+    case endpoint
+    when :files
+      OpenAI::FileCreateParams.dump_request(file: file, purpose: :assistants).first
+    when :upload_parts
+      OpenAI::Uploads::PartCreateParams.dump_request(data: file).first
+    end
+  end
+
+  private def expected_filename(input, wrapped:)
+    if input.is_a?(IO)
+      return input.to_path&.then { File.basename(_1) } if wrapped
+
+      return input.to_path.nil? ? "upload" : File.basename(input.to_path)
+    end
+
+    return File.basename(input.to_path) if input.is_a?(Pathname)
+
+    "upload" unless wrapped
+  end
+
+  private def pathless_io
+    reader, writer = IO.pipe
+    writer.write("contents")
+    writer.close
+    reader
+  end
+end

--- a/test/openai/internal/multipart_content_type_test.rb
+++ b/test/openai/internal/multipart_content_type_test.rb
@@ -3,6 +3,17 @@
 require_relative "../test_helper"
 
 class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
+  class OverriddenContentTypeFile < OpenAI::FilePart
+    def initialize(content, effective_content_type:)
+      @effective_content_type = effective_content_type
+      super(content, content_type: "text/plain")
+    end
+
+    def content_type
+      @effective_content_type
+    end
+  end
+
   def test_direct_uploads_and_upload_parts_reject_mutated_mime_header_injection
     inputs = {
       "String" => -> { "contents" },
@@ -42,6 +53,57 @@ class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
         ensure
           input&.close if input.is_a?(IO) && !input.closed?
         end
+      end
+    end
+  end
+
+  def test_direct_uploads_and_upload_parts_reject_overridden_mime_header_injection
+    content_types = [
+      "text/plain\r\nX-Injected: yes",
+      "text/plain\r\n\r\ninjected-body",
+      "text/plain;\r\nX-Injected: yes"
+    ]
+
+    content_types.each do |content_type|
+      [:files, :upload_parts].each do |endpoint|
+        file = OverriddenContentTypeFile.new(
+          StringIO.new("contents"),
+          effective_content_type: content_type
+        )
+        chunks = []
+
+        assert_raises(ArgumentError, "#{endpoint}: #{content_type.inspect}") do
+          body = multipart_upload_body(file, endpoint: endpoint)
+          _headers, stream = OpenAI::Internal::Util.encode_content(
+            {"content-type" => "multipart/form-data"},
+            body
+          )
+          stream.each { chunks << _1 }
+        end
+
+        refute_includes(chunks.join, "\r\nX-Injected:")
+        refute_includes(chunks.join, "\r\n\r\ninjected-body")
+      end
+    end
+  end
+
+  def test_direct_uploads_and_upload_parts_preserve_valid_overridden_content_types
+    content_types = ["text/plain; charset=UTF-8", "text/plain;;charset=UTF-8", nil]
+
+    content_types.each do |content_type|
+      [:files, :upload_parts].each do |endpoint|
+        file = OverriddenContentTypeFile.new(
+          StringIO.new("contents"),
+          effective_content_type: content_type
+        )
+        body = multipart_upload_body(file, endpoint: endpoint)
+        _headers, stream = OpenAI::Internal::Util.encode_content(
+          {"content-type" => "multipart/form-data"},
+          body
+        )
+        effective = content_type || "application/octet-stream"
+
+        assert_includes(stream.to_a.join, "Content-Type: #{effective}\r\n\r\ncontents")
       end
     end
   end

--- a/test/openai/internal/multipart_content_type_test.rb
+++ b/test/openai/internal/multipart_content_type_test.rb
@@ -11,7 +11,12 @@ class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
       "pathless IO" => -> { pathless_io },
       "Pathname" => -> { Pathname(__FILE__) }
     }
-    payloads = ["text/plain\r\nX-Injected: yes", "text/plain\r\n\r\ninjected-body"]
+    payloads = [
+      "text/plain\r\nX-Injected: yes",
+      "text/plain\r\n\r\ninjected-body",
+      "text/plain;\r\nX-Injected: yes",
+      "text/plain;;charset=UTF-8\r\n\r\ninjected-body"
+    ]
 
     inputs.each do |input_name, input_factory|
       [:files, :upload_parts].each do |endpoint|
@@ -97,6 +102,23 @@ class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
         ensure
           input&.close if input.is_a?(IO) && !input.closed?
         end
+      end
+    end
+  end
+
+  def test_direct_uploads_and_upload_parts_preserve_empty_content_type_parameter_slots
+    content_types = ["text/plain;", "text/plain;;charset=UTF-8", "text/plain; ;charset=UTF-8; "]
+
+    content_types.each do |content_type|
+      [:files, :upload_parts].each do |endpoint|
+        file = OpenAI::FilePart.new(StringIO.new("contents"), content_type: content_type)
+        body = multipart_upload_body(file, endpoint: endpoint)
+        _headers, stream = OpenAI::Internal::Util.encode_content(
+          {"content-type" => "multipart/form-data"},
+          body
+        )
+
+        assert_includes(stream.to_a.join, "Content-Type: #{content_type}\r\n\r\ncontents")
       end
     end
   end

--- a/test/openai/internal/multipart_content_type_test.rb
+++ b/test/openai/internal/multipart_content_type_test.rb
@@ -16,6 +16,7 @@ class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
     inputs.each do |input_name, input_factory|
       [:files, :upload_parts].each do |endpoint|
         payloads.each do |payload|
+          input = nil
           input = input_factory.call
           content_type = +"text/plain"
           file = OpenAI::FilePart.new(input, filename: "safe.txt", content_type: content_type)
@@ -74,6 +75,7 @@ class OpenAI::Test::MultipartContentTypeTest < Minitest::Test
     inputs.each do |input_name, (input_factory, expected_content_type)|
       [:files, :upload_parts].each do |endpoint|
         [false, true].each do |wrapped|
+          input = nil
           input = input_factory.call
           file = wrapped ? OpenAI::FilePart.new(input) : input
           body = multipart_upload_body(file, endpoint: endpoint)

--- a/test/openai/internal/vector_store_file_uploader_test.rb
+++ b/test/openai/internal/vector_store_file_uploader_test.rb
@@ -260,7 +260,7 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
     custom_part = OpenAI::FilePart.new(
       "custom-body",
       filename: "nested/custom.txt",
-      content_type: "text/custom"
+      content_type: "text/custom; charset=UTF-8; name=\"custom; file.txt\""
     )
     unnamed_part = OpenAI::FilePart.new("unnamed-body")
     file_part = OpenAI::FilePart.new(part_source_file)
@@ -297,7 +297,10 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
       ["upload", "application/octet-stream", "pipe-body"],
       metadata_and_contents(pathless_io)
     )
-    assert_equal(["custom.txt", "text/custom", "custom-body"], metadata_and_contents(part))
+    assert_equal(
+      ["custom.txt", "text/custom; charset=UTF-8; name=\"custom; file.txt\"", "custom-body"],
+      metadata_and_contents(part)
+    )
     assert_equal([nil, "text/plain", "unnamed-body"], metadata_and_contents(unnamed))
     assert_equal(
       [File.basename(part_source_file.to_path), "application/octet-stream", "file-body"],
@@ -337,6 +340,30 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
       refute_includes(body, local_path)
       refute_predicate(content, :closed?)
       refute_path_exists(staged_paths.fetch(0))
+    end
+  end
+
+  def test_upload_rejects_mutated_mime_header_injection_before_staging_metadata
+    payloads = ["text/plain\r\nX-Injected: yes", "text/plain\r\n\r\ninjected-body"]
+    original_tempfile_new = Tempfile.method(:new)
+
+    payloads.each do |payload|
+      resource = FilesResource.new { flunk("upload should not be called") }
+      content_type = +"text/plain"
+      file = OpenAI::FilePart.new(StringIO.new("contents"), content_type: content_type)
+      content_type.replace(payload)
+      staged_path = nil
+      tempfile_factory = lambda do |*args|
+        original_tempfile_new.call(*args).tap { staged_path = Pathname(_1.path) }
+      end
+
+      Tempfile.stub(:new, tempfile_factory) do
+        assert_raises(ArgumentError, payload.inspect) { uploader(resource).upload([file]) }
+      end
+
+      refute_nil(staged_path)
+      refute_predicate(staged_path, :exist?)
+      assert_empty(resource.calls)
     end
   end
 


### PR DESCRIPTION
## Summary

- Validate `OpenAI::FilePart#content_type` as a complete MIME media type before it reaches multipart headers, including revalidation when callers mutate existing metadata.
- Preserve constructor signatures, method visibility, valid MIME parameters and quoted values, filenames, upload defaults, vector-store staging, and supported Ruby versions.
- Add focused direct-upload, upload-part, String/StringIO/IO/Pathname, pathless-IO, subclass, staged-upload, and temporary-file cleanup coverage.

## Compatibility

Valid documented inputs retain their existing wire format and object behavior. Invalid media types, malformed parameters, and forbidden header control characters now raise `ArgumentError`; callers should supply a valid `type/subtype` or use `nil` for existing defaults.

## Validation

- `MT_CPU=1 mise exec ruby@4.0.6 -- bundle exec rake test` — 936 tests, 5,278 assertions, 0 failures; one credential-gated live test skipped.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — Sorbet, 1,236 RBS signatures, rubyfmt, suppression guards, and 2,701 RuboCop targets pass.
- Affected security/compatibility suites pass on Ruby 3.3, 3.4, and 4.0 (88 tests and 729 assertions per version).
- Reviewed against the pinned baseline for public/protected/private API, typed signatures, generated-file ownership, hostile MIME inputs, and bounded regex behavior.