### PR TITLE
fix: fix Page#next_page to raise when unavailable

### DIFF
--- a/lib/openai/internal/page.rb
+++ b/lib/openai/internal/page.rb
@@ -30,7 +30,7 @@ module OpenAI
       # @raise [OpenAI::HTTP::Error]
       # @return [self]
       def next_page
-        RuntimeError.new("No more pages available.")
+        raise RuntimeError.new("No more pages available.")
       end
 
       # @param blk [Proc]

--- a/test/openai/internal/page_test.rb
+++ b/test/openai/internal/page_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::PageTest < Minitest::Test
+  def test_next_page_is_unavailable
+    page = OpenAI::Internal::Page.allocate
+
+    refute(page.next_page?)
+    error = assert_raises(RuntimeError) { page.next_page }
+    assert_equal("No more pages available.", error.message)
+  end
+end


### PR DESCRIPTION
<!-- improve-openai-ruby -->

## Summary

- make `OpenAI::Internal::Page#next_page` raise `RuntimeError` when no next page exists
- add a focused regression test for the false pagination predicate, exception class, and existing message

## Reproduction

```ruby
page = OpenAI::Internal::Page.allocate
page.next_page? # => false
page.next_page  # previously returned RuntimeError.new("No more pages available.")
```

The method now raises that same `RuntimeError` instance message instead of returning it.

## Compatibility

This restores the documented raising behavior and matches every cursor-page sibling. The method signature, exception class, and exact message remain unchanged. Because `Page#next_page?` is always false, there is no successful `next_page` return path to alter; this is a backward-compatible bug fix.

## Verification

Ruby 4.0.6:

- `bundle exec ruby -Itest test/openai/internal/page_test.rb` — 1 run, 3 assertions, 0 failures
- `./scripts/test` with the documented Steady mock server — 1,093 runs, 9,998 assertions, 0 failures, 0 errors, 1 existing skip
- `bundle exec rake lint` — RuboCop clean across 2,709 files; Sorbet clean; 1,236 RBS files validated
- `bundle exec rake test:examples:inventory` — 23 of 29 examples covered, 6 explicitly excluded
- `bundle exec rake build:gem` — built `openai-0.80.0.gem`
- `python3 scripts/castiron/custom_code_report.py report ... --public` — generated baselines verified; no new custom-code files
- `git diff --check`
