### PR TITLE
test: isolate Bedrock AWS dependencies

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -116,8 +116,32 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Check primary dependency bundle
+        run: bundle check
       - name: Run tests
         run: ./scripts/test
+
+  test-bedrock:
+    timeout-minutes: 10
+    name: test (bedrock, ruby 4.0)
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runner }}
+    env:
+      BUNDLE_GEMFILE: gemfiles/bedrock.gemfile
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+      - name: Check Bedrock dependency bundle
+        run: bundle check
+      - name: Run Bedrock tests
+        run: bundle exec rake test:bedrock
 
   required:
     timeout-minutes: 5
@@ -128,6 +152,7 @@ jobs:
       - typecheck
       - validate-rbs
       - package
+      - test-bedrock
       - test-ruby
     if: ${{ always() }}
     permissions: {}
@@ -139,10 +164,12 @@ jobs:
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           RBS_VALIDATION_RESULT: ${{ needs.validate-rbs.result }}
           PACKAGE_RESULT: ${{ needs.package.result }}
+          BEDROCK_TEST_RESULT: ${{ needs.test-bedrock.result }}
           TEST_RESULT: ${{ needs.test-ruby.result }}
         run: |
           test "$LINT_RESULT" = "success"
           test "$TYPECHECK_RESULT" = "success"
           test "$RBS_VALIDATION_RESULT" = "success"
           test "$PACKAGE_RESULT" = "success"
+          test "$BEDROCK_TEST_RESULT" = "success"
           test "$TEST_RESULT" = "success"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ This will install all the required dependencies.
   request/response bodies, prompts, or uploaded files from logs, exceptions,
   error messages, fixtures, and CI artifacts. Clearly fake or sanitized
   payloads may remain in tests and diagnostics.
-- **Dependencies:** Review `Gemfile`, `Gemfile.lock`, and `openai.gemspec`
+- **Dependencies:** Review `Gemfile`, `Gemfile.lock`, `gemfiles/*.gemfile`,
+  `gemfiles/*.gemfile.lock`, and `openai.gemspec`
   changes, including direct and transitive gems, sources, locked Git revisions,
   native extensions, and install/build scripts. Do not run unreviewed scripts
   or accept unexplained lockfile changes.
@@ -108,6 +109,14 @@ $ ./scripts/mock
 
 ```bash
 $ bundle exec rake test
+```
+
+The primary bundle intentionally omits the optional AWS SDK. Install the
+dedicated Bedrock bundle and run its tests separately:
+
+```bash
+$ BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle install
+$ BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec rake test:bedrock
 ```
 
 ### Running examples end-to-end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ end
 group :development, :test do
   gem "async"
   gem "async-websocket"
-  gem "aws-sdk-core", "~> 3"
   gem "cgi"
   gem "minitest", "~> 6.0"
   gem "minitest-hooks", ">= 1.5.4"

--- a/Rakefile
+++ b/Rakefile
@@ -29,13 +29,30 @@ multitask(:"docs:preview") do
   sh(*%w[yard server --reload --quiet --bind \[::\] --port], ENV.fetch("PORT", "8808"))
 end
 
-desc("Run test suites; use `TEST=path/to/test.rb` to run a specific test file")
-multitask(test: [:"test:examples:inventory"]) do
-  rb = FileList[ENV.fetch("TEST", "./test/**/*_test.rb")]
-    .map { "require_relative(#{_1.dump});" }
-    .join
+bedrock_tests = FileList["test/openai/providers/bedrock*_test.rb"]
+
+run_tests = lambda do |files|
+  abort("No test files selected") if files.empty?
+
+  rb = files.map { "require_relative(#{_1.dump});" }.join
 
   ruby(*%w[-w -e], rb, verbose: false) { fail unless _1 }
+end
+
+desc("Run non-Bedrock test suites; use `TEST=path/to/test.rb` to run a specific test file")
+multitask(test: [:"test:examples:inventory"]) do
+  files = FileList[ENV.fetch("TEST", "test/**/*_test.rb")]
+  requested_bedrock_tests = files.to_a & bedrock_tests.to_a
+  if ENV.key?("TEST") && !requested_bedrock_tests.empty?
+    abort("Run Bedrock tests with `BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec rake test:bedrock`")
+  end
+
+  run_tests.call(files.exclude(*bedrock_tests))
+end
+
+desc("Run Bedrock tests with the AWS test bundle")
+multitask("test:bedrock") do
+  run_tests.call(bedrock_tests)
 end
 
 desc("Lint `*.rb(i)`")

--- a/bedrock.md
+++ b/bedrock.md
@@ -187,6 +187,7 @@ Real AWS requests are disabled in the test suite unless `BEDROCK_LIVE_TEST=1` is
 
 ```sh
 AWS_REGION=us-east-1 BEDROCK_LIVE_TEST=1 \
+  BUNDLE_GEMFILE=gemfiles/bedrock.gemfile \
   bundle exec ruby test/openai/providers/bedrock_live_test.rb
 ```
 

--- a/gemfiles/bedrock.gemfile
+++ b/gemfiles/bedrock.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile(File.expand_path("../Gemfile", __dir__))
+
+gem "aws-sdk-core", "~> 3"

--- a/gemfiles/bedrock.gemfile.lock
+++ b/gemfiles/bedrock.gemfile.lock
@@ -9,7 +9,7 @@ GIT
       syntax_tree (>= 2.0.1)
 
 PATH
-  remote: .
+  remote: ..
   specs:
     openai (0.80.0)
       connection_pool (>= 2.2.3)
@@ -43,6 +43,18 @@ GEM
       protocol-http (~> 0.34)
       protocol-rack (~> 0.7)
       protocol-websocket (~> 0.17)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1280.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     cgi (0.5.2)
@@ -74,6 +86,7 @@ GEM
     io-event (1.19.4)
     io-stream (0.14.0)
       openssl (>= 3.3)
+    jmespath (1.6.2)
     json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
@@ -195,6 +208,7 @@ PLATFORMS
 DEPENDENCIES
   async
   async-websocket
+  aws-sdk-core (~> 3)
   cgi
   minitest (~> 6.0)
   minitest-hooks (>= 1.5.4)

--- a/test/openai/providers/bedrock_live_test.rb
+++ b/test/openai/providers/bedrock_live_test.rb
@@ -5,6 +5,7 @@ require_relative "../test_helper"
 # Real AWS requests are disabled unless BEDROCK_LIVE_TEST=1 is explicitly set.
 #
 # AWS_REGION=us-east-1 BEDROCK_LIVE_TEST=1 \
+#   BUNDLE_GEMFILE=gemfiles/bedrock.gemfile \
 #   bundle exec ruby test/openai/providers/bedrock_live_test.rb
 #
 # BEDROCK_AUTH_MODE selects auto, bearer, token-provider, sigv4, static, or profile.


### PR DESCRIPTION
## Summary

- move `aws-sdk-core` and its transitive dependencies out of the primary contributor bundle into `gemfiles/bedrock.gemfile` and its dedicated lockfile
- split Bedrock signing and AWS credential coverage into `rake test:bedrock`, and add a required Ruby 4.0 CI job using the AWS bundle
- keep bearer-mode Bedrock behavior, consumer installation guidance, and live-test documentation intact

The primary lockfile shrinks from 89 to 84 gem specs by removing `aws-sdk-core`, `aws-eventstream`, `aws-partitions`, `aws-sigv4`, and `jmespath`. There is no runtime dependency or public API change.

## Verification

- primary `bundle check`
- Bedrock `bundle check`
- `./scripts/test`: 1,060 runs, 9,654 assertions
- `rake test:bedrock`: 38 runs, 377 assertions (1 intentionally disabled live-AWS test)
- `rake lint`
- `rake build:gem`