### PR TITLE
chore: isolate documentation dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,28 @@ updates:
           - patch
     open-pull-requests-limit: 5
 
+  - package-ecosystem: bundler
+    directory: /docs
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 8
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,9 @@
   errors, snapshots, and CI artifacts. Clearly fake or sanitized payloads may
   remain in tests and diagnostics.
 - Review direct and transitive dependency changes in `Gemfile`, `Gemfile.lock`,
-  and `openai.gemspec`, including gem sources, locked Git revisions, native
-  extensions, and install/build scripts. Do not run unreviewed scripts.
+  `docs/Gemfile`, `docs/Gemfile.lock`, and `openai.gemspec`, including gem
+  sources, locked Git revisions, native extensions, and install/build scripts.
+  Do not run unreviewed scripts.
 - Pin GitHub Actions to full commit SHAs and preserve least-privilege job
   permissions, `permissions: {}`, and `persist-credentials: false`.
 - Protect GitHub App private keys and release credentials. Preserve protected

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ To set up the repository, run:
 $ ./scripts/bootstrap
 ```
 
-This will install all the required dependencies.
+This installs the dependencies used by the normal test, lint, typecheck, and
+package workflows. Documentation tooling has a separate bundle; see
+[Documentation](#documentation).
 
 ## Security requirements
 
@@ -30,10 +32,10 @@ This will install all the required dependencies.
   error messages, fixtures, and CI artifacts. Clearly fake or sanitized
   payloads may remain in tests and diagnostics.
 - **Dependencies:** Review `Gemfile`, `Gemfile.lock`, `gemfiles/*.gemfile`,
-  `gemfiles/*.gemfile.lock`, and `openai.gemspec`
-  changes, including direct and transitive gems, sources, locked Git revisions,
-  native extensions, and install/build scripts. Do not run unreviewed scripts
-  or accept unexplained lockfile changes.
+  `gemfiles/*.gemfile.lock`, `docs/Gemfile`, `docs/Gemfile.lock`, and
+  `openai.gemspec` changes, including direct and transitive gems, sources,
+  locked Git revisions, native extensions, and install/build scripts. Do not
+  run unreviewed scripts or accept unexplained lockfile changes.
 - **CI and publishing:** Pin GitHub Actions to full commit SHAs, grant minimum
   per-job permissions, and preserve `permissions: {}`,
   `persist-credentials: false`, protected release environments, and RubyGems
@@ -190,10 +192,26 @@ This can be installed along side Ruby LSP.
 
 2. For each generic type in `*.rbi` files, a spurious "Duplicate type member" error is present.
 
-## Documentation Preview
+## Documentation
+
+Documentation dependencies are intentionally isolated from the primary
+contributor bundle. Install them with:
+
+```bash
+$ ./scripts/docs install
+```
+
+To build the documentation, run:
+
+```bash
+$ ./scripts/docs build
+```
 
 To preview the documentation, run:
 
 ```bash
-$ bundle exec rake docs:preview [PORT=8808]
+$ PORT=8808 ./scripts/docs preview
 ```
+
+The existing `bundle exec rake build:docs` and
+`bundle exec rake docs:preview` tasks delegate to the same docs bundle.

--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,3 @@ group :development, :test do
   gem "sorbet-runtime"
   gem "webmock"
 end
-
-group :development, :docs do
-  gem "redcarpet"
-  gem "webrick"
-  gem "yard"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,6 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
-    redcarpet (3.6.1)
     regexp_parser (2.12.0)
     rexml (3.4.4)
     rubocop (1.89.0)
@@ -179,8 +178,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
-    yard (0.9.45)
 
 PLATFORMS
   aarch64-linux
@@ -203,7 +200,6 @@ DEPENDENCIES
   openai!
   rake
   rbs
-  redcarpet
   rubocop
   sorbet (< 0.6.12760)
   sorbet-runtime
@@ -211,8 +207,6 @@ DEPENDENCIES
   syntax_tree
   syntax_tree-rbs!
   webmock
-  webrick
-  yard
 
 BUNDLED WITH
   4.0.17

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ end
 
 desc("Preview docs; use `PORT=<PORT>` to change the port")
 multitask(:"docs:preview") do
-  Bundler.with_unbundled_env { sh(*%w[./scripts/docs preview]) }
+  Bundler.with_original_env { sh(*%w[./scripts/docs preview]) }
 end
 
 bedrock_tests = FileList["test/openai/providers/bedrock*_test.rb"]
@@ -161,7 +161,7 @@ multitask(lint: [:"lint:rubocop", :"lint:rubocop_directives", :typecheck])
 
 desc("Build yard docs")
 multitask(:"build:docs") do
-  Bundler.with_unbundled_env { sh(*%w[./scripts/docs build]) }
+  Bundler.with_original_env { sh(*%w[./scripts/docs build]) }
 end
 
 desc("Build ruby gem")

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler"
 require "pathname"
 require "tempfile"
 
@@ -26,7 +27,7 @@ end
 
 desc("Preview docs; use `PORT=<PORT>` to change the port")
 multitask(:"docs:preview") do
-  sh(*%w[yard server --reload --quiet --bind \[::\] --port], ENV.fetch("PORT", "8808"))
+  Bundler.with_unbundled_env { sh(*%w[./scripts/docs preview]) }
 end
 
 bedrock_tests = FileList["test/openai/providers/bedrock*_test.rb"]
@@ -160,7 +161,7 @@ multitask(lint: [:"lint:rubocop", :"lint:rubocop_directives", :typecheck])
 
 desc("Build yard docs")
 multitask(:"build:docs") do
-  sh(*%w[yard])
+  Bundler.with_unbundled_env { sh(*%w[./scripts/docs build]) }
 end
 
 desc("Build ruby gem")

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Keep documentation tooling out of the primary contributor dependency graph.
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 gem "redcarpet"
 gem "webrick"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Keep documentation tooling out of the primary contributor dependency graph.
+source "https://rubygems.org"
+
+gem "redcarpet"
+gem "webrick"
+gem "yard"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -16,9 +16,9 @@ DEPENDENCIES
 
 CHECKSUMS
   bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
-  redcarpet (3.6.1)
-  webrick (1.9.2)
-  yard (0.9.45)
+  redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
 
 BUNDLED WITH
   4.0.17

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,24 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    redcarpet (3.6.1)
+    webrick (1.9.2)
+    yard (0.9.45)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  redcarpet
+  webrick
+  yard
+
+CHECKSUMS
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
+  redcarpet (3.6.1)
+  webrick (1.9.2)
+  yard (0.9.45)
+
+BUNDLED WITH
+  4.0.17

--- a/gemfiles/bedrock.gemfile.lock
+++ b/gemfiles/bedrock.gemfile.lock
@@ -136,7 +136,6 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
-    redcarpet (3.6.1)
     regexp_parser (2.12.0)
     rexml (3.4.4)
     rubocop (1.89.0)
@@ -192,8 +191,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
-    yard (0.9.45)
 
 PLATFORMS
   aarch64-linux
@@ -217,7 +214,6 @@ DEPENDENCIES
   openai!
   rake
   rbs
-  redcarpet
   rubocop
   sorbet (< 0.6.12760)
   sorbet-runtime
@@ -225,8 +221,6 @@ DEPENDENCIES
   syntax_tree
   syntax_tree-rbs!
   webmock
-  webrick
-  yard
 
 BUNDLED WITH
   4.0.17

--- a/scripts/docs
+++ b/scripts/docs
@@ -4,7 +4,11 @@ set -e
 
 cd -- "$(dirname -- "$0")/.."
 
-export BUNDLE_APP_CONFIG="${BUNDLE_APP_CONFIG:-$PWD/.bundle}"
+if [[ -z "${BUNDLE_APP_CONFIG:-}" ]]; then
+  export BUNDLE_APP_CONFIG="$PWD/.bundle"
+elif [[ "$BUNDLE_APP_CONFIG" != /* ]]; then
+  export BUNDLE_APP_CONFIG="$PWD/$BUNDLE_APP_CONFIG"
+fi
 export BUNDLE_GEMFILE="$PWD/docs/Gemfile"
 export BUNDLE_LOCKFILE="$PWD/docs/Gemfile.lock"
 

--- a/scripts/docs
+++ b/scripts/docs
@@ -4,7 +4,9 @@ set -e
 
 cd -- "$(dirname -- "$0")/.."
 
+export BUNDLE_APP_CONFIG="${BUNDLE_APP_CONFIG:-$PWD/.bundle}"
 export BUNDLE_GEMFILE="$PWD/docs/Gemfile"
+export BUNDLE_LOCKFILE="$PWD/docs/Gemfile.lock"
 
 case "${1:-}" in
   install)

--- a/scripts/docs
+++ b/scripts/docs
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd -- "$(dirname -- "$0")/.."
+
+export BUNDLE_GEMFILE="$PWD/docs/Gemfile"
+
+case "${1:-}" in
+  install)
+    shift
+    exec bundle install "$@"
+    ;;
+  build)
+    shift
+    exec bundle exec yard "$@"
+    ;;
+  preview)
+    shift
+    exec bundle exec yard server --reload --quiet --bind '[::]' --port "${PORT:-8808}" "$@"
+    ;;
+  *)
+    echo "Usage: $0 {install|build|preview}" >&2
+    exit 64
+    ;;
+esac

--- a/test/scripts/docs_workflow_test.rb
+++ b/test/scripts/docs_workflow_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "json"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+require "yaml"
+
+class DocsWorkflowTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_docs_bundle_uses_repository_source_cooldown
+    gemfile = File.read(File.join(ROOT, "docs/Gemfile"))
+
+    assert_includes(gemfile, "source \"https://rubygems.org\", cooldown: 7")
+  end
+
+  def test_dependabot_updates_the_docs_bundle
+    dependabot = YAML.safe_load_file(File.join(ROOT, ".github/dependabot.yml"))
+    bundler_updates = dependabot.fetch("updates").select { _1.fetch("package-ecosystem") == "bundler" }
+    root = bundler_updates.find { _1.fetch("directory") == "/" }
+    docs = bundler_updates.find do |update|
+      update.fetch("package-ecosystem") == "bundler" && update.fetch("directory") == "/docs"
+    end
+
+    refute_nil(docs)
+    %w[schedule cooldown groups open-pull-requests-limit].each do |setting|
+      assert_equal(root.fetch(setting), docs.fetch(setting))
+    end
+  end
+
+  def test_rake_aliases_preserve_user_bundle_settings
+    rakefile = File.read(File.join(ROOT, "Rakefile"))
+
+    assert_equal(2, rakefile.scan("Bundler.with_original_env").length)
+    refute_includes(rakefile, "Bundler.with_unbundled_env")
+  end
+
+  def test_rake_alias_passes_user_bundle_settings_to_docs_bundle
+    Dir.mktmpdir do |directory|
+      bundle = File.join(directory, "bundle")
+      File.write(
+        bundle,
+        <<~RUBY
+          #!#{RbConfig.ruby}
+          require "json"
+          puts JSON.generate(ENV.select { |key, _value| key.start_with?("BUNDLE_") })
+        RUBY
+      )
+      File.chmod(0o755, bundle)
+
+      mirror = "https://rubygems.org"
+      env = unactivated_env.merge(
+        "BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/" => mirror,
+        "PATH" => [directory, File.dirname(RbConfig.ruby), ENV.fetch("PATH")].join(File::PATH_SEPARATOR)
+      )
+      bundler = Gem.bin_path("bundler", "bundle")
+      stdout, stderr, status = Open3.capture3(
+        env,
+        RbConfig.ruby,
+        bundler,
+        "exec",
+        "rake",
+        "build:docs",
+        chdir: ROOT
+      )
+
+      assert(status.success?, stderr)
+      docs_env = JSON.parse(stdout.lines.last)
+      assert_equal(mirror, docs_env.fetch("BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/"))
+      assert_equal(File.join(ROOT, "docs/Gemfile"), docs_env.fetch("BUNDLE_GEMFILE"))
+      refute(docs_env.key?("BUNDLE_BIN_PATH"))
+    end
+  end
+
+  def test_original_env_preserves_caller_bundle_policy
+    settings = {
+      "BUNDLE_COOLDOWN" => "7",
+      "BUNDLE_DEPLOYMENT" => "true",
+      "BUNDLE_FROZEN" => "true",
+      "BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/" => "https://mirror.example",
+      "BUNDLE_PATH" => "/opt/bundle"
+    }
+    source = <<~RUBY
+      require "bundler"
+      require "json"
+
+      ENV["BUNDLE_BIN_PATH"] = "/parent/bin/bundle"
+      ENV["BUNDLE_GEMFILE"] = "/parent/Gemfile"
+      Bundler.with_original_env do
+        puts JSON.generate(ENV.select { |key, _value| #{settings.keys.inspect}.include?(key) })
+        puts ENV.key?("BUNDLE_BIN_PATH")
+        puts ENV.key?("BUNDLE_GEMFILE")
+      end
+    RUBY
+    stdout, stderr, status = Open3.capture3(unactivated_env.merge(settings), RbConfig.ruby, "-e", source)
+
+    assert(status.success?, stderr)
+    lines = stdout.lines.map(&:chomp)
+    assert_equal(settings, JSON.parse(lines.fetch(0)))
+    assert_equal(%w[false false], lines.drop(1))
+  end
+
+  def test_dependency_review_covers_docs_manifests
+    instructions = File.read(File.join(ROOT, "AGENTS.md"))
+
+    assert_includes(instructions, "`docs/Gemfile`")
+    assert_includes(instructions, "`docs/Gemfile.lock`")
+  end
+
+  private
+
+  def unactivated_env
+    keys = ENV.each_key.grep(/\A(?:BUNDLE_|BUNDLER_ORIG_)/)
+    keys.concat(%w[BUNDLER_SETUP BUNDLER_VERSION RUBYLIB RUBYOPT])
+    keys.to_h { [_1, nil] }
+  end
+end

--- a/test/scripts/docs_workflow_test.rb
+++ b/test/scripts/docs_workflow_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "fileutils"
 require "json"
 require "open3"
 require "rbconfig"
@@ -9,6 +10,9 @@ require "yaml"
 
 class DocsWorkflowTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
+  BUNDLER = Gem.bin_path("bundler", "bundle")
+  DOCS_GEMFILE = File.join(ROOT, "docs/Gemfile")
+  DOCS_LOCKFILE = File.join(ROOT, "docs/Gemfile.lock")
 
   def test_docs_bundle_uses_repository_source_cooldown
     gemfile = File.read(File.join(ROOT, "docs/Gemfile"))
@@ -37,40 +41,83 @@ class DocsWorkflowTest < Minitest::Test
     refute_includes(rakefile, "Bundler.with_unbundled_env")
   end
 
-  def test_rake_alias_passes_user_bundle_settings_to_docs_bundle
+  def test_docs_script_defaults_to_repository_config_and_docs_lockfile
     Dir.mktmpdir do |directory|
-      bundle = File.join(directory, "bundle")
-      File.write(
-        bundle,
-        <<~RUBY
-          #!#{RbConfig.ruby}
-          require "json"
-          puts JSON.generate(ENV.select { |key, _value| key.start_with?("BUNDLE_") })
-        RUBY
-      )
-      File.chmod(0o755, bundle)
-
-      mirror = "https://rubygems.org"
+      bundle = write_bundle_probe(directory)
       env = unactivated_env.merge(
-        "BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/" => mirror,
-        "PATH" => [directory, File.dirname(RbConfig.ruby), ENV.fetch("PATH")].join(File::PATH_SEPARATOR)
+        "BUNDLE_LOCKFILE" => File.join(ROOT, "Gemfile.lock"),
+        "PATH" => executable_path(directory)
       )
-      bundler = Gem.bin_path("bundler", "bundle")
-      stdout, stderr, status = Open3.capture3(
+
+      %w[install build preview].each do |command|
+        stdout, stderr, status = Open3.capture3(env, File.join(ROOT, "scripts/docs"), command)
+
+        assert(status.success?, stderr)
+        docs = JSON.parse(stdout)
+        assert_equal(File.join(ROOT, ".bundle"), docs.fetch("app_config_path"))
+        assert_equal(DOCS_GEMFILE, docs.fetch("gemfile"))
+        assert_equal(DOCS_LOCKFILE, docs.fetch("lockfile"))
+      end
+
+      assert(File.executable?(bundle))
+    end
+  end
+
+  def test_rake_aliases_preserve_explicit_config_and_select_docs_lockfile
+    Dir.mktmpdir do |directory|
+      write_bundle_probe(directory)
+      app_config = File.join(directory, "bundle-config")
+      env = unactivated_env.merge(
+        "BUNDLE_APP_CONFIG" => app_config,
+        "BUNDLE_LOCKFILE" => File.join(ROOT, "Gemfile.lock"),
+        "PATH" => executable_path(directory)
+      )
+
+      %w[build:docs docs:preview].each do |task|
+        stdout, stderr, status = Open3.capture3(
+          env,
+          RbConfig.ruby,
+          BUNDLER,
+          "exec",
+          "rake",
+          task,
+          chdir: ROOT
+        )
+
+        assert(status.success?, stderr)
+        docs = JSON.parse(stdout.lines.last)
+        assert_equal(app_config, docs.fetch("app_config_path"))
+        assert_equal(DOCS_GEMFILE, docs.fetch("gemfile"))
+        assert_equal(DOCS_LOCKFILE, docs.fetch("lockfile"))
+        refute(docs.fetch("env").key?("BUNDLE_BIN_PATH"))
+      end
+    end
+  end
+
+  def test_docs_install_cannot_modify_primary_bundle_files
+    Dir.mktmpdir do |directory|
+      project = File.join(directory, "project")
+      prepare_bundle_fixture(project)
+      primary_lockfile = File.join(project, "Gemfile.lock")
+      primary_config = File.join(project, ".bundle/config")
+      docs_lockfile = File.join(project, "docs/Gemfile.lock")
+      originals = [primary_lockfile, primary_config, docs_lockfile].to_h { [_1, File.binread(_1)] }
+      env = unactivated_env.merge(
+        "BUNDLE_LOCKFILE" => primary_lockfile,
+        "PATH" => executable_path
+      )
+
+      _stdout, stderr, status = Open3.capture3(
         env,
-        RbConfig.ruby,
-        bundler,
-        "exec",
-        "rake",
-        "build:docs",
-        chdir: ROOT
+        File.join(project, "scripts/docs"),
+        "install",
+        "--local"
       )
 
       assert(status.success?, stderr)
-      docs_env = JSON.parse(stdout.lines.last)
-      assert_equal(mirror, docs_env.fetch("BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/"))
-      assert_equal(File.join(ROOT, "docs/Gemfile"), docs_env.fetch("BUNDLE_GEMFILE"))
-      refute(docs_env.key?("BUNDLE_BIN_PATH"))
+      originals.each do |path, content|
+        assert_equal(content, File.binread(path), "Expected #{path} to remain unchanged")
+      end
     end
   end
 
@@ -110,6 +157,81 @@ class DocsWorkflowTest < Minitest::Test
   end
 
   private
+
+  def bundle_lock(project, gemfile, lockfile)
+    env = unactivated_env.merge(
+      "BUNDLE_APP_CONFIG" => File.join(project, "seed-config"),
+      "BUNDLE_GEMFILE" => gemfile,
+      "BUNDLE_LOCKFILE" => lockfile,
+      "PATH" => executable_path
+    )
+    _stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, BUNDLER, "lock", "--local", chdir: project)
+
+    assert(status.success?, stderr)
+  end
+
+  def executable_path(directory = nil)
+    [directory, File.dirname(RbConfig.ruby), ENV.fetch("PATH")].compact.join(File::PATH_SEPARATOR)
+  end
+
+  def prepare_bundle_fixture(project)
+    FileUtils.mkdir_p(File.join(project, ".bundle"))
+    FileUtils.mkdir_p(File.join(project, "docs/fixture/lib"))
+    FileUtils.mkdir_p(File.join(project, "scripts"))
+    File.symlink(File.join(ROOT, "scripts/docs"), File.join(project, "scripts/docs"))
+    File.write(File.join(project, "Gemfile"), "source \"https://rubygems.org\"\n")
+    File.write(
+      File.join(project, "docs/Gemfile"),
+      <<~RUBY
+        source "https://rubygems.org"
+        gem "docs_fixture", path: "fixture"
+      RUBY
+    )
+    File.write(
+      File.join(project, "docs/fixture/docs_fixture.gemspec"),
+      <<~RUBY
+        Gem::Specification.new do |spec|
+          spec.name = "docs_fixture"
+          spec.version = "1.0.0"
+          spec.summary = "Docs workflow test fixture"
+          spec.authors = ["OpenAI"]
+          spec.files = ["lib/docs_fixture.rb"]
+        end
+      RUBY
+    )
+    File.write(File.join(project, "docs/fixture/lib/docs_fixture.rb"), "# frozen_string_literal: true\n")
+    bundle_lock(project, File.join(project, "Gemfile"), File.join(project, "Gemfile.lock"))
+    bundle_lock(project, File.join(project, "docs/Gemfile"), File.join(project, "docs/Gemfile.lock"))
+    File.write(
+      File.join(project, ".bundle/config"),
+      <<~YAML
+        ---
+        BUNDLE_FROZEN: "true"
+        BUNDLE_PATH: "vendor/repository-bundle"
+      YAML
+    )
+  end
+
+  def write_bundle_probe(directory)
+    bundle = File.join(directory, "bundle")
+    File.write(
+      bundle,
+      <<~RUBY
+        #!#{RbConfig.ruby}
+        require "bundler"
+        require "json"
+
+        puts JSON.generate(
+          "app_config_path" => Bundler.app_config_path.to_s,
+          "env" => ENV.select { |key, _value| key.start_with?("BUNDLE_") },
+          "gemfile" => Bundler.default_gemfile.to_s,
+          "lockfile" => Bundler.default_lockfile.to_s
+        )
+      RUBY
+    )
+    File.chmod(0o755, bundle)
+    bundle
+  end
 
   def unactivated_env
     keys = ENV.each_key.grep(/\A(?:BUNDLE_|BUNDLER_ORIG_)/)

--- a/test/scripts/docs_workflow_test.rb
+++ b/test/scripts/docs_workflow_test.rb
@@ -20,6 +20,14 @@ class DocsWorkflowTest < Minitest::Test
     assert_includes(gemfile, "source \"https://rubygems.org\", cooldown: 7")
   end
 
+  def test_docs_lockfile_checksums_all_documentation_gems
+    lockfile = File.read(DOCS_LOCKFILE)
+
+    %w[redcarpet webrick yard].each do |gem|
+      assert_match(/^  #{gem} \([^)]+\) sha256=[0-9a-f]{64}$/, lockfile)
+    end
+  end
+
   def test_dependabot_updates_the_docs_bundle
     dependabot = YAML.safe_load_file(File.join(ROOT, ".github/dependabot.yml"))
     bundler_updates = dependabot.fetch("updates").select { _1.fetch("package-ecosystem") == "bundler" }

--- a/test/scripts/docs_workflow_test.rb
+++ b/test/scripts/docs_workflow_test.rb
@@ -63,10 +63,27 @@ class DocsWorkflowTest < Minitest::Test
     end
   end
 
+  def test_docs_script_resolves_explicit_relative_config_from_repository_root
+    Dir.mktmpdir do |directory|
+      write_bundle_probe(directory)
+      app_config = "relative-bundle-config"
+      env = unactivated_env.merge(
+        "BUNDLE_APP_CONFIG" => app_config,
+        "PATH" => executable_path(directory)
+      )
+
+      stdout, stderr, status = Open3.capture3(env, File.join(ROOT, "scripts/docs"), "install")
+
+      assert(status.success?, stderr)
+      docs = JSON.parse(stdout)
+      assert_equal(File.join(ROOT, app_config), docs.fetch("app_config_path"))
+    end
+  end
+
   def test_rake_aliases_preserve_explicit_config_and_select_docs_lockfile
     Dir.mktmpdir do |directory|
       write_bundle_probe(directory)
-      app_config = File.join(directory, "bundle-config")
+      app_config = "relative-bundle-config"
       env = unactivated_env.merge(
         "BUNDLE_APP_CONFIG" => app_config,
         "BUNDLE_LOCKFILE" => File.join(ROOT, "Gemfile.lock"),
@@ -86,7 +103,7 @@ class DocsWorkflowTest < Minitest::Test
 
         assert(status.success?, stderr)
         docs = JSON.parse(stdout.lines.last)
-        assert_equal(app_config, docs.fetch("app_config_path"))
+        assert_equal(File.join(ROOT, app_config), docs.fetch("app_config_path"))
         assert_equal(DOCS_GEMFILE, docs.fetch("gemfile"))
         assert_equal(DOCS_LOCKFILE, docs.fetch("lockfile"))
         refute(docs.fetch("env").key?("BUNDLE_BIN_PATH"))


### PR DESCRIPTION
## Summary

- move Redcarpet, WEBrick, and YARD into a dedicated `docs/Gemfile` and lockfile
- add one `scripts/docs` entry point for installing, building, and previewing documentation
- preserve the existing Rake aliases while clearing the parent Bundler environment
- document the separate contributor workflow and dependency-review boundary

## Why

Documentation-only gems currently live in the primary contributor bundle, so normal installs and CI resolve tooling they do not use. Keeping a separate docs bundle removes those three specs from the primary lock graph while preserving reproducible documentation builds and previews.

## Validation

- `bundle check`
- `BUNDLE_GEMFILE=docs/Gemfile bundle check`
- `bundle exec rake lint`
- `bundle exec rake build:gem`
- `bundle exec rake build:docs` (2,358 files; both lockfile hashes unchanged)
- `PORT=18810 bundle exec rake docs:preview` (WEBrick reached server startup and was stopped cleanly)
- targeted contributor-script tests pass
- full local suite reached 986 passing tests; one unrelated Realtime proxy invariant cannot reach its test listener in the Codex sandbox, so GitHub CI will provide the clean-network result
