### PR TITLE
fix: keep CodeQL action updates atomic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,5 +37,5 @@ updates:
     groups:
       codeql:
         patterns:
-          - "github/codeql-action"
+          - "github/codeql-action/*"
     open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:${{ matrix.language }}'

--- a/test/scripts/codeql_workflow_test.rb
+++ b/test/scripts/codeql_workflow_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "yaml"
+
+class CodeQLWorkflowTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  WORKFLOW = File.join(ROOT, ".github/workflows/codeql.yml")
+  ACTIONS = %w[github/codeql-action/init github/codeql-action/analyze].freeze
+
+  def test_codeql_actions_use_the_same_pinned_release
+    uses = File.read(WORKFLOW).scan(
+      %r{^\s*uses:\s+(github/codeql-action/(?:init|analyze))@([0-9a-f]{40})\s+#\s+(v\d+\.\d+\.\d+)\s*$}
+    )
+
+    assert_equal(ACTIONS, uses.map(&:first))
+    assert_equal(1, uses.map { _1.fetch(1) }.uniq.length, "CodeQL actions must use the same commit")
+    assert_equal(1, uses.map { _1.fetch(2) }.uniq.length, "CodeQL actions must use the same release")
+  end
+
+  def test_dependabot_groups_every_codeql_sub_action
+    dependabot = YAML.safe_load_file(File.join(ROOT, ".github/dependabot.yml"))
+    updates = dependabot.fetch("updates").find { _1.fetch("package-ecosystem") == "github-actions" }
+    patterns = updates.fetch("groups").fetch("codeql").fetch("patterns")
+
+    ACTIONS.each do |action|
+      assert(patterns.any? { File.fnmatch?(_1, action) }, "Dependabot does not group #{action}")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Update `github/codeql-action/init` and `github/codeql-action/analyze` together to the verified official `v4.37.7` commit `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`.
- Fix the existing Dependabot CodeQL group to match actual sub-action dependency names with `github/codeql-action/*`, preventing future split updates.
- Add focused regression coverage requiring both sub-actions to share one full SHA/version and confirming the Dependabot pattern matches both real dependency names.

Dependabot PRs #458 and #463 independently update only one sub-action, which makes both Actions and Ruby CodeQL jobs fail with a loaded/running version mismatch. The existing `github/codeql-action` group pattern does not match `github/codeql-action/init` or `github/codeql-action/analyze`; this PR replaces both broken updates atomically.

Supersedes #458 and #463.

## Security and compatibility

- Verified GitHub's official `v4.37.7` tag resolves to the pinned full commit SHA.
- Preserves all workflow triggers, concurrency, scan languages, action inputs, least-privilege permissions, `persist-credentials: false`, SHA pinning, and release protections.
- No changes to runtime/public APIs, supported Ruby versions, gem dependencies, gem sources, lockfiles, native extensions, or published package behavior.

## Validation

- Reproduced the original failure: the new Dependabot regression fails against the previous group pattern.
- Full Ruby 3.3, 3.4, and 4.0 suites: **958 tests / 5,211 assertions each; 0 failures, 0 errors**.
- Full RuboCop and Ruby/RBS formatting checks: **2,701 files; 0 offenses**.
- Sorbet: no errors.
- RBS/Steep: **1,236 signature files validated; 0 errors**.
- `bundle exec rake build:gem`: succeeded.
- Targeted CodeQL/Dependabot regression: 2 tests / 5 assertions.
- Parsed both YAML files and compared the complete CodeQL workflow against `main`, allowing only the two intended action-reference changes.

Requesting review from @openai/sdks-team because this changes CI/security dependencies.