### PR TITLE
chore(deps-dev): upgrade Steep with compatible RBS diagnostics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,19 +18,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2.1)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
@@ -83,7 +70,6 @@ GEM
       bigdecimal
       rexml
     csv (3.3.5)
-    drb (2.2.3)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -97,8 +83,6 @@ GEM
     fiber-storage (1.0.1)
     fileutils (1.8.0)
     hashdiff (1.2.1)
-    i18n (1.15.2)
-      concurrent-ruby (~> 1.0)
     io-endpoint (0.17.2)
     io-event (1.11.2)
     io-stream (0.14.0)
@@ -117,7 +101,6 @@ GEM
       minitest (> 5.3)
     minitest-proveit (1.0.0)
       minitest (> 5, < 7)
-    mutex_m (0.3.0)
     openssl (4.0.2)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -147,8 +130,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.9.5)
+    rbs (4.1.3)
       logger
+      prism (>= 1.6.0)
+      tsort
     redcarpet (3.6.1)
     regexp_parser (2.11.3)
     rexml (3.4.4)
@@ -174,8 +159,7 @@ GEM
     sorbet-static (0.6.12690-aarch64-linux)
     sorbet-static (0.6.12690-universal-darwin)
     sorbet-static (0.6.12690-x86_64-linux)
-    steep (1.10.0)
-      activesupport (>= 5.1)
+    steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -183,10 +167,10 @@ GEM
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.1)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.9)
+      rbs (~> 4.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
@@ -197,8 +181,7 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     traces (0.18.2)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
+    tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)

--- a/test/scripts/validate_rbs_test.rb
+++ b/test/scripts/validate_rbs_test.rb
@@ -56,8 +56,22 @@ class ValidateRBSScriptTest < Minitest::Test
     )
 
     refute_predicate(status, :success?)
-    assert_includes(stdout, "RBS::UnknownTypeName")
-    assert_includes(stdout, "b.rbs")
+    assert_match(
+      /sig\/a\.rbs.*string contains null byte.*RBS::UnexpectedError|sig\/b\.rbs.*RBS::UnknownTypeName/m,
+      stdout
+    )
+  end
+
+  def test_checks_original_files_directly_when_a_signature_contains_nul
+    stdout, stderr, status, calls = run_validation(
+      {"invalid.rbs" => "module Example\nend\n\x00"},
+      fake_steep_results: [1]
+    )
+
+    refute_predicate(status, :success?)
+    assert_empty(stdout)
+    assert_empty(stderr)
+    assert_equal([%w[check --no-type-check]], calls)
   end
 
   def test_uses_one_consolidated_steep_check_on_success


### PR DESCRIPTION
## Summary
- Supersedes Dependabot #461 with a conservative development-only upgrade: `steep` 1.10.0 → 2.0.0 and `rbs` 3.9.5 → 4.1.3.
- Preserve rejection of malformed NUL-containing signatures and require the exact original-file diagnostic appropriate to each RBS generation: either `a.rbs` + `string contains null byte` + `RBS::UnexpectedError`, or `b.rbs` + `RBS::UnknownTypeName`.
- Add a focused regression proving NUL-containing inputs execute exactly one original-file Steep check and retain a failing exit status.
- Keep unrelated transitive versions—including native `ffi`—unchanged; add only required `tsort` and remove dependencies no longer required by Steep 2.

## Compatibility and supply-chain review
- No SDK runtime code, public API, gemspec, supported Ruby version, published runtime dependency, gem source, pinned Git revision, platform, workflow, authentication, transport, or generated code changes.
- Inspected Steep/RBS/tsort gemspecs and the RBS native-extension build script; the published gem still depends only on `connection_pool >= 2.2.3` and `logger`.

## Verification
- Full Ruby 3.3.12, 3.4.10, and 4.0.6 suites: **957 tests, 5,210 assertions, zero failures** on each version.
- Focused validator regressions against legacy RBS 3.9.5 and newer RBS behavior; complete updated validator suite: 13 tests, 64 assertions.
- `bundle exec rake lint:rubocop` (2,700 files, formatting and RuboCop-directive validation included).
- `bundle exec rake typecheck:sorbet`.
- `bundle exec rake validate:rbs` (1,236 signatures).
- `bundle exec rake build:gem`; inspected packaged runtime dependencies and confirmed development-only changed files are excluded.
- Bundler confirms the conservative lockfile is canonical; `bundle check` passes for Ruby 3.3, 3.4, and 4.0.