### PR TITLE
fix(ci): require fail-closed CodeQL checks for Ruby and GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ permissions: {}
 
 jobs:
   analyze:
-    name: analyze (${{ matrix.language }})
+    name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -43,8 +43,54 @@ jobs:
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
+          build-mode: none
 
       - name: Perform CodeQL analysis
+        id: analyze
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:${{ matrix.language }}'
+          output: ${{ runner.temp }}/codeql-results/${{ matrix.language }}
+
+      - name: Reject CodeQL findings
+        env:
+          CODEQL_LANGUAGE: ${{ matrix.language }}
+          SARIF_DIRECTORY: ${{ steps.analyze.outputs.sarif-output }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          sarif_files=("${SARIF_DIRECTORY}"/*.sarif)
+          if [[ ${#sarif_files[@]} -eq 0 ]]; then
+            echo "::error::CodeQL produced no SARIF results for ${CODEQL_LANGUAGE}."
+            exit 1
+          fi
+
+          for sarif_file in "${sarif_files[@]}"; do
+            if ! jq -e \
+              '(.runs | type == "array" and length > 0) and all(.runs[]; .results | type == "array")' \
+              "${sarif_file}" > /dev/null; then
+              echo "::error::CodeQL produced invalid SARIF for ${CODEQL_LANGUAGE}."
+              exit 1
+            fi
+
+            finding_count="$(jq '[.runs[] | .results // [] | .[]] | length' "${sarif_file}")"
+            if [[ ${finding_count} -ne 0 ]]; then
+              jq -r '
+                def escape_data:
+                  tostring | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
+                def escape_property:
+                  escape_data | gsub(":"; "%3A") | gsub(","; "%2C");
+
+                .runs[] | .results[] |
+                (.ruleId // "unknown" | escape_property) as $rule |
+                (.message.text // .message.markdown // "CodeQL finding" | escape_data) as $message |
+                (.locations[0].physicalLocation.artifactLocation.uri // "unknown" | escape_property) as $file |
+                (.locations[0].physicalLocation.region.startLine // 1 |
+                  if type == "number" and . > 0 then floor else 1 end) as $line |
+                "::error file=\($file),line=\($line),title=\($rule)::\($message)"
+              ' "${sarif_file}"
+              exit 1
+            fi
+          done

--- a/test/scripts/codeql_workflow_test.rb
+++ b/test/scripts/codeql_workflow_test.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "json"
+require "open3"
+require "tmpdir"
 require "yaml"
 
 class CodeQLWorkflowTest < Minitest::Test
@@ -25,6 +28,112 @@ class CodeQLWorkflowTest < Minitest::Test
 
     ACTIONS.each do |action|
       assert(patterns.any? { File.fnmatch?(_1, action) }, "Dependabot does not group #{action}")
+    end
+  end
+
+  def test_codeql_has_stable_required_checks_for_actions_and_ruby
+    workflow = YAML.safe_load_file(WORKFLOW)
+    analyze = workflow.fetch("jobs").fetch("analyze")
+
+    assert_equal("CodeQL (${{ matrix.language }})", analyze.fetch("name"))
+    assert_equal(%w[actions ruby], analyze.fetch("strategy").fetch("matrix").fetch("language"))
+    assert_includes(workflow.fetch(true), "pull_request")
+    assert_includes(workflow.fetch(true), "merge_group")
+  end
+
+  def test_codeql_preserves_published_security_results
+    workflow = YAML.safe_load_file(WORKFLOW)
+    analyze = workflow.fetch("jobs").fetch("analyze")
+    step = analyze.fetch("steps").find { _1.fetch("name") == "Perform CodeQL analysis" }
+
+    assert_equal("write", analyze.fetch("permissions").fetch("security-events"))
+    assert_equal("analyze", step.fetch("id"))
+    assert_equal(
+      "${{ runner.temp }}/codeql-results/${{ matrix.language }}",
+      step.fetch("with").fetch("output")
+    )
+    refute_equal("never", step.fetch("with")["upload"])
+  end
+
+  def test_findings_gate_accepts_clean_sarif
+    output, error, status = run_findings_gate("clean.sarif" => {"runs" => [{"results" => []}]})
+
+    assert(status.success?, "#{output}\n#{error}")
+  end
+
+  def test_findings_gate_rejects_missing_sarif
+    output, _error, status = run_findings_gate({})
+
+    refute(status.success?)
+    assert_includes(output, "CodeQL produced no SARIF results for ruby")
+  end
+
+  def test_findings_gate_rejects_invalid_sarif
+    ["invalid-json", {"runs" => []}, {"runs" => [{}]}].each do |sarif|
+      output, _error, status = run_findings_gate("invalid.sarif" => sarif)
+
+      refute(status.success?, sarif.inspect)
+      assert_includes(output, "CodeQL produced invalid SARIF for ruby")
+    end
+  end
+
+  def test_findings_gate_rejects_findings_in_any_sarif_file
+    sarif = {"runs" => [{"results" => [{"ruleId" => "ruby/security", "message" => {"text" => "unsafe"}}]}]}
+    output, _error, status = run_findings_gate(
+      "clean.sarif" => {"runs" => [{"results" => []}]},
+      "findings.sarif" => sarif
+    )
+
+    refute(status.success?)
+    assert_includes(output, "title=ruby/security::unsafe")
+  end
+
+  def test_findings_gate_escapes_github_workflow_commands
+    sarif = {
+      "runs" => [
+        {
+          "results" => [
+            {
+              "ruleId" => "ruby,rule:1\n::warning::injected",
+              "message" => {"text" => "first%line\r\n::warning::injected"},
+              "locations" => [
+                {
+                  "physicalLocation" => {
+                    "artifactLocation" => {"uri" => "lib/a,b:c%file.rb\r\n::notice::injected"},
+                    "region" => {"startLine" => 7}
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    output, _error, status = run_findings_gate("findings.sarif" => sarif)
+
+    refute(status.success?)
+    assert_equal(1, output.lines.length)
+    assert_includes(output, "file=lib/a%2Cb%3Ac%25file.rb%0D%0A%3A%3Anotice%3A%3Ainjected,line=7")
+    assert_includes(output, "title=ruby%2Crule%3A1%0A%3A%3Awarning%3A%3Ainjected")
+    assert_includes(output, "::first%25line%0D%0A::warning::injected")
+  end
+
+  private
+
+  def run_findings_gate(files)
+    workflow = YAML.safe_load_file(WORKFLOW)
+    step = workflow.fetch("jobs").fetch("analyze").fetch("steps").find do
+      _1.fetch("name") == "Reject CodeQL findings"
+    end
+
+    Dir.mktmpdir("openai-codeql-workflow-test") do |directory|
+      files.each do |name, sarif|
+        content = sarif.is_a?(String) ? sarif : JSON.generate(sarif)
+        File.write(File.join(directory, name), content)
+      end
+
+      Open3.capture3({"CODEQL_LANGUAGE" => "ruby", "SARIF_DIRECTORY" => directory}, "bash", "-c", step.fetch("run"))
     end
   end
 end


### PR DESCRIPTION
## Summary

- give the GitHub Actions and Ruby CodeQL jobs stable, individually requireable `CodeQL (actions)` and `CodeQL (ruby)` check names
- keep publishing CodeQL SARIF to GitHub code scanning while failing closed on missing, malformed, or non-empty SARIF results, matching the enforcement used by the Node SDK
- cover PR and merge-queue scanning, SARIF validation, multiple-result handling, and GitHub workflow-command escaping with executable regression tests

## Why

The existing Ruby CodeQL workflow runs on pull requests and merge groups, but a successful analysis does not reject findings and its jobs are not required by the protected-branch ruleset. This change makes both language checks meaningful merge-protection gates while preserving SHA-pinned actions, `permissions: {}`, per-job least privilege, `persist-credentials: false`, and existing code-scanning uploads.

After both new checks have succeeded on this pull request, add `CodeQL (actions)` and `CodeQL (ruby)` to the existing `main` ruleset without removing `ci / ci-required` or weakening its current strict-check and bypass settings.

## Validation

- Ruby 3.3.12: `bundle exec rake test` — 994 tests, 5,924 assertions, no failures
- Ruby 3.4.10: `bundle exec rake test` — 994 tests, 5,924 assertions, no failures
- Ruby 4.0.6: `bundle exec rake test` — 994 tests, 5,924 assertions, no failures
- `bundle exec rake lint:rubocop` — 2,703 files, no offenses
- `bundle exec rake typecheck:sorbet`
- `bundle exec rake validate:rbs` — 1,236 signatures, no errors
- `bundle exec rake build:gem`
- `actionlint` across every GitHub Actions workflow
- focused CodeQL workflow security tests — 9 tests, 39 assertions