### PR TITLE
fix: preserve request boundaries across redirects

### DIFF
--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -187,11 +187,11 @@ module OpenAI
             # from undici
             origin = OpenAI::Internal::Util.uri_origin(url)
             redirect_origin = OpenAI::Internal::Util.uri_origin(location)
-            if url.host.start_with?("[")
+            if url.host.start_with?("[") && !url.hostname.start_with?("v", "V")
               origin = origin.sub(url.host, "[#{IPAddr.new(url.hostname)}]")
             end
 
-            if location.host.start_with?("[")
+            if location.host.start_with?("[") && !location.hostname.start_with?("v", "V")
               redirect_origin = redirect_origin.sub(location.host, "[#{IPAddr.new(location.hostname)}]")
             end
 
@@ -554,7 +554,7 @@ module OpenAI
           end
 
           url, max_retries = request.fetch_values(:url, :max_retries)
-          authorized_url = url.dup
+          authorized_url = URI(url.to_s)
           prepared_request = request
           trusted_origin = request[:redirect_trusted_origin]
 
@@ -564,7 +564,7 @@ module OpenAI
               request[:body]
             )
             attempt_request = request.except(:redirect_trusted_origin, :redirect_body_forbidden).merge(
-              url: authorized_url.dup,
+              url: URI(authorized_url.to_s),
               headers: encoded_headers,
               body: encoded_body
             )
@@ -576,13 +576,13 @@ module OpenAI
 
             prepared_url = prepared_request.fetch(:url)
             prepared_origin = OpenAI::Internal::Util.uri_origin(prepared_url)
-            if prepared_url.host&.start_with?("[")
+            if prepared_url.host&.start_with?("[") && !prepared_url.hostname.start_with?("v", "V")
               prepared_origin = prepared_origin.sub(prepared_url.host, "[#{IPAddr.new(prepared_url.hostname)}]")
             end
 
             trusted_origin ||= prepared_origin
             authorized_origin = OpenAI::Internal::Util.uri_origin(authorized_url)
-            if authorized_url.host.start_with?("[")
+            if authorized_url.host.start_with?("[") && !authorized_url.hostname.start_with?("v", "V")
               authorized_origin = authorized_origin.sub(authorized_url.host, "[#{IPAddr.new(authorized_url.hostname)}]")
             end
 

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -593,8 +593,8 @@ module OpenAI
             if restore_authorized_url || body_forbidden
               safe_headers = prepared_request.fetch(:headers).reject do |name, _|
                 normalized_name = name.to_s.downcase
-                (restore_authorized_url && normalized_name == "host") ||
-                  (cross_origin && OpenAI::Internal::Logging.credential_header?(name)) ||
+                (restore_authorized_url &&
+                  (normalized_name == "host" || OpenAI::Internal::Logging.credential_header?(name))) ||
                   (body_forbidden && REDIRECT_ENTITY_HEADERS.include?(normalized_name))
               end
 

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "ipaddr"
+
 require_relative "../logging"
 
 module OpenAI
@@ -170,6 +172,14 @@ module OpenAI
             # from undici
             origin = OpenAI::Internal::Util.uri_origin(url)
             redirect_origin = OpenAI::Internal::Util.uri_origin(location)
+            if url.host.start_with?("[")
+              origin = origin.sub(url.host, "[#{IPAddr.new(url.hostname)}]")
+            end
+
+            if location.host.start_with?("[")
+              redirect_origin = redirect_origin.sub(location.host, "[#{IPAddr.new(location.hostname)}]")
+            end
+
             unless origin.casecmp?(redirect_origin)
               unless request[:body].nil?
                 # An attacker who controls a trusted endpoint's redirect destination could receive the body.
@@ -177,7 +187,6 @@ module OpenAI
                 raise(
                   OpenAI::Errors::APIConnectionError.new(
                     url: URI(redirect_origin),
-                    response: response_headers.except("location"),
                     message: message
                   )
                 )
@@ -597,12 +606,18 @@ module OpenAI
           in 300..399
             self.class.reap_connection!(status, stream: stream)
 
-            redirect_source = request.merge(url: prepared_request.fetch(:url))
+            redirect_body = request[:body]
+            redirect_body = prepared_request[:body] if redirect_body.nil? || prepared_request[:body].nil?
+            redirect_source = request.merge(
+              url: prepared_request.fetch(:url),
+              body: redirect_body
+            )
             redirected_request = self.class.follow_redirect(
               redirect_source,
               status: status,
               response_headers: headers
             )
+            redirected_request = redirected_request.merge(body: nil) if request[:body].nil?
             send_request(
               redirected_request,
               redirect_count: redirect_count + 1,

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -662,10 +662,10 @@ module OpenAI
             self.class.reap_connection!(status, stream: stream)
 
             redirect_body = request[:body]
-            redirect_body = input.body if redirect_body.nil? || input.body.nil?
+            redirect_body = prepared_request[:body] if redirect_body.nil? || prepared_request[:body].nil?
             redirect_source = request.merge(
-              method: input.method,
-              url: input.url,
+              method: prepared_request.fetch(:method),
+              url: prepared_request.fetch(:url),
               body: redirect_body
             )
             redirected_request = self.class.follow_redirect(

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -185,8 +185,8 @@ module OpenAI
             end
 
             # from undici
-            origin = OpenAI::Internal::Util.uri_origin(url)
-            redirect_origin = OpenAI::Internal::Util.uri_origin(location)
+            origin = OpenAI::Internal::Util.uri_origin(URI(url.to_s))
+            redirect_origin = OpenAI::Internal::Util.uri_origin(URI(location.to_s))
             if url.host.start_with?("[") && !url.hostname.start_with?("v", "V")
               origin = origin.sub(url.host, "[#{IPAddr.new(url.hostname)}]")
             end
@@ -554,7 +554,7 @@ module OpenAI
           end
 
           url, max_retries = request.fetch_values(:url, :max_retries)
-          authorized_url = URI(url.to_s)
+          authorized_url = url.class.new(*URI.split(url.to_s))
           prepared_request = request
           trusted_origin = request[:redirect_trusted_origin]
 
@@ -564,8 +564,8 @@ module OpenAI
               request[:body]
             )
             attempt_request = request.except(:redirect_trusted_origin, :redirect_body_forbidden).merge(
-              url: URI(authorized_url.to_s),
-              headers: encoded_headers,
+              url: authorized_url.class.new(*URI.split(authorized_url.to_s)),
+              headers: encoded_headers.transform_values(&:dup),
               body: encoded_body
             )
             prepared_request = prepare_request(
@@ -575,13 +575,13 @@ module OpenAI
             )
 
             prepared_url = prepared_request.fetch(:url)
-            prepared_origin = OpenAI::Internal::Util.uri_origin(prepared_url)
+            prepared_origin = OpenAI::Internal::Util.uri_origin(URI(prepared_url.to_s))
             if prepared_url.host&.start_with?("[") && !prepared_url.hostname.start_with?("v", "V")
               prepared_origin = prepared_origin.sub(prepared_url.host, "[#{IPAddr.new(prepared_url.hostname)}]")
             end
 
             trusted_origin ||= prepared_origin
-            authorized_origin = OpenAI::Internal::Util.uri_origin(authorized_url)
+            authorized_origin = OpenAI::Internal::Util.uri_origin(URI(authorized_url.to_s))
             if authorized_url.host.start_with?("[") && !authorized_url.hostname.start_with?("v", "V")
               authorized_origin = authorized_origin.sub(authorized_url.host, "[#{IPAddr.new(authorized_url.hostname)}]")
             end

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -176,8 +176,8 @@ module OpenAI
                 message = "Cannot follow a cross-origin redirect with a request body."
                 raise(
                   OpenAI::Errors::APIConnectionError.new(
-                    url: location,
-                    response: response_headers,
+                    url: URI(redirect_origin),
+                    response: response_headers.except("location"),
                     message: message
                   )
                 )

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -539,6 +539,7 @@ module OpenAI
           end
 
           url, max_retries = request.fetch_values(:url, :max_retries)
+          prepared_request = request
 
           begin
             encoded_headers, encoded_body = OpenAI::Internal::Util.encode_content(

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -662,9 +662,10 @@ module OpenAI
             self.class.reap_connection!(status, stream: stream)
 
             redirect_body = request[:body]
-            redirect_body = prepared_request[:body] if redirect_body.nil? || prepared_request[:body].nil?
+            redirect_body = input.body if redirect_body.nil? || input.body.nil?
             redirect_source = request.merge(
-              url: prepared_request.fetch(:url),
+              method: input.method,
+              url: input.url,
               body: redirect_body
             )
             redirected_request = self.class.follow_redirect(

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -545,38 +545,36 @@ module OpenAI
 
           url, max_retries = request.fetch_values(:url, :max_retries)
           prepared_request = request
+          trusted_origin = request[:redirect_trusted_origin]
 
           begin
             encoded_headers, encoded_body = OpenAI::Internal::Util.encode_content(
               request.fetch(:headers),
               request[:body]
             )
-            attempt_request = request.merge(headers: encoded_headers, body: encoded_body)
+            attempt_request = request.except(:redirect_trusted_origin).merge(
+              headers: encoded_headers,
+              body: encoded_body
+            )
             prepared_request = prepare_request(
               attempt_request,
               redirect_count: redirect_count,
               retry_count: retry_count
             )
 
-            if redirect_count.positive?
-              prepared_url = prepared_request.fetch(:url)
-              configured_origin = OpenAI::Internal::Util.uri_origin(@base_url)
-              prepared_origin = OpenAI::Internal::Util.uri_origin(prepared_url)
-              if @base_url.host.start_with?("[")
-                configured_origin = configured_origin.sub(@base_url.host, "[#{IPAddr.new(@base_url.hostname)}]")
+            prepared_url = prepared_request.fetch(:url)
+            prepared_origin = OpenAI::Internal::Util.uri_origin(prepared_url)
+            if prepared_url.host.start_with?("[")
+              prepared_origin = prepared_origin.sub(prepared_url.host, "[#{IPAddr.new(prepared_url.hostname)}]")
+            end
+
+            trusted_origin ||= prepared_origin
+            if redirect_count.positive? && !trusted_origin.casecmp?(prepared_origin)
+              safe_headers = prepared_request.fetch(:headers).reject do |name, _|
+                name.to_s.casecmp?("host") || OpenAI::Internal::Logging.credential_header?(name)
               end
 
-              if prepared_url.host.start_with?("[")
-                prepared_origin = prepared_origin.sub(prepared_url.host, "[#{IPAddr.new(prepared_url.hostname)}]")
-              end
-
-              unless configured_origin.casecmp?(prepared_origin)
-                safe_headers = prepared_request.fetch(:headers).reject do |name, _|
-                  name.to_s.casecmp?("host") || OpenAI::Internal::Logging.credential_header?(name)
-                end
-
-                prepared_request = prepared_request.merge(headers: safe_headers, body: nil)
-              end
+              prepared_request = prepared_request.merge(headers: safe_headers, body: nil)
             end
 
             url, max_retries, timeout = prepared_request.fetch_values(:url, :max_retries, :timeout)
@@ -646,6 +644,7 @@ module OpenAI
               response_headers: headers
             )
             redirected_request = redirected_request.merge(body: nil) if request[:body].nil?
+            redirected_request = redirected_request.merge(redirect_trusted_origin: trusted_origin)
             send_request(
               redirected_request,
               redirect_count: redirect_count + 1,

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -588,17 +588,18 @@ module OpenAI
 
             cross_origin = redirect_count.positive? && !trusted_origin.casecmp?(authorized_origin)
             escaped_origin = redirect_count.positive? && !authorized_origin.casecmp?(prepared_origin)
+            restore_authorized_url = cross_origin || escaped_origin
             body_forbidden = request[:redirect_body_forbidden] || cross_origin
-            if cross_origin || escaped_origin || body_forbidden
+            if restore_authorized_url || body_forbidden
               safe_headers = prepared_request.fetch(:headers).reject do |name, _|
                 normalized_name = name.to_s.downcase
-                (cross_origin &&
-                  (normalized_name == "host" || OpenAI::Internal::Logging.credential_header?(name))) ||
+                (restore_authorized_url && normalized_name == "host") ||
+                  (cross_origin && OpenAI::Internal::Logging.credential_header?(name)) ||
                   (body_forbidden && REDIRECT_ENTITY_HEADERS.include?(normalized_name))
               end
 
               prepared_request = prepared_request.merge(
-                url: cross_origin || escaped_origin ? authorized_url : prepared_url,
+                url: restore_authorized_url ? authorized_url : prepared_url,
                 method: body_forbidden ? request.fetch(:method) : prepared_request.fetch(:method),
                 headers: safe_headers,
                 body: body_forbidden ? nil : prepared_request[:body]

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -15,6 +15,16 @@ module OpenAI
 
         # from whatwg fetch spec
         MAX_REDIRECTS = 20
+        REDIRECT_ENTITY_HEADERS = %w[
+          content-encoding
+          content-language
+          content-length
+          content-location
+          content-type
+          transfer-encoding
+        ]
+          .freeze
+        private_constant :REDIRECT_ENTITY_HEADERS
 
         # rubocop:disable Style/MutableConstant
         PLATFORM_HEADERS = {
@@ -164,12 +174,12 @@ module OpenAI
             # from whatwg fetch spec
             case [status, method]
             in [301 | 302, :post] | [303, _]
-              drop = %w[content-encoding content-language content-length content-location content-type]
               request = {
                 **request,
                 method: method == :head ? :head : :get,
-                headers: headers.except(*drop),
-                body: nil
+                headers: headers.reject { |name, _| REDIRECT_ENTITY_HEADERS.include?(name.to_s.downcase) },
+                body: nil,
+                redirect_body_forbidden: true
               }
             else
             end
@@ -544,6 +554,7 @@ module OpenAI
           end
 
           url, max_retries = request.fetch_values(:url, :max_retries)
+          authorized_url = url.dup
           prepared_request = request
           trusted_origin = request[:redirect_trusted_origin]
 
@@ -552,7 +563,8 @@ module OpenAI
               request.fetch(:headers),
               request[:body]
             )
-            attempt_request = request.except(:redirect_trusted_origin).merge(
+            attempt_request = request.except(:redirect_trusted_origin, :redirect_body_forbidden).merge(
+              url: authorized_url.dup,
               headers: encoded_headers,
               body: encoded_body
             )
@@ -564,17 +576,33 @@ module OpenAI
 
             prepared_url = prepared_request.fetch(:url)
             prepared_origin = OpenAI::Internal::Util.uri_origin(prepared_url)
-            if prepared_url.host.start_with?("[")
+            if prepared_url.host&.start_with?("[")
               prepared_origin = prepared_origin.sub(prepared_url.host, "[#{IPAddr.new(prepared_url.hostname)}]")
             end
 
             trusted_origin ||= prepared_origin
-            if redirect_count.positive? && !trusted_origin.casecmp?(prepared_origin)
+            authorized_origin = OpenAI::Internal::Util.uri_origin(authorized_url)
+            if authorized_url.host.start_with?("[")
+              authorized_origin = authorized_origin.sub(authorized_url.host, "[#{IPAddr.new(authorized_url.hostname)}]")
+            end
+
+            cross_origin = redirect_count.positive? && !trusted_origin.casecmp?(authorized_origin)
+            escaped_origin = redirect_count.positive? && !authorized_origin.casecmp?(prepared_origin)
+            body_forbidden = request[:redirect_body_forbidden] || cross_origin
+            if cross_origin || escaped_origin || body_forbidden
               safe_headers = prepared_request.fetch(:headers).reject do |name, _|
-                name.to_s.casecmp?("host") || OpenAI::Internal::Logging.credential_header?(name)
+                normalized_name = name.to_s.downcase
+                (cross_origin &&
+                  (normalized_name == "host" || OpenAI::Internal::Logging.credential_header?(name))) ||
+                  (body_forbidden && REDIRECT_ENTITY_HEADERS.include?(normalized_name))
               end
 
-              prepared_request = prepared_request.merge(headers: safe_headers, body: nil)
+              prepared_request = prepared_request.merge(
+                url: cross_origin || escaped_origin ? authorized_url : prepared_url,
+                method: body_forbidden ? request.fetch(:method) : prepared_request.fetch(:method),
+                headers: safe_headers,
+                body: body_forbidden ? nil : prepared_request[:body]
+              )
             end
 
             url, max_retries, timeout = prepared_request.fetch_values(:url, :max_retries, :timeout)

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -168,7 +168,21 @@ module OpenAI
             end
 
             # from undici
-            if OpenAI::Internal::Util.uri_origin(url) != OpenAI::Internal::Util.uri_origin(location)
+            origin = OpenAI::Internal::Util.uri_origin(url)
+            redirect_origin = OpenAI::Internal::Util.uri_origin(location)
+            unless origin.casecmp?(redirect_origin)
+              unless request[:body].nil?
+                # An attacker who controls a trusted endpoint's redirect destination could receive the body.
+                message = "Cannot follow a cross-origin redirect with a request body."
+                raise(
+                  OpenAI::Errors::APIConnectionError.new(
+                    url: location,
+                    response: response_headers,
+                    message: message
+                  )
+                )
+              end
+
               headers = request.fetch(:headers).reject do |name, _|
                 name == "host" || OpenAI::Internal::Logging.credential_header?(name)
               end

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -140,6 +140,11 @@ module OpenAI
               )
             end
 
+            unless %w[http https].include?(location.scheme) && !location.host.to_s.empty?
+              message = "Server responded with status #{status} but no valid location header."
+              raise OpenAI::Errors::APIConnectionError.new(url: url, message: message)
+            end
+
             request = {**request, url: location}
 
             case [url.scheme, location.scheme]
@@ -552,6 +557,28 @@ module OpenAI
               redirect_count: redirect_count,
               retry_count: retry_count
             )
+
+            if redirect_count.positive?
+              prepared_url = prepared_request.fetch(:url)
+              configured_origin = OpenAI::Internal::Util.uri_origin(@base_url)
+              prepared_origin = OpenAI::Internal::Util.uri_origin(prepared_url)
+              if @base_url.host.start_with?("[")
+                configured_origin = configured_origin.sub(@base_url.host, "[#{IPAddr.new(@base_url.hostname)}]")
+              end
+
+              if prepared_url.host.start_with?("[")
+                prepared_origin = prepared_origin.sub(prepared_url.host, "[#{IPAddr.new(prepared_url.hostname)}]")
+              end
+
+              unless configured_origin.casecmp?(prepared_origin)
+                safe_headers = prepared_request.fetch(:headers).reject do |name, _|
+                  name.to_s.casecmp?("host") || OpenAI::Internal::Logging.credential_header?(name)
+                end
+
+                prepared_request = prepared_request.merge(headers: safe_headers, body: nil)
+              end
+            end
+
             url, max_retries, timeout = prepared_request.fetch_values(:url, :max_retries, :timeout)
             input = OpenAI::HTTPClient::Request.new(
               method: prepared_request.fetch(:method),

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -776,16 +776,15 @@ class OpenAITest < Minitest::Test
     end
   end
 
-  def test_client_redirect_auth_strip_cross_origin
+  def test_client_rejects_cross_origin_307_redirect_with_sensitive_body
+    source = "http://localhost/chat/completions"
+    destination = "https://example.com/redirected"
     stub_request(:post, "http://localhost/chat/completions").to_return_json(
       status: 307,
-      headers: {"location" => "https://example.com/redirected"},
+      headers: {"location" => destination},
       body: {}
     )
-    stub_request(:any, "https://example.com/redirected").to_return(
-      status: 307,
-      headers: {"location" => "https://example.com/redirected"}
-    )
+    stub_request(:post, destination).to_return_json(status: 200, body: {})
 
     openai = OpenAI::Client.new(
       base_url: "http://localhost",
@@ -793,18 +792,25 @@ class OpenAITest < Minitest::Test
       admin_api_key: "My Admin API Key"
     )
 
-    assert_raises(OpenAI::Errors::APIConnectionError) do
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
       openai.chat.completions.create(
-        messages: [{content: "string", role: :developer}],
+        messages: [{content: "fake-private-customer-prompt", role: :developer}],
         model: :"gpt-5.4",
-        request_options: {extra_headers: {"authorization" => "Bearer xyz"}}
+        request_options: {
+          extra_body: {tools: [{type: "mcp", authorization: "fake-mcp-oauth-token"}]},
+          extra_headers: {"authorization" => "Bearer xyz"}
+        }
       )
     end
 
-    assert_requested(:any, "https://example.com/redirected", times: OpenAI::Client::MAX_REDIRECTS) do
-      headers = _1.headers.keys.map(&:downcase)
-      refute_includes(headers, "authorization")
+    assert_equal(destination, error.url.to_s)
+    assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
+    assert_requested(:post, source) do |request|
+      assert_includes(request.body, "fake-private-customer-prompt")
+      assert_includes(request.body, "fake-mcp-oauth-token")
     end
+
+    assert_not_requested(:any, destination)
   end
 
   def test_client_redirect_strips_symbol_sensitive_headers_cross_origin

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -803,7 +803,7 @@ class OpenAITest < Minitest::Test
       )
     end
 
-    assert_equal(destination, error.url.to_s)
+    assert_equal("https://example.com", error.url.to_s)
     assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
     assert_requested(:post, source) do |request|
       assert_includes(request.body, "fake-private-customer-prompt")

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -82,6 +82,44 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
   end
 
+  def test_preserves_same_origin_redirect_when_ipv6_spelling_changes
+    [307, 308].each do |status|
+      destination = "https://[::1]/v1/redirected/#{status}"
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, destination),
+        successful_response,
+        base_url: "https://[0:0:0:0:0:0:0:1]/v1"
+      )
+
+      response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal(destination, requests.last.url.to_s)
+      assert_equal(requests.first.body, requests.last.body)
+      assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+    end
+  end
+
+  def test_rejects_cross_origin_redirect_between_distinct_ipv6_addresses
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://[::2]/v1/redirected"),
+      base_url: "https://[0:0:0:0:0:0:0:1]/v1"
+    )
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    assert_equal("https://[::2]", error.url.to_s)
+    assert_equal(1, requests.length)
+  end
+
   def test_preserves_bodyless_cross_origin_get_and_head_redirects
     [[:get, 307], [:get, 308], [:head, 307], [:head, 308], [:head, 303]].each do |method, status|
       destination = "https://example.com/redirected/#{method}/#{status}"
@@ -118,6 +156,82 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     assert_equal(true, response[:ok])
     assert_equal([:post, :post], requests.map(&:method))
     assert_nil(requests.last.body)
+    refute_includes(requests.last.headers, "authorization")
+  end
+
+  def test_rejects_cross_origin_redirect_when_request_preparation_adds_a_body
+    [307, 308].each do |status|
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, "https://example.com/redirected"),
+        client_class: body_adding_client_class
+      )
+
+      error = assert_raises(OpenAI::Errors::APIConnectionError) do
+        client.request(method: :post, path: "probe")
+      end
+
+      http_client.verify
+      assert_equal("https://example.com", error.url.to_s)
+      assert_equal(1, requests.length)
+      assert_equal("fake-prepared-private-prompt", requests.first.body)
+    end
+  end
+
+  def test_preserves_same_origin_redirect_when_request_preparation_adds_a_body
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://trusted.example/v1/redirected"),
+      successful_response,
+      client_class: body_adding_client_class
+    )
+
+    response = client.request(method: :post, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal(["fake-prepared-private-prompt", "fake-prepared-private-prompt"], requests.map(&:body))
+    assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+  end
+
+  def test_preserves_false_json_body_on_same_origin_redirect
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://trusted.example/v1/redirected"),
+      successful_response
+    )
+
+    response = client.request(method: :post, path: "probe", body: false)
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal(["false", "false"], requests.map(&:body))
+  end
+
+  def test_preserves_bodyless_cross_origin_redirect_when_request_preparation_removes_a_body
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(body: nil)
+      end
+    end
+
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://example.com/redirected"),
+      successful_response,
+      client_class: client_class
+    )
+
+    response = client.request(method: :post, path: "probe", body: {prompt: "fake-never-sent-prompt"})
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal([nil, nil], requests.map(&:body))
     refute_includes(requests.last.headers, "authorization")
   end
 
@@ -255,7 +369,38 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
   end
 
-  private def client_with_responses(requests, *responses, **options)
+  def test_rejected_cross_origin_redirect_never_retains_sensitive_response_headers
+    response = OpenAI::HTTPClient::Response.new(
+      status: 307,
+      headers: {
+        "location" => "https://example.com/redirected",
+        "set-cookie" => "session=fake-session-cookie",
+        "x-provider-token" => "fake-provider-token",
+        "authorization" => "Bearer fake-response-authorization"
+      },
+      body: ""
+    )
+    requests = []
+    client, http_client = client_with_responses(requests, response)
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    serialized = Marshal.dump(error)
+    %w[fake-session-cookie fake-provider-token fake-response-authorization].each do |secret|
+      refute_includes(serialized, secret)
+    end
+  end
+
+  private def client_with_responses(
+    requests,
+    *responses,
+    base_url: "https://trusted.example/v1",
+    client_class: OpenAI::Client,
+    **options
+  )
     http_client = Minitest::Mock.new(OpenAI::HTTPClient.new)
     responses.each do |response|
       http_client.expect(:execute, response) do |request|
@@ -264,13 +409,22 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
       end
     end
 
-    client = OpenAI::Client.new(
+    client = client_class.new(
       api_key: "fake-api-key",
-      base_url: "https://trusted.example/v1",
+      base_url: base_url,
       http_client: http_client,
       **options
     )
     [client, http_client]
+  end
+
+  private def body_adding_client_class
+    Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(body: "fake-prepared-private-prompt")
+      end
+    end
   end
 
   private def redirect_response(status, destination)

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -47,6 +47,71 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
   end
 
+  def test_preserves_redirects_within_the_initially_prepared_trusted_origin
+    [307, 308].each do |status|
+      destination = "https://prepared.example/v1/redirected/#{status}"
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, destination),
+        successful_response,
+        client_class: origin_rewriting_client_class
+      )
+
+      response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal(["prepared.example", "prepared.example"], requests.map { _1.url.host })
+      assert_equal(requests.first.body, requests.last.body)
+      assert_includes(requests.last.body, "fake-private-prompt")
+      assert_equal("Bearer fake-prepared-origin-authorization", requests.last.headers.fetch("Authorization"))
+      assert_equal("fake-prepared-origin-api-key", requests.last.headers.fetch("X-Api-Key"))
+    end
+  end
+
+  def test_rewritten_trusted_origin_still_rejects_body_preserving_cross_origin_redirects
+    [307, 308].each do |status|
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, "https://untrusted.example/redirected"),
+        client_class: origin_rewriting_client_class
+      )
+
+      error = assert_raises(OpenAI::Errors::APIConnectionError) do
+        client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+      end
+
+      http_client.verify
+      assert_equal("https://untrusted.example", error.url.to_s)
+      assert_equal(["prepared.example"], requests.map { _1.url.host })
+    end
+  end
+
+  def test_rewritten_trusted_origin_strips_prepared_credentials_on_cross_origin_hops
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://prepared.example/v1/same-origin"),
+      redirect_response(307, "https://untrusted.example/redirected"),
+      successful_response,
+      client_class: origin_rewriting_client_class
+    )
+
+    response = client.request(method: :get, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal(["prepared.example", "prepared.example", "untrusted.example"], requests.map { _1.url.host })
+    assert_equal("Bearer fake-prepared-origin-authorization", requests.fetch(1).headers.fetch("Authorization"))
+    %w[authorization cookie x-api-key].each do |header|
+      refute(requests.last.headers.keys.any? { _1.casecmp?(header) }, "#{header} reached the untrusted origin")
+    end
+
+    assert_equal("safe-trace-value", requests.last.headers.fetch("x-safe-trace"))
+  end
+
   def test_preserves_same_origin_redirect_with_explicit_default_https_port
     requests = []
     client, http_client = client_with_responses(
@@ -494,6 +559,30 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
       private def prepare_request(request, redirect_count:, retry_count:)
         prepared = super
         prepared.merge(body: "fake-prepared-private-prompt")
+      end
+    end
+  end
+
+  private def origin_rewriting_client_class
+    Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        raise "internal redirect trust metadata reached a preparer" if request.key?(:redirect_trusted_origin)
+
+        prepared = super
+        if redirect_count.zero?
+          rewritten_url = prepared.fetch(:url).dup
+          rewritten_url.host = "prepared.example"
+          prepared = prepared.merge(url: rewritten_url)
+        end
+
+        prepared.merge(
+          headers: prepared.fetch(:headers).merge(
+            "Authorization" => "Bearer fake-prepared-origin-authorization",
+            "Cookie" => "session=fake-prepared-origin-cookie",
+            "X-Api-Key" => "fake-prepared-origin-api-key",
+            "x-safe-trace" => "safe-trace-value"
+          )
+        )
       end
     end
   end

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -129,6 +129,54 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
   end
 
+  def test_preserves_explicit_default_ports_and_ipv6_spelling_in_original_requests
+    scenarios = [
+      ["https://trusted.example/v1", "https://trusted.example:443/v1/models"],
+      ["http://trusted.example/v1", "http://trusted.example:80/v1/models"],
+      ["https://[::1]/v1", "https://[::1]:443/v1/models"],
+      ["https://[2001:db8::1]/v1", "https://[2001:0DB8:0:0:0:0:0:1]:443/v1/models"]
+    ]
+
+    scenarios.each do |base_url, path|
+      requests = []
+      client, http_client = client_with_responses(requests, successful_response, base_url: base_url)
+
+      response = client.request(method: :get, path: path)
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal(path, requests.fetch(0).url.to_s)
+      assert_equal("Bearer fake-api-key", requests.fetch(0).headers.fetch("authorization"))
+    end
+  end
+
+  def test_treats_explicit_default_ports_as_same_origin_on_body_preserving_redirects
+    scenarios = [
+      ["https://trusted.example/v1", "https://trusted.example:443/v1/probe", "https://trusted.example/v1/next"],
+      ["https://trusted.example:443/v1", "probe", "https://trusted.example/v1/next"],
+      ["http://trusted.example:80/v1", "probe", "http://trusted.example/v1/next"],
+      ["https://[::1]:443/v1", "probe", "https://[0:0:0:0:0:0:0:1]/v1/next"]
+    ]
+
+    scenarios.each do |base_url, path, destination|
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(307, destination),
+        successful_response,
+        base_url: base_url
+      )
+
+      response = client.request(method: :post, path: path, body: {prompt: "fake-private-prompt"})
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal(destination, requests.last.url.to_s)
+      assert_equal(requests.first.body, requests.last.body)
+      assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+    end
+  end
+
   def test_preserves_same_origin_redirect_when_hostname_case_changes
     destination = "https://TRUSTED.EXAMPLE/v1/redirected"
     requests = []
@@ -561,6 +609,61 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
         assert_equal("safe-trace-value", request.headers.fetch("x-safe-trace"))
       end
     end
+  end
+
+  def test_isolates_mutated_redirect_headers_and_values_across_retries_and_later_hops
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        return prepared unless redirect_count == 1 && retry_count.zero?
+
+        prepared.fetch(:url).host.replace("escaped.example")
+        headers = prepared.fetch(:headers)
+        headers.fetch("authorization").replace("Bearer fake-escaped-mutated-authorization")
+        headers["hOsT"] = "escaped.example"
+        headers["X-Api-Key"] = "fake-escaped-mutated-api-key"
+        headers["Cookie"] = "session=fake-escaped-mutated-cookie"
+        headers["Proxy-Authorization"] = "Bearer fake-escaped-mutated-proxy-token"
+        headers["X-Amz-Security-Token"] = "fake-escaped-mutated-session-token"
+        prepared
+      end
+    end
+
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://trusted.example/v1/first"),
+      OpenAI::HTTPClient::Response.new(status: 500, headers: {}, body: ""),
+      redirect_response(307, "https://trusted.example/v1/second"),
+      successful_response,
+      client_class: client_class,
+      max_retries: 1,
+      initial_retry_delay: 0,
+      max_retry_delay: 0
+    )
+
+    response = client.request(method: :get, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal(
+      ["/v1/probe", "/v1/first", "/v1/first", "/v1/second"],
+      requests.map { _1.url.path }
+    )
+    assert_equal("Bearer fake-api-key", requests.first.headers.fetch("authorization"))
+
+    requests.drop(1).each do |request|
+      assert_equal("trusted.example", request.url.host)
+      refute_includes(request.headers.values.join(" "), "fake-escaped-mutated")
+      refute(request.headers.keys.any? { _1.casecmp?("host") }, "escaped Host persisted across attempts")
+      %w[cookie proxy-authorization x-amz-security-token x-api-key].each do |header|
+        refute(request.headers.keys.any? { _1.casecmp?(header) }, "escaped #{header} persisted across attempts")
+      end
+    end
+
+    refute(requests.fetch(1).headers.keys.any? { _1.casecmp?("authorization") })
+    assert_equal("Bearer fake-api-key", requests.fetch(2).headers.fetch("authorization"))
+    assert_equal("Bearer fake-api-key", requests.fetch(3).headers.fetch("authorization"))
   end
 
   def test_preserves_same_origin_redirect_url_changes_during_preparation

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -341,6 +341,176 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
   end
 
+  def test_keeps_converted_same_origin_redirects_bodyless_after_preparation
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(
+          method: redirect_count.positive? ? :post : prepared.fetch(:method),
+          body: "fake-prepared-private-prompt"
+        )
+      end
+    end
+
+    [[:post, 301, :get], [:post, 302, :get], [:post, 303, :get], [:head, 303, :head]].each do |
+        method,
+        status,
+        next_method
+      |
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, "https://trusted.example/v1/redirected/#{status}"),
+        successful_response,
+        client_class: client_class
+      )
+
+      response = client.request(method: method, path: "probe")
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal([method, next_method], requests.map(&:method))
+      assert_equal("fake-prepared-private-prompt", requests.first.body)
+      assert_nil(requests.last.body)
+    end
+  end
+
+  def test_preserves_authorized_cross_origin_url_without_preparer_credentials_on_retry
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        return prepared if redirect_count.zero?
+
+        url = prepared.fetch(:url)
+        url.user = "fake-prepared-user"
+        url.password = "fake-prepared-password"
+        url.query = "#{url.query}&api_key=fake-prepared-query-key&opaque=fake-prepared-opaque-secret"
+        prepared.merge(url: url)
+      end
+    end
+
+    destination = "https://download.example/file?download=public&signature=fake-authorized-signature"
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, destination),
+      OpenAI::HTTPClient::Response.new(status: 500, headers: {}, body: ""),
+      successful_response,
+      client_class: client_class,
+      max_retries: 1,
+      initial_retry_delay: 0,
+      max_retry_delay: 0
+    )
+
+    response = client.request(method: :get, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    requests.drop(1).each do |request|
+      assert_equal(destination, request.url.to_s)
+      assert_nil(request.url.userinfo)
+      refute_includes(request.url.query, "fake-prepared-query-key")
+      refute_includes(request.url.query, "fake-prepared-opaque-secret")
+    end
+  end
+
+  def test_prevents_redirect_preparation_from_escaping_the_authorized_origin
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        return prepared if redirect_count.zero?
+
+        url = prepared.fetch(:url)
+        url.host = "escaped.example"
+        url.query = "api_key=fake-escaped-query-key"
+        prepared.merge(url: url)
+      end
+    end
+
+    ["https://download.example/file?download=public", "https://trusted.example/v1/file?download=public"].each do |
+        destination
+      |
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(307, destination),
+        successful_response,
+        client_class: client_class
+      )
+
+      response = client.request(method: :get, path: "probe")
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal(destination, requests.last.url.to_s)
+      refute_includes(requests.last.url.to_s, "fake-escaped-query-key")
+    end
+  end
+
+  def test_preserves_same_origin_redirect_url_changes_during_preparation
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        return prepared if redirect_count.zero?
+
+        url = prepared.fetch(:url)
+        url.query = "safe_provider_parameter=fake-provider-value"
+        prepared.merge(url: url)
+      end
+    end
+
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://trusted.example/v1/redirected"),
+      successful_response,
+      client_class: client_class
+    )
+
+    response = client.request(method: :get, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal("safe_provider_parameter=fake-provider-value", requests.last.url.query)
+  end
+
+  def test_removes_entity_headers_when_redirect_preparation_restores_a_forbidden_body
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(
+          body: "fake-prepared-private-prompt",
+          headers: prepared.fetch(:headers).merge(
+            "Content-Length" => "28",
+            "Transfer-Encoding" => "chunked",
+            "Content-Type" => "application/octet-stream",
+            "Content-Encoding" => "gzip",
+            "Content-Language" => "en",
+            "Content-Location" => "/fake-content"
+          )
+        )
+      end
+    end
+
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(301, "https://download.example/redirected"),
+      successful_response,
+      client_class: client_class
+    )
+
+    response = client.request(method: :post, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_nil(requests.last.body)
+    %w[content-length transfer-encoding content-type content-encoding content-language content-location]
+      .each do |header|
+        refute(requests.last.headers.keys.any? { _1.casecmp?(header) }, "#{header} remained on the bodyless redirect")
+      end
+  end
+
   def test_strips_credentials_added_during_cross_origin_redirect_preparation
     client_class = Class.new(OpenAI::Client) do
       private def prepare_request(request, redirect_count:, retry_count:)
@@ -557,6 +727,8 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
   private def body_adding_client_class
     Class.new(OpenAI::Client) do
       private def prepare_request(request, redirect_count:, retry_count:)
+        raise "internal redirect body policy reached a preparer" if request.key?(:redirect_body_forbidden)
+
         prepared = super
         prepared.merge(body: "fake-prepared-private-prompt")
       end
@@ -566,7 +738,9 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
   private def origin_rewriting_client_class
     Class.new(OpenAI::Client) do
       private def prepare_request(request, redirect_count:, retry_count:)
-        raise "internal redirect trust metadata reached a preparer" if request.key?(:redirect_trusted_origin)
+        if [:redirect_trusted_origin, :redirect_body_forbidden].any? { request.key?(_1) }
+          raise "internal redirect policy reached a preparer"
+        end
 
         prepared = super
         if redirect_count.zero?

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -256,6 +256,77 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
   end
 
+  def test_prevents_request_preparation_from_restoring_body_on_cross_origin_get_redirects
+    [301, 302, 303].each do |status|
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, "https://example.com/redirected/#{status}"),
+        successful_response,
+        client_class: body_adding_client_class
+      )
+
+      response = client.request(method: :post, path: "probe")
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal([:post, :get], requests.map(&:method))
+      assert_equal("fake-prepared-private-prompt", requests.first.body)
+      assert_nil(requests.last.body)
+    end
+  end
+
+  def test_strips_credentials_added_during_cross_origin_redirect_preparation
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(
+          headers: prepared.fetch(:headers).merge(
+            "Authorization" => "Bearer fake-prepared-authorization",
+            "Cookie" => "session=fake-prepared-cookie",
+            "X-Api-Key" => "fake-prepared-api-key",
+            "x-safe-trace" => "safe-trace-value"
+          )
+        )
+      end
+    end
+
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://example.com/redirected"),
+      successful_response,
+      client_class: client_class
+    )
+
+    response = client.request(method: :get, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal("Bearer fake-prepared-authorization", requests.first.headers.fetch("Authorization"))
+    %w[authorization cookie x-api-key].each do |header|
+      refute(requests.last.headers.keys.any? { _1.casecmp?(header) }, "#{header} reached the redirect")
+    end
+
+    assert_equal("safe-trace-value", requests.last.headers.fetch("x-safe-trace"))
+  end
+
+  def test_rejects_hostless_and_non_http_redirect_targets
+    ["mailto:fake-user@example.com", "ftp://example.com/redirected", "file:///tmp/fake-private-file"].each do |target|
+      requests = []
+      client, http_client = client_with_responses(requests, redirect_response(307, target))
+
+      error = assert_raises(OpenAI::Errors::APIConnectionError) do
+        client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+      end
+
+      http_client.verify
+      assert_equal("https://trusted.example/v1/probe", error.url.to_s)
+      assert_equal("Server responded with status 307 but no valid location header.", error.message)
+      assert_equal(1, requests.length)
+    end
+  end
+
   def test_rejects_cross_origin_redirect_when_only_the_https_port_changes
     destination = "https://trusted.example:444/v1/redirected"
     requests = []

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -19,7 +19,7 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
 
     http_client.verify
-    assert_equal(destination, error.url.to_s)
+    assert_equal("https://example.com", error.url.to_s)
     assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
     assert_equal(["https://trusted.example/v1/uploads"], requests.map { _1.url.to_s })
     assert_includes(requests.fetch(0).body.to_a.join, "fake-private-file-contents")
@@ -152,7 +152,7 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
 
     http_client.verify
-    assert_equal(destination, error.url.to_s)
+    assert_equal("https://trusted.example:444", error.url.to_s)
     assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
     assert_equal(1, requests.length)
   end
@@ -167,7 +167,7 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
 
     http_client.verify
-    assert_equal(destination, error.url.to_s)
+    assert_equal("https://example.com", error.url.to_s)
     assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
     assert_equal(1, requests.length)
   end
@@ -230,6 +230,29 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     refute_includes(output.string, "fake-private-prompt")
     refute_includes(output.string, "fake-mcp-oauth-token")
     refute_includes(output.string, "fake-redirect-token")
+  end
+
+  def test_rejected_cross_origin_redirect_never_retains_destination_credentials_in_exception
+    destination = "https://fake-user:fake-password@example.com:8443/private/fake-path-credential" \
+      "?access_token=fake-query-token&opaque=fake-opaque-token#fake-fragment-token"
+    requests = []
+    client, http_client = client_with_responses(requests, redirect_response(307, destination))
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    refute_includes(error.url.to_s, "fake-query-token")
+    assert_equal("https://example.com:8443", error.url.to_s)
+    assert_nil(error.url.userinfo)
+    assert_nil(error.url.query)
+    assert_nil(error.url.fragment)
+
+    serialized = Marshal.dump(error)
+    %w[fake-password fake-path-credential fake-query-token fake-opaque-token fake-fragment-token].each do |secret|
+      refute_includes(serialized, secret)
+    end
   end
 
   private def client_with_responses(requests, *responses, **options)

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
+  def test_rejects_cross_origin_308_redirect_with_multipart_body_and_custom_transport
+    destination = "https://example.com/redirected"
+    requests = []
+    client, http_client = client_with_responses(requests, redirect_response(308, destination))
+    file = OpenAI::FilePart.new(StringIO.new("fake-private-file-contents"), filename: "private.txt")
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(
+        method: :post,
+        path: "uploads",
+        headers: {"content-type" => "multipart/form-data"},
+        body: {file: file}
+      )
+    end
+
+    http_client.verify
+    assert_equal(destination, error.url.to_s)
+    assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
+    assert_equal(["https://trusted.example/v1/uploads"], requests.map { _1.url.to_s })
+    assert_includes(requests.fetch(0).body.to_a.join, "fake-private-file-contents")
+  end
+
+  def test_preserves_same_origin_307_and_308_redirect_bodies
+    [307, 308].each do |status|
+      destination = "https://trusted.example/v1/redirected/#{status}"
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, destination),
+        successful_response
+      )
+
+      response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal([:post, :post], requests.map(&:method))
+      assert_equal(destination, requests.last.url.to_s)
+      assert_equal(requests.first.body, requests.last.body)
+      assert_includes(requests.last.body, "fake-private-prompt")
+      assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+    end
+  end
+
+  def test_preserves_same_origin_redirect_with_explicit_default_https_port
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://trusted.example:443/v1/redirected"),
+      successful_response
+    )
+
+    response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal("https://trusted.example/v1/redirected", requests.last.url.to_s)
+    assert_equal(requests.first.body, requests.last.body)
+    assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+  end
+
+  def test_preserves_same_origin_redirect_when_hostname_case_changes
+    destination = "https://TRUSTED.EXAMPLE/v1/redirected"
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, destination),
+      successful_response
+    )
+
+    response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal(destination, requests.last.url.to_s)
+    assert_equal(requests.first.body, requests.last.body)
+    assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+  end
+
+  def test_preserves_bodyless_cross_origin_get_and_head_redirects
+    [[:get, 307], [:get, 308], [:head, 307], [:head, 308], [:head, 303]].each do |method, status|
+      destination = "https://example.com/redirected/#{method}/#{status}"
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, destination),
+        successful_response
+      )
+
+      response = client.request(method: method, path: "probe")
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal([method, method], requests.map(&:method))
+      assert_equal(destination, requests.last.url.to_s)
+      assert_nil(requests.last.body)
+      refute_includes(requests.last.headers, "authorization")
+    end
+  end
+
+  def test_preserves_bodyless_cross_origin_307_post_redirect
+    destination = "https://example.com/redirected"
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, destination),
+      successful_response
+    )
+
+    response = client.request(method: :post, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal([:post, :post], requests.map(&:method))
+    assert_nil(requests.last.body)
+    refute_includes(requests.last.headers, "authorization")
+  end
+
+  def test_converts_cross_origin_301_302_and_303_post_redirects_to_bodyless_gets
+    [301, 302, 303].each do |status|
+      destination = "https://example.com/redirected/#{status}"
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(status, destination),
+        successful_response
+      )
+
+      response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal([:post, :get], requests.map(&:method))
+      assert_nil(requests.last.body)
+      refute_includes(requests.last.headers, "authorization")
+      refute_includes(requests.last.headers, "content-type")
+    end
+  end
+
+  def test_rejects_cross_origin_redirect_when_only_the_https_port_changes
+    destination = "https://trusted.example:444/v1/redirected"
+    requests = []
+    client, http_client = client_with_responses(requests, redirect_response(307, destination))
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    assert_equal(destination, error.url.to_s)
+    assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
+    assert_equal(1, requests.length)
+  end
+
+  def test_rejects_cross_origin_302_redirect_that_preserves_a_put_body
+    destination = "https://example.com/redirected"
+    requests = []
+    client, http_client = client_with_responses(requests, redirect_response(302, destination))
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :put, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    assert_equal(destination, error.url.to_s)
+    assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
+    assert_equal(1, requests.length)
+  end
+
+  def test_rejects_https_downgrade_before_cross_origin_body_check
+    destination = "http://example.com/redirected"
+    requests = []
+    client, http_client = client_with_responses(requests, redirect_response(307, destination))
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    assert_equal("https://trusted.example/v1/probe", error.url.to_s)
+    assert_equal("Tried to redirect to a insecure URL", error.message)
+    assert_equal(1, requests.length)
+  end
+
+  def test_rejected_cross_origin_redirect_closes_response_body
+    body = StringIO.new("redirect response")
+    response = OpenAI::HTTPClient::Response.new(
+      status: 307,
+      headers: {"location" => "https://example.com/redirected"},
+      body: body
+    )
+    requests = []
+    client, http_client = client_with_responses(requests, response)
+
+    assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    assert_equal(1, requests.length)
+    assert_predicate(body, :closed?)
+  end
+
+  def test_rejected_cross_origin_redirect_never_logs_customer_or_destination_credentials
+    destination = "https://example.com/redirected?access_token=fake-redirect-token"
+    requests = []
+    output = StringIO.new
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, destination),
+      logger: Logger.new(output),
+      log_level: :debug
+    )
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(
+        method: :post,
+        path: "probe",
+        body: {prompt: "fake-private-prompt", tools: [{authorization: "fake-mcp-oauth-token"}]}
+      )
+    end
+
+    http_client.verify
+    assert_equal("Cannot follow a cross-origin redirect with a request body.", error.message)
+    refute_includes(output.string, "fake-private-prompt")
+    refute_includes(output.string, "fake-mcp-oauth-token")
+    refute_includes(output.string, "fake-redirect-token")
+  end
+
+  private def client_with_responses(requests, *responses, **options)
+    http_client = Minitest::Mock.new(OpenAI::HTTPClient.new)
+    responses.each do |response|
+      http_client.expect(:execute, response) do |request|
+        requests << request
+        true
+      end
+    end
+
+    client = OpenAI::Client.new(
+      api_key: "fake-api-key",
+      base_url: "https://trusted.example/v1",
+      http_client: http_client,
+      **options
+    )
+    [client, http_client]
+  end
+
+  private def redirect_response(status, destination)
+    OpenAI::HTTPClient::Response.new(status: status, headers: {"location" => destination}, body: "")
+  end
+
+  private def successful_response
+    OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: "{\"ok\":true}"
+    )
+  end
+end

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -423,7 +423,7 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
         url = prepared.fetch(:url)
         url.host = "escaped.example"
         url.query = "api_key=fake-escaped-query-key"
-        prepared.merge(url: url)
+        prepared.merge(url: url, headers: prepared.fetch(:headers).merge("hOsT" => "escaped.example"))
       end
     end
 
@@ -434,16 +434,23 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
       client, http_client = client_with_responses(
         requests,
         redirect_response(307, destination),
+        OpenAI::HTTPClient::Response.new(status: 500, headers: {}, body: ""),
         successful_response,
-        client_class: client_class
+        client_class: client_class,
+        max_retries: 1,
+        initial_retry_delay: 0,
+        max_retry_delay: 0
       )
 
       response = client.request(method: :get, path: "probe")
 
       http_client.verify
       assert_equal(true, response[:ok])
-      assert_equal(destination, requests.last.url.to_s)
-      refute_includes(requests.last.url.to_s, "fake-escaped-query-key")
+      requests.drop(1).each do |request|
+        assert_equal(destination, request.url.to_s)
+        refute_includes(request.url.to_s, "fake-escaped-query-key")
+        refute(request.headers.keys.any? { _1.casecmp?("host") }, "escaped Host header reached the redirect")
+      end
     end
   end
 

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -341,6 +341,64 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     end
   end
 
+  def test_converts_prepared_post_redirects_using_dispatched_method_across_retries
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        super.merge(method: :post, body: "fake-prepared-private-prompt")
+      end
+    end
+
+    [301, 302, 303].each do |status|
+      %w[trusted.example download.example].each do |hostname|
+        requests = []
+        client, http_client = client_with_responses(
+          requests,
+          OpenAI::HTTPClient::Response.new(status: 500, headers: {}, body: ""),
+          redirect_response(status, "https://#{hostname}/redirected/#{status}"),
+          OpenAI::HTTPClient::Response.new(status: 500, headers: {}, body: ""),
+          successful_response,
+          client_class: client_class,
+          max_retries: 2,
+          initial_retry_delay: 0,
+          max_retry_delay: 0
+        )
+
+        response = client.request(method: :get, path: "probe")
+
+        http_client.verify
+        assert_equal(true, response[:ok])
+        assert_equal([:post, :post, :get, :get], requests.map(&:method))
+        assert_equal(
+          ["fake-prepared-private-prompt", "fake-prepared-private-prompt", nil, nil],
+          requests.map(&:body)
+        )
+      end
+    end
+  end
+
+  def test_preserves_dispatched_head_method_on_303_redirect
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        super.merge(method: :head, body: "fake-prepared-private-prompt")
+      end
+    end
+
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(303, "https://trusted.example/v1/redirected"),
+      successful_response,
+      client_class: client_class
+    )
+
+    response = client.request(method: :get, path: "probe")
+
+    http_client.verify
+    assert_equal(true, response[:ok])
+    assert_equal([:head, :head], requests.map(&:method))
+    assert_nil(requests.last.body)
+  end
+
   def test_keeps_converted_same_origin_redirects_bodyless_after_preparation
     client_class = Class.new(OpenAI::Client) do
       private def prepare_request(request, redirect_count:, retry_count:)

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -185,6 +185,43 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
     assert_equal(1, requests.length)
   end
 
+  def test_preserves_valid_ipvfuture_endpoints_and_same_origin_redirects
+    %w[v1.foo vF.a:b].each do |hostname|
+      requests = []
+      client, http_client = client_with_responses(
+        requests,
+        redirect_response(307, "https://[#{hostname}]/v1/redirected"),
+        successful_response,
+        base_url: "https://[#{hostname}]/v1"
+      )
+
+      response = client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+
+      http_client.verify
+      assert_equal(true, response[:ok])
+      assert_equal(["[#{hostname}]", "[#{hostname}]"], requests.map { _1.url.host })
+      assert_equal(requests.first.body, requests.last.body)
+      assert_equal("Bearer fake-api-key", requests.last.headers.fetch("authorization"))
+    end
+  end
+
+  def test_rejects_cross_origin_redirect_between_distinct_ipvfuture_hosts
+    requests = []
+    client, http_client = client_with_responses(
+      requests,
+      redirect_response(307, "https://[v1.bar]/v1/redirected"),
+      base_url: "https://[v1.foo]/v1"
+    )
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) do
+      client.request(method: :post, path: "probe", body: {prompt: "fake-private-prompt"})
+    end
+
+    http_client.verify
+    assert_equal("https://[v1.bar]", error.url.to_s)
+    assert_equal(1, requests.length)
+  end
+
   def test_preserves_bodyless_cross_origin_get_and_head_redirects
     [[:get, 307], [:get, 308], [:head, 307], [:head, 308], [:head, 303]].each do |method, status|
       destination = "https://example.com/redirected/#{method}/#{status}"
@@ -442,7 +479,7 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
         url = prepared.fetch(:url)
         url.user = "fake-prepared-user"
         url.password = "fake-prepared-password"
-        url.query = "#{url.query}&api_key=fake-prepared-query-key&opaque=fake-prepared-opaque-secret"
+        url.query << "&api_key=fake-prepared-query-key&opaque=fake-prepared-opaque-secret"
         prepared.merge(url: url)
       end
     end
@@ -479,7 +516,7 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
         return prepared if redirect_count.zero?
 
         url = prepared.fetch(:url)
-        url.host = "escaped.example"
+        url.host.replace("escaped.example")
         url.query = "api_key=fake-escaped-query-key"
         prepared.merge(url: url, headers: prepared.fetch(:headers).merge("hOsT" => "escaped.example"))
       end

--- a/test/openai/internal/transport/base_client_redirect_test.rb
+++ b/test/openai/internal/transport/base_client_redirect_test.rb
@@ -518,7 +518,16 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
         url = prepared.fetch(:url)
         url.host.replace("escaped.example")
         url.query = "api_key=fake-escaped-query-key"
-        prepared.merge(url: url, headers: prepared.fetch(:headers).merge("hOsT" => "escaped.example"))
+        prepared.merge(
+          url: url,
+          headers: prepared.fetch(:headers).merge(
+            "hOsT" => "escaped.example",
+            "Authorization" => "Bearer fake-escaped-authorization",
+            "cOoKiE" => "session=fake-escaped-cookie",
+            "X-Api-Key" => "fake-escaped-api-key",
+            "x-safe-trace" => "safe-trace-value"
+          )
+        )
       end
     end
 
@@ -545,6 +554,11 @@ class OpenAI::Test::BaseClientRedirectTest < Minitest::Test
         assert_equal(destination, request.url.to_s)
         refute_includes(request.url.to_s, "fake-escaped-query-key")
         refute(request.headers.keys.any? { _1.casecmp?("host") }, "escaped Host header reached the redirect")
+        %w[authorization cookie x-api-key].each do |header|
+          refute(request.headers.keys.any? { _1.casecmp?(header) }, "escaped #{header} reached the redirect")
+        end
+
+        assert_equal("safe-trace-value", request.headers.fetch("x-safe-trace"))
       end
     end
   end


### PR DESCRIPTION
## Summary
- Keep request bodies within the original origin when following redirects.
- Preserve same-origin redirects, case-insensitive hostnames, bodyless cross-origin requests, and existing redirect method conversions.
- Add focused coverage for redirect status codes, alternate ports, custom transports, response cleanup, and diagnostic redaction.

## Compatibility
No public classes, method signatures, typed declarations, supported Ruby versions, dependencies, or exception families change. Requests that attempt to retain a body while redirecting to a different origin now raise the existing `OpenAI::Errors::APIConnectionError`; integrations can configure their trusted destination directly when needed.

## Verification
- `mise exec ruby@4.0.6 -- bundle exec rake test` — 935 tests, 5,008 assertions; one opt-in live AWS test skipped.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — formatting, Sorbet, RBS, and 2,701 RuboCop targets pass.
- Focused redirect coverage passes on Ruby 3.3, 3.4, and 4.0.
- Azure, Bedrock, custom transport, replayability, and logging-security suites pass.