### PR TITLE
chore(ci): upgrade actions/checkout to v7.0.1

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       RUBOCOP_CACHE_ROOT: ${{ github.workspace }}/.cache/rubocop
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -46,7 +46,7 @@ jobs:
       contents: read
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -68,7 +68,7 @@ jobs:
       # fallback tuned so failing builds produce exact diagnostics promptly.
       STEEP_JOBS: 8
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -86,7 +86,7 @@ jobs:
       contents: read
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -108,7 +108,7 @@ jobs:
       matrix:
         ruby-version: ['3.3', '3.4', '4.0']
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Ruby

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -61,7 +61,7 @@ jobs:
       id-token: write # Exchange GitHub OIDC credentials with RubyGems.org.
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Avoid persisting the default GITHUB_TOKEN; the RubyGems release action
           # configures the credentials it needs only when publishing.

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ github.sha }}


### PR DESCRIPTION
## Summary

- Upgrade all eight `actions/checkout` references across CI checks, CodeQL, RubyGems publishing, and examples E2E from v6.0.2 to the official GitHub-verified v7.0.1 commit `3d3c42e5aac5ba805825da76410c181273ba90b1`.
- Correct every full-SHA annotation to `# v7.0.1`; Dependabot #464 updates the commit but incorrectly leaves all eight annotations at `# v6`.
- Preserve full immutable commit pinning, workflow-level `permissions: {}`, least-privilege per-job permissions, `persist-credentials: false`, protected `release`/`publish`/`ci` environments, RubyGems OIDC trusted publishing, and the examples workflow's explicit `${{ github.sha }}` checkout ref.

Supersedes #464.

## Compatibility and supply-chain review

- Confirmed the upstream v7.0.1 release is GitHub-signed and resolves to the exact pinned commit.
- Confirmed the upstream action still runs on Node 24, which checkout has already required since v5; all affected jobs use GitHub-hosted `ubuntu-latest` runners.
- Confirmed no repository workflow uses `pull_request_target` or `workflow_run`, so v7's safer default blocking of privileged fork checkouts cannot break an existing trigger; no unsafe override was introduced.
- Confirmed upstream immutable-release behavior does not change our stronger full-commit-SHA pinning.
- Confirmed `Gemfile`, `Gemfile.lock`, `openai.gemspec`, published runtime dependencies, SDK behavior, and supported Ruby versions are unchanged.

## Validation

- `actionlint` across every workflow.
- Focused workflow provenance/security validation across all 5 workflows and all 8 checkout steps: exact signed SHA, accurate version annotations, full-SHA action pins, disabled credential persistence, safe triggers, least-privilege permissions, protected environments, RubyGems OIDC publishing, and the examples checkout ref.
- Existing examples-workflow security regression: 1 test, 17 assertions.
- Full Ruby 3.3, 3.4, and 4.0 matrix: **956 tests and 5,206 assertions passing on each version** (one pre-existing skip per run).
- Full formatting/RuboCop suite: **2,700 files, no offenses**.
- Sorbet: no errors.
- RBS/Steep: **1,236 RBS files validated**.
- Example inventory and `bundle exec rake build:gem`.
- Strict maintainability, general code, workflow-security, and supply-chain reviews: no findings.