### PR TITLE
fix: redact credentials from client inspect

### DIFF
--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -863,7 +863,8 @@ module OpenAI
         #
         # @return [String]
         def inspect
-          "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{@base_url} max_retries=#{@max_retries} timeout=#{@timeout}>"
+          safe_base_url = OpenAI::Internal::Logging.safe_url(@base_url)
+          "#<#{self.class.name}:0x#{object_id.to_s(16)} base_url=#{safe_base_url} max_retries=#{@max_retries} timeout=#{@timeout}>"
         end
 
         define_sorbet_constant!(:RequestComponents) do

--- a/test/openai/internal/transport/base_client_inspect_test.rb
+++ b/test/openai/internal/transport/base_client_inspect_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::BaseClientInspectTest < Minitest::Test
+  def test_inspect_omits_base_url_userinfo_and_fragment
+    client = new_client(
+      "https://fake-user:fake-password@example.test/v1#access_token=fake-fragment-token"
+    )
+
+    inspected = client.inspect
+
+    assert_includes(inspected, "base_url=https://example.test/v1")
+    refute_includes(inspected, "fake-user")
+    refute_includes(inspected, "fake-password")
+    refute_includes(inspected, "fake-fragment-token")
+    refute_includes(inspected, "#access_token")
+    assert_includes(client.base_url.to_s, "fake-user:fake-password@")
+    assert_equal("access_token=fake-fragment-token", client.base_url.fragment)
+  end
+
+  def test_inspect_redacts_sensitive_base_url_query_values
+    client = new_client(
+      "https://example.test/v1?X-Amz-Signature=fake-signature&" \
+        "access_token=fake-access-token&safe=visible"
+    )
+
+    inspected = client.inspect
+
+    assert_includes(inspected, "X-Amz-Signature=%5BREDACTED%5D")
+    assert_includes(inspected, "access_token=%5BREDACTED%5D")
+    assert_includes(inspected, "safe=visible")
+    refute_includes(inspected, "fake-signature")
+    refute_includes(inspected, "fake-access-token")
+  end
+
+  def test_inspect_preserves_ordinary_base_url_diagnostics
+    client = new_client("https://example.test:8443/custom/v2?region=us")
+
+    inspected = client.inspect
+
+    assert_match(/\A#<OpenAI::Client:0x[0-9a-f]+ /, inspected)
+    assert_includes(
+      inspected,
+      "base_url=https://example.test:8443/custom/v2?region=us max_retries=2 timeout=600.0>"
+    )
+  end
+
+  def test_inspect_redacts_a_normalized_malformed_base_url_query
+    client = new_client("https://example.test/v1?token=fake-query-secret%GG")
+
+    inspected = client.inspect
+
+    assert_includes(inspected, "base_url=https://example.test/v1?token=%5BREDACTED%5D max_retries=")
+    refute_includes(inspected, "fake-query-secret")
+    assert_equal("token=fake-query-secret%25GG", client.base_url.query)
+  end
+
+  def test_malformed_base_url_still_raises
+    assert_raises(URI::InvalidURIError) { new_client("https://[") }
+  end
+
+  private def new_client(base_url)
+    OpenAI::Client.new(
+      api_key: "fake-api-key",
+      base_url: base_url,
+      http_client: OpenAI::HTTPClient.new
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- sanitize `BaseClient#inspect` URLs with the existing logging URL sanitizer
- omit URL userinfo and fragments while redacting signed and credential query values
- preserve ordinary scheme, host, port, path, and safe-query diagnostics without mutating `base_url`

## Security

Client inspection previously rendered credential-bearing base URLs verbatim. This closes that diagnostic disclosure boundary while leaving request routing and public base URL behavior unchanged.

## Testing

- `bundle exec rake test TEST=test/openai/internal/transport/base_client_inspect_test.rb` (5 runs, 33 assertions)
- logging tests (35 runs, 372 assertions)
- base-client origin tests (24 runs, 412 assertions)
- client-options tests (13 runs, 87 assertions)
- `bundle exec rake lint` (RuboCop, rubyfmt, Sorbet, and RBS validation)
- relevant aggregate suite (1,090 runs, 9,988 assertions; 0 failures/errors)
- `bundle exec rake build:gem`

The unfiltered suite's only remaining error is an unrelated realtime HTTP proxy socket test (`TCPServer#accept: closed stream`) that reproduces independently in this environment; the other six tests in that file pass.