### PR TITLE
fix: preserve derived pagination cursors

### DIFF
--- a/lib/openai/internal/type/base_page.rb
+++ b/lib/openai/internal/type/base_page.rb
@@ -58,8 +58,16 @@ module OpenAI
         # @param response_metadata [OpenAI::ResponseMetadata]
         # @param page_data [Object]
         def initialize(client:, req:, response_metadata:, page_data:)
+          options = req[:options].to_h
+
           @client = client
-          @req = req
+          # Keep the effective query, but clear its higher-precedence copy so a page's
+          # follow-up cursor can replace the caller's original cursor.
+          @req = {
+            **req,
+            query: OpenAI::Internal::Util.deep_merge(req[:query].to_h, options[:extra_query].to_h),
+            options: {**options, extra_query: {}}
+          }
           @model = req.fetch(:model)
           @last_response = response_metadata
           super()

--- a/lib/openai/internal/type/base_page.rb
+++ b/lib/openai/internal/type/base_page.rb
@@ -61,11 +61,11 @@ module OpenAI
           options = req[:options].to_h
           query = OpenAI::Internal::Util
             .deep_merge(req[:query].to_h, options[:extra_query].to_h)
-            .to_h { |key, value| [key.is_a?(String) ? key.to_sym : key, value] }
+            .to_h { |key, value| [key == "after" ? :after : key, value] }
 
           @client = client
-          # Keep the normalized effective query, but clear its higher-precedence copy
-          # so a page's follow-up cursor can replace the caller's original cursor.
+          # Keep the effective query with a canonical cursor key, but clear its
+          # higher-precedence copy so a page can replace the caller's original cursor.
           @req = {
             **req,
             query: query,

--- a/lib/openai/internal/type/base_page.rb
+++ b/lib/openai/internal/type/base_page.rb
@@ -59,13 +59,16 @@ module OpenAI
         # @param page_data [Object]
         def initialize(client:, req:, response_metadata:, page_data:)
           options = req[:options].to_h
+          query = OpenAI::Internal::Util
+            .deep_merge(req[:query].to_h, options[:extra_query].to_h)
+            .to_h { |key, value| [key.is_a?(String) ? key.to_sym : key, value] }
 
           @client = client
-          # Keep the effective query, but clear its higher-precedence copy so a page's
-          # follow-up cursor can replace the caller's original cursor.
+          # Keep the normalized effective query, but clear its higher-precedence copy
+          # so a page's follow-up cursor can replace the caller's original cursor.
           @req = {
             **req,
-            query: OpenAI::Internal::Util.deep_merge(req[:query].to_h, options[:extra_query].to_h),
+            query: query,
             options: {**options, extra_query: {}}
           }
           @model = req.fetch(:model)

--- a/test/openai/path_parameter_query_test.rb
+++ b/test/openai/path_parameter_query_test.rb
@@ -273,11 +273,13 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
     assert_requested(next_request)
   end
 
-  def test_id_cursor_pagination_overrides_extra_query_cursor
+  def test_id_cursor_pagination_normalizes_string_extra_query_cursor
     path = "/chat/completions"
+    first_query = {"after" => "chatcmpl_old", "debug" => "enabled", "trace" => "enabled"}
+    next_query = {"after" => "chatcmpl_new", "debug" => "enabled", "trace" => "enabled"}
     first_request = stub_get(
       path,
-      query: {"after" => "chatcmpl_old", "trace" => "enabled"},
+      query: first_query,
       body: {
         data: [
           {
@@ -292,44 +294,60 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
         object: "list"
       }
     )
-    next_request = stub_get(
-      path,
-      query: {"after" => "chatcmpl_new", "trace" => "enabled"}
-    )
+    next_request = stub_get(path, query: next_query)
 
     page = @client.chat.completions.list(
-      request_options: {extra_query: {after: "chatcmpl_old", trace: "enabled"}}
+      request_options: {
+        extra_query: {"after" => "chatcmpl_old", "trace" => "enabled", :debug => "enabled"}
+      }
     )
     stored_request = page.instance_variable_get(:@req)
+    next_page = page.next_page
+    next_stored_request = next_page.instance_variable_get(:@req)
 
-    assert_equal({after: "chatcmpl_old", trace: "enabled"}, stored_request[:query])
-    assert_empty(stored_request.dig(:options, :extra_query))
-    assert_instance_of(OpenAI::Internal::CursorPage, page.next_page)
     assert_requested(first_request)
     assert_requested(next_request)
+    assert_equal(
+      {after: "chatcmpl_old", debug: "enabled", trace: "enabled"},
+      stored_request[:query]
+    )
+    assert_equal(
+      {after: "chatcmpl_new", debug: "enabled", trace: "enabled"},
+      next_stored_request[:query]
+    )
+    assert_empty(stored_request.dig(:options, :extra_query))
+    assert_empty(next_stored_request.dig(:options, :extra_query))
+    assert_instance_of(OpenAI::Internal::CursorPage, next_page)
   end
 
-  def test_server_cursor_pagination_overrides_extra_query_cursor
+  def test_server_cursor_pagination_normalizes_string_extra_query_cursor
     path = "/projects/proj_123/users/user_123/roles"
+    first_query = {"after" => "role_old", "debug" => "enabled", "trace" => "enabled"}
+    next_query = {"after" => "role_new", "debug" => "enabled", "trace" => "enabled"}
     first_request = stub_get(
       path,
-      query: {"after" => "role_old", "trace" => "enabled"},
+      query: first_query,
       body: {data: [], has_more: true, next: "role_new"}
     )
-    next_request = stub_get(
-      path,
-      query: {"after" => "role_new", "trace" => "enabled"}
-    )
+    next_request = stub_get(path, query: next_query)
 
     page = @client.admin.organization.projects.users.roles.list(
       "user_123",
       project_id: "proj_123",
-      request_options: {extra_query: {after: "role_old", trace: "enabled"}}
+      request_options: {extra_query: {"after" => "role_old", "trace" => "enabled", :debug => "enabled"}}
     )
 
-    assert_instance_of(OpenAI::Internal::NextCursorPage, page.next_page)
+    next_page = page.next_page
+    stored_request = page.instance_variable_get(:@req)
+    next_stored_request = next_page.instance_variable_get(:@req)
+
     assert_requested(first_request)
     assert_requested(next_request)
+    assert_equal({after: "role_old", debug: "enabled", trace: "enabled"}, stored_request[:query])
+    assert_equal({after: "role_new", debug: "enabled", trace: "enabled"}, next_stored_request[:query])
+    assert_empty(stored_request.dig(:options, :extra_query))
+    assert_empty(next_stored_request.dig(:options, :extra_query))
+    assert_instance_of(OpenAI::Internal::NextCursorPage, next_page)
   end
 
   private

--- a/test/openai/path_parameter_query_test.rb
+++ b/test/openai/path_parameter_query_test.rb
@@ -6,6 +6,25 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
   extend Minitest::Serial
   include WebMock::API
 
+  class PaginatedHTTPClient < OpenAI::HTTPClient
+    attr_reader :requests
+
+    def initialize(*bodies)
+      super()
+      @bodies = bodies
+      @requests = []
+    end
+
+    def execute(request)
+      @requests << request
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: [JSON.generate(@bodies.fetch(@requests.length - 1))]
+      )
+    end
+  end
+
   def before_all
     super
     WebMock.enable!
@@ -273,6 +292,47 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
     assert_requested(next_request)
   end
 
+  def test_beta_response_input_items_pagination_preserves_string_path_query_override
+    first_body = {
+      data: [
+        {
+          id: "item_1",
+          content: [],
+          role: "user",
+          status: "completed",
+          type: "message"
+        }
+      ],
+      first_id: "item_1",
+      has_more: true,
+      last_id: "item_1",
+      object: "list"
+    }
+    transport = PaginatedHTTPClient.new(first_body, {data: [], has_more: false})
+    client = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "test-api-key",
+      http_client: transport
+    )
+
+    page = client.beta.responses.input_items.list(
+      "resp_123",
+      request_options: {extra_query: {"beta" => "false"}}
+    )
+    next_page = page.next_page
+
+    assert_equal(
+      [
+        [["beta", "false"]],
+        [["after", "item_1"], ["beta", "false"]]
+      ],
+      transport.requests.map { URI.decode_www_form(_1.url.query.to_s).sort }
+    )
+    assert_equal("false", page.instance_variable_get(:@req).dig(:query, "beta"))
+    assert_equal("false", next_page.instance_variable_get(:@req).dig(:query, "beta"))
+    assert_instance_of(OpenAI::Internal::CursorPage, next_page)
+  end
+
   def test_id_cursor_pagination_normalizes_string_extra_query_cursor
     path = "/chat/completions"
     first_query = {"after" => "chatcmpl_old", "debug" => "enabled", "trace" => "enabled"}
@@ -308,11 +368,11 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
     assert_requested(first_request)
     assert_requested(next_request)
     assert_equal(
-      {after: "chatcmpl_old", debug: "enabled", trace: "enabled"},
+      {:after => "chatcmpl_old", :debug => "enabled", "trace" => "enabled"},
       stored_request[:query]
     )
     assert_equal(
-      {after: "chatcmpl_new", debug: "enabled", trace: "enabled"},
+      {:after => "chatcmpl_new", :debug => "enabled", "trace" => "enabled"},
       next_stored_request[:query]
     )
     assert_empty(stored_request.dig(:options, :extra_query))
@@ -343,8 +403,8 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
 
     assert_requested(first_request)
     assert_requested(next_request)
-    assert_equal({after: "role_old", debug: "enabled", trace: "enabled"}, stored_request[:query])
-    assert_equal({after: "role_new", debug: "enabled", trace: "enabled"}, next_stored_request[:query])
+    assert_equal({:after => "role_old", :debug => "enabled", "trace" => "enabled"}, stored_request[:query])
+    assert_equal({:after => "role_new", :debug => "enabled", "trace" => "enabled"}, next_stored_request[:query])
     assert_empty(stored_request.dig(:options, :extra_query))
     assert_empty(next_stored_request.dig(:options, :extra_query))
     assert_instance_of(OpenAI::Internal::NextCursorPage, next_page)

--- a/test/openai/path_parameter_query_test.rb
+++ b/test/openai/path_parameter_query_test.rb
@@ -273,6 +273,65 @@ class OpenAI::Test::PathParameterQueryTest < Minitest::Test
     assert_requested(next_request)
   end
 
+  def test_id_cursor_pagination_overrides_extra_query_cursor
+    path = "/chat/completions"
+    first_request = stub_get(
+      path,
+      query: {"after" => "chatcmpl_old", "trace" => "enabled"},
+      body: {
+        data: [
+          {
+            id: "chatcmpl_new",
+            choices: [],
+            created: 1_700_000_000,
+            model: "gpt-5.4",
+            object: "chat.completion"
+          }
+        ],
+        has_more: true,
+        object: "list"
+      }
+    )
+    next_request = stub_get(
+      path,
+      query: {"after" => "chatcmpl_new", "trace" => "enabled"}
+    )
+
+    page = @client.chat.completions.list(
+      request_options: {extra_query: {after: "chatcmpl_old", trace: "enabled"}}
+    )
+    stored_request = page.instance_variable_get(:@req)
+
+    assert_equal({after: "chatcmpl_old", trace: "enabled"}, stored_request[:query])
+    assert_empty(stored_request.dig(:options, :extra_query))
+    assert_instance_of(OpenAI::Internal::CursorPage, page.next_page)
+    assert_requested(first_request)
+    assert_requested(next_request)
+  end
+
+  def test_server_cursor_pagination_overrides_extra_query_cursor
+    path = "/projects/proj_123/users/user_123/roles"
+    first_request = stub_get(
+      path,
+      query: {"after" => "role_old", "trace" => "enabled"},
+      body: {data: [], has_more: true, next: "role_new"}
+    )
+    next_request = stub_get(
+      path,
+      query: {"after" => "role_new", "trace" => "enabled"}
+    )
+
+    page = @client.admin.organization.projects.users.roles.list(
+      "user_123",
+      project_id: "proj_123",
+      request_options: {extra_query: {after: "role_old", trace: "enabled"}}
+    )
+
+    assert_instance_of(OpenAI::Internal::NextCursorPage, page.next_page)
+    assert_requested(first_request)
+    assert_requested(next_request)
+  end
+
   private
 
   def stub_response_stream(query:, headers: {}, include_keepalive: false)


### PR DESCRIPTION
<!-- improve-openai-ruby -->

## Summary

- make page-derived follow-up cursors authoritative over an original `request_options[:extra_query][:after]`
- preserve unrelated extra query parameters on subsequent pages
- cover both ID-derived and server-provided cursors

## Reproduction

Start a paginated list with `request_options: {extra_query: {after: "old", trace: "enabled"}}` and let the first page return a follow-up cursor of `"new"`. The page implementation updates `req[:query][:after]`, but request construction deep-merges `extra_query` afterward, so `after=old` wins again. Repeated auto-pagination can therefore request the same page indefinitely.

## Compatibility

First-request behavior is unchanged: caller-supplied extra query values still override generated query values. After the first response, `BasePage` stores the effective merged query and clears only its higher-precedence `extra_query` copy. Existing page implementations can then replace the stored cursor for follow-up requests, while unrelated parameters such as `trace=enabled` remain in the query. This changes no public method, argument, return type, RBI, RBS, or generated API surface.

## Verification

- `bundle exec ruby -Itest test/openai/path_parameter_query_test.rb` — 16 runs, 23 assertions
- `bundle exec ruby -Itest test/openai/client_test.rb` — 36 runs, 189 assertions
- `./scripts/mock --daemon && bundle exec rake test` — 1,094 runs, 10,000 assertions, 0 failures, 0 errors, 1 intentional skip
- `bundle exec rake lint` — RuboCop 2,707 files, Sorbet, RBS 1,236 files, rubyfmt, and directive validation passed
- `bundle exec rake test:examples:inventory` — 23/29 exercised, 6 explicitly excluded
- `bundle exec rake build:gem`
- `git diff --check`
