### PR TITLE
fix: normalize filenames inferred from file handles

### DIFF
--- a/lib/openai/file_part.rb
+++ b/lib/openai/file_part.rb
@@ -70,7 +70,7 @@ module OpenAI
       in [nil, Pathname]
         content.basename.to_path
       in [nil, IO]
-        content.to_path
+        content.to_path&.then { ::File.basename(_1) }
       else
         filename
       end

--- a/test/openai/file_part_test.rb
+++ b/test/openai/file_part_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "tempfile"
 
 class OpenAI::Test::FilePartTest < Minitest::Test
   def test_to_json
@@ -9,6 +10,105 @@ class OpenAI::Test::FilePartTest < Minitest::Test
 
     assert_equal(text.to_json, filepart.to_json)
     assert_equal(text.to_yaml, filepart.to_yaml)
+  end
+
+  def test_path_backed_io_filename_uses_basename
+    File.open(__FILE__, "rb") do |content|
+      assert_equal(File.basename(content.to_path), OpenAI::FilePart.new(content).filename)
+    end
+  end
+
+  def test_path_backed_io_filename_preserves_platform_path_semantics
+    paths = [
+      "/nested/directory/document.txt",
+      "relative/directory/document.txt",
+      "C:/nested/directory/document.txt",
+      "C:\\nested\\directory\\document.txt",
+      "/nested/.hidden",
+      "/nested/report with spaces.txt",
+      ""
+    ]
+
+    File.open(__FILE__, "rb") do |content|
+      paths.each do |path|
+        content.stub(:to_path, path) do
+          assert_equal(File.basename(path), OpenAI::FilePart.new(content).filename, path)
+        end
+      end
+    end
+  end
+
+  def test_pathless_streams_have_no_filename
+    reader, writer = IO.pipe
+
+    assert_nil(OpenAI::FilePart.new(reader).filename)
+    assert_nil(OpenAI::FilePart.new(StringIO.new("contents")).filename)
+  ensure
+    reader&.close
+    writer&.close
+  end
+
+  def test_pathname_filename_uses_basename
+    content = Pathname("/nested/directory/document.txt")
+
+    assert_equal("document.txt", OpenAI::FilePart.new(content).filename)
+  end
+
+  def test_explicit_filename_takes_precedence_for_path_backed_io
+    File.open(__FILE__, "rb") do |content|
+      ["nested/override.txt", Pathname("nested/override.txt")].each do |filename|
+        file = OpenAI::FilePart.new(content, filename: filename, content_type: "text/custom")
+
+        assert_same(content, file.content)
+        assert_equal("override.txt", file.filename)
+        assert_equal("text/custom", file.content_type)
+      end
+    end
+  end
+
+  def test_generated_file_upload_preserves_public_api_and_omits_local_path
+    Tempfile.create(["upload-", ".txt"]) do |content|
+      content.write("upload-body")
+      content.rewind
+      local_path = content.to_path
+      response = OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: JSON.generate(
+          id: "file_test",
+          bytes: 11,
+          created_at: 1,
+          filename: File.basename(local_path),
+          object: "file",
+          purpose: "assistants",
+          status: "processed"
+        )
+      )
+      transport = Minitest::Mock.new(OpenAI::HTTPClient.new)
+      transport.expect(:execute, response) do |request|
+        assert_equal(:post, request.method)
+        assert_equal("/v1/files", request.url.path)
+        body = request.body.to_a.join
+        assert_includes(body, "filename=\"#{File.basename(local_path)}\"")
+        assert_includes(body, "upload-body")
+        refute_includes(body, local_path)
+        true
+      end
+
+      client = OpenAI::Client.new(
+        api_key: "test-key",
+        base_url: "http://example.test/v1",
+        http_client: transport,
+        max_retries: 1
+      )
+      file = OpenAI::FilePart.new(content)
+      uploaded = client.files.create(file: file, purpose: :assistants)
+
+      assert_instance_of(OpenAI::FileObject, uploaded)
+      assert_equal("file_test", uploaded.id)
+      refute(OpenAI::Internal::Transport::BaseClient.request_body_replayable?({file: file}))
+      assert_mock(transport)
+    end
   end
 
   def test_with_content_preserves_original_and_effective_multipart_metadata
@@ -22,5 +122,21 @@ class OpenAI::Test::FilePartTest < Minitest::Test
     assert_same(replacement, copy.content)
     assert_equal("text/plain", copy.content_type)
     assert_nil(copy.filename)
+  end
+
+  def test_with_content_preserves_inferred_filename_and_io_metadata
+    File.open(__FILE__, "rb") do |content|
+      original = OpenAI::FilePart.new(content)
+      replacement = Pathname("replacement")
+
+      copy = original.with_content(replacement)
+
+      assert_same(content, original.content)
+      assert_nil(original.content_type)
+      assert_equal(File.basename(content.to_path), original.filename)
+      assert_same(replacement, copy.content)
+      assert_equal("application/octet-stream", copy.content_type)
+      assert_equal(original.filename, copy.filename)
+    end
   end
 end

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require "tempfile"
 
 class OpenAI::Test::UtilDataHandlingTest < Minitest::Test
   def test_left_map
@@ -272,6 +273,22 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
 
     assert_includes(body, "filename=\"a \\\"b\\\"Evil: 1.md\"")
     refute_includes(body, "\r\nEvil:")
+  end
+
+  def test_multipart_file_part_io_omits_absolute_local_path
+    Tempfile.create(["upload-", ".txt"]) do |content|
+      content.write("upload-body")
+      content.rewind
+      local_path = content.to_path
+      _headers, stream = OpenAI::Internal::Util.encode_content(
+        {"content-type" => "multipart/form-data"},
+        {file: OpenAI::FilePart.new(content)}
+      )
+      body = stream.to_a.join
+
+      assert_includes(body, "filename=\"#{File.basename(local_path)}\"")
+      refute_includes(body, local_path)
+    end
   end
 
   def test_multipart_filename_encoding_with_binary_content

--- a/test/openai/internal/vector_store_file_uploader_test.rb
+++ b/test/openai/internal/vector_store_file_uploader_test.rb
@@ -300,7 +300,7 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
     assert_equal(["custom.txt", "text/custom", "custom-body"], metadata_and_contents(part))
     assert_equal([nil, "text/plain", "unnamed-body"], metadata_and_contents(unnamed))
     assert_equal(
-      [part_source_file.to_path, "application/octet-stream", "file-body"],
+      [File.basename(part_source_file.to_path), "application/octet-stream", "file-body"],
       metadata_and_contents(io_part)
     )
     assert_same(pathname, path.fetch(0))
@@ -311,6 +311,33 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
     source_file&.close
     part_source_file&.close
     tempfile&.close!
+  end
+
+  def test_staged_file_part_io_upload_omits_absolute_local_path
+    bodies = []
+    staged_paths = []
+    resource = FilesResource.new(capture_contents: false) do |file|
+      staged_paths << file.content.to_path
+      _headers, stream = OpenAI::Internal::Util.encode_content(
+        {"content-type" => "multipart/form-data"},
+        {file: file}
+      )
+      bodies << stream.to_a.join
+      UploadedFile.new("uploaded")
+    end
+
+    Tempfile.create(["upload-", ".txt"]) do |content|
+      content.write("upload-body")
+      content.rewind
+      local_path = content.to_path
+      uploader(resource).upload([OpenAI::FilePart.new(content)])
+
+      body = bodies.fetch(0)
+      assert_includes(body, "filename=\"#{File.basename(local_path)}\"")
+      refute_includes(body, local_path)
+      refute_predicate(content, :closed?)
+      refute_path_exists(staged_paths.fetch(0))
+    end
   end
 
   def test_upload_removes_spooled_files_after_failure


### PR DESCRIPTION
## Summary

- Normalize inferred `OpenAI::FilePart` filenames for path-backed `IO` objects with the platform-native basename while preserving pathless streams, explicit filename overrides, and `Pathname` behavior.
- Preserve multipart content types, file contents, retry classification, caller-owned stream lifetime, and vector-store staging/cleanup.
- Add direct `client.files.create`, multipart wire-format, platform-path, metadata, and staged vector-store regression coverage.

## Compatibility

`OpenAI::FilePart#filename` now returns `document.txt` instead of `/nested/document.txt` when its name is inferred from a path-backed `IO`. This matches existing `Pathname` and explicit-filename normalization; callers that need the original filesystem path can continue using `file_part.content.to_path`. Public method signatures, visibility, RBI/RBS declarations, supported Ruby versions, dependencies, and generated interfaces are unchanged.

## Validation

- `bundle exec rake test` on Ruby 3.3.12, 3.4.10, and 4.0.6: **932 tests, 4,942 assertions** per runtime; the live Bedrock integration is intentionally skipped.
- `bundle exec rake lint`: Sorbet, 1,236 RBS signatures, formatter/directive checks, and RuboCop across 2,700 files.
- Reviewed generator ownership: production and regression-test changes are SDK-owned; no Castiron changes are required.