### PR TITLE
fix: preserve generic request authentication precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,11 @@ response = client.request(
 )
 ```
 
+Generic requests use the ordinary API key when one is configured, even if an
+admin API key is also available. A client configured with only an admin API key
+uses that key. To explicitly use an admin API key when both credentials are
+configured, pass `security: {admin_api_key_auth: true}` to `client.request`.
+
 ### Concurrency & connection pooling
 
 `OpenAI::Client` instances using the default `OpenAI::NetHTTPClient` are threadsafe, but are only fork-safe when there are no in-flight HTTP requests. Injected HTTP clients are responsible for documenting and enforcing their own concurrency guarantees.

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -133,7 +133,13 @@ module OpenAI
       return {} if @provider_runtime
 
       enabled_security = security.select { |_, enabled| enabled }
-      headers = {bearer_auth:, admin_api_key_auth:}.slice(*enabled_security.keys).values.reduce({}, :merge)
+      enabled_auth = {bearer_auth:, admin_api_key_auth:}.select { |scheme, _| enabled_security.key?(scheme) }
+      headers = enabled_auth.values.reduce({}) do |merged, authentication|
+        merged.merge(authentication) do |header, previous, current|
+          header == "authorization" ? previous : current
+        end
+      end
+
       if headers.empty? && enabled_security.any?
         raise(
           ArgumentError,

--- a/test/openai/client_authentication_test.rb
+++ b/test/openai/client_authentication_test.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::ClientAuthenticationTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def test_generic_request_uses_only_configured_normal_api_key
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key", admin_api_key: nil)
+
+    assert_equal({}, openai.request(method: :get, path: "models"))
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      assert_equal("Bearer My API Key", request.headers["Authorization"])
+    end
+  end
+
+  def test_generic_request_uses_only_configured_admin_api_key
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: nil, admin_api_key: "My Admin API Key")
+
+    openai.request(method: :get, path: "models")
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      assert_equal("Bearer My Admin API Key", request.headers["Authorization"])
+    end
+  end
+
+  def test_generic_request_prefers_normal_api_key_when_both_credentials_exist
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.request(method: :get, path: "models")
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      assert_equal("Bearer My API Key", request.headers["Authorization"])
+    end
+  end
+
+  def test_generic_request_prefers_normal_api_key_regardless_of_security_scheme_order
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.request(method: :get, path: "models", security: {admin_api_key_auth: true, bearer_auth: true})
+    openai.request(method: :get, path: "models", security: {bearer_auth: true, admin_api_key_auth: true})
+
+    assert_requested(:get, "http://localhost/models", times: 2) do |request|
+      assert_equal("Bearer My API Key", request.headers["Authorization"])
+    end
+  end
+
+  def test_generic_request_preserves_noncolliding_authentication_headers
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    client_class = Class.new(OpenAI::Client) do
+      private def bearer_auth
+        super.merge("x-ordinary-auth" => "ordinary", "x-shared-auth" => "ordinary")
+      end
+
+      private def admin_api_key_auth
+        super.merge("x-admin-auth" => "admin", "x-shared-auth" => "admin")
+      end
+    end
+
+    openai = client_class.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.request(method: :get, path: "models")
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      headers = request.headers.transform_keys(&:downcase)
+      assert_equal("Bearer My API Key", headers["authorization"])
+      assert_equal("ordinary", headers["x-ordinary-auth"])
+      assert_equal("admin", headers["x-admin-auth"])
+      assert_equal("admin", headers["x-shared-auth"])
+    end
+  end
+
+  def test_generic_request_preserves_explicit_admin_authentication
+    stub_request(:get, "http://localhost/organization/admin_api_keys").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.request(method: :get, path: "organization/admin_api_keys", security: {admin_api_key_auth: true})
+
+    assert_requested(:get, "http://localhost/organization/admin_api_keys") do |request|
+      assert_equal("Bearer My Admin API Key", request.headers["Authorization"])
+    end
+  end
+
+  def test_disabled_security_schemes_do_not_send_authentication_headers
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.request(method: :get, path: "models", security: {bearer_auth: false, admin_api_key_auth: false})
+
+    assert_requested(:get, "http://localhost/models") do |request|
+      refute_includes(request.headers.transform_keys(&:downcase), "authorization")
+    end
+  end
+
+  def test_generic_request_options_preserve_default_credential_and_header_overrides
+    stub_request(:get, "http://localhost/models").to_return_json(status: 200, body: {})
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.request(method: :get, path: "models", options: {extra_headers: {"x-request-option" => "kept"}})
+    openai.request(
+      method: :get,
+      path: "models",
+      options: {extra_headers: {"authorization" => "Bearer explicit-request-key"}}
+    )
+
+    assert_requested(:get, "http://localhost/models", headers: {"X-Request-Option" => "kept"}) do |request|
+      assert_equal("Bearer My API Key", request.headers["Authorization"])
+    end
+
+    assert_requested(
+      :get,
+      "http://localhost/models",
+      headers: {"Authorization" => "Bearer explicit-request-key"}
+    ) do |request|
+      assert_equal("Bearer explicit-request-key", request.headers["Authorization"])
+    end
+  end
+
+  def test_generated_resources_preserve_route_specific_authentication_and_request_options
+    ordinary_url = "http://localhost/models"
+    admin_url = "http://localhost/organization/admin_api_keys"
+    response = {object: "list", data: [], has_more: false}
+    stub_request(:get, ordinary_url).to_return_json(status: 200, body: response)
+    stub_request(:get, admin_url).to_return_json(status: 200, body: response)
+    openai = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "My API Key",
+      admin_api_key: "My Admin API Key"
+    )
+
+    openai.models.list(request_options: {extra_headers: {"x-resource" => "ordinary"}})
+    openai.admin.organization.admin_api_keys.list(request_options: {extra_headers: {"x-resource" => "admin"}})
+
+    assert_requested(:get, ordinary_url, headers: {"X-Resource" => "ordinary"}) do |request|
+      assert_equal("Bearer My API Key", request.headers["Authorization"])
+    end
+
+    assert_requested(:get, admin_url, headers: {"X-Resource" => "admin"}) do |request|
+      assert_equal("Bearer My Admin API Key", request.headers["Authorization"])
+    end
+  end
+
+  def test_generated_resources_do_not_substitute_an_unrequested_credential
+    ordinary_only = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key", admin_api_key: nil)
+    admin_only = OpenAI::Client.new(base_url: "http://localhost", api_key: nil, admin_api_key: "My Admin API Key")
+
+    ordinary_error = assert_raises(ArgumentError) { ordinary_only.admin.organization.admin_api_keys.list }
+    admin_error = assert_raises(ArgumentError) { admin_only.models.list }
+
+    assert_match(/Could not resolve authentication method/, ordinary_error.message)
+    assert_match(/Could not resolve authentication method/, admin_error.message)
+    assert_not_requested(:any, /./)
+  end
+
+  def test_provider_runtime_preserves_its_own_authentication
+    url = "https://example.openai.azure.com/openai/v1/models"
+    stub_request(:get, url).to_return_json(status: 200, body: {})
+    provider = OpenAI::Providers.azure(endpoint: "https://example.openai.azure.com", api_key: "azure-key")
+    openai = OpenAI::Client.new(provider: provider)
+
+    openai.request(method: :get, path: "models")
+
+    assert_requested(:get, url) do |request|
+      headers = request.headers.transform_keys(&:downcase)
+      assert_equal("azure-key", headers["api-key"])
+      refute_includes(headers, "authorization")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Keep generic request authentication consistent with the configured ordinary API credential while preserving explicit administrator authentication and administrator-only clients.
- Preserve independent authentication headers, request options, provider runtimes, route-specific behavior, and existing public Ruby/RBI/RBS interfaces.
- Document explicit administrator authentication and add focused compatibility coverage.

## Test plan

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/client_authentication_test.rb` (11 tests, 25 assertions; also passes on Ruby 3.3.12 and 3.4.10).
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/client_test.rb` (36 tests, 185 assertions).
- `mise exec ruby@4.0.6 -- bundle exec rake lint` (Sorbet, 1,236 RBS files, and 2,701 RuboCop-inspected files).
- Broad suite: 930 tests pass together; four pre-existing timing-sensitive tests pass when isolated on supported Ruby runtimes.
