### PR TITLE
fix: retain collection conversion errors

### DIFF
--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -82,16 +82,22 @@ module OpenAI
 
           target = item_type
           exactness[:yes] += 1
-          value
-            .map do |item|
-              case [nilable?, item]
-              in [true, nil]
-                exactness[:yes] += 1
-                nil
-              else
-                OpenAI::Internal::Type::Converter.coerce(target, item, state: state)
-              end
+          previous_error = state.fetch(:error)
+          last_error = nil
+          converted = value.map do |item|
+            case [nilable?, item]
+            in [true, nil]
+              exactness[:yes] += 1
+              nil
+            else
+              coerced, item_error = OpenAI::Internal::Type::Converter.coerce_with_error(target, item, state: state)
+              last_error = item_error if item_error
+              coerced
             end
+          end
+
+          state[:error] = last_error || previous_error
+          converted
         end
 
         # @api private

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -97,20 +97,26 @@ module OpenAI
 
           target = item_type
           exactness[:yes] += 1
-          value
-            .to_h do |key, val|
-              k = key.is_a?(String) ? key.to_sym : key
-              v = case [nilable?, val]
-              in [true, nil]
-                exactness[:yes] += 1
-                nil
-              else
-                OpenAI::Internal::Type::Converter.coerce(target, val, state: state)
-              end
-
-              exactness[:no] += 1 unless k.is_a?(Symbol)
-              [k, v]
+          previous_error = state.fetch(:error)
+          last_error = nil
+          converted = value.to_h do |key, val|
+            k = key.is_a?(String) ? key.to_sym : key
+            v = case [nilable?, val]
+            in [true, nil]
+              exactness[:yes] += 1
+              nil
+            else
+              coerced, value_error = OpenAI::Internal::Type::Converter.coerce_with_error(target, val, state: state)
+              last_error = value_error if value_error
+              coerced
             end
+
+            exactness[:no] += 1 unless k.is_a?(Symbol)
+            [k, v]
+          end
+
+          state[:error] = last_error || previous_error
+          converted
         end
 
         # @api private

--- a/test/openai/internal/type/collection_state_test.rb
+++ b/test/openai/internal/type/collection_state_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::CollectionStateTest < Minitest::Test
+  class Item < OpenAI::Internal::Type::BaseModel
+    required :value, Integer
+  end
+
+  def test_array_errors_do_not_depend_on_element_order
+    inputs = [
+      [{value: "invalid"}, {value: "1"}],
+      [{value: "1"}, {value: "invalid"}]
+    ]
+
+    inputs.each do |input|
+      value, state = coerce(OpenAI::Internal::Type::ArrayOf[Item], input)
+
+      assert(value.all? { _1.is_a?(Item) })
+      assert_instance_of(ArgumentError, state.fetch(:error))
+      assert_match(/invalid/, state.fetch(:error).message)
+      assert_equal({yes: 3, no: 1, maybe: 1}, state.fetch(:exactness))
+    end
+  end
+
+  def test_hash_errors_do_not_depend_on_value_order
+    inputs = [
+      {invalid: {value: "invalid"}, valid: {value: "1"}},
+      {valid: {value: "1"}, invalid: {value: "invalid"}}
+    ]
+
+    inputs.each do |input|
+      value, state = coerce(OpenAI::Internal::Type::HashOf[Item], input)
+
+      assert(value.values.all? { _1.is_a?(Item) })
+      assert_instance_of(ArgumentError, state.fetch(:error))
+      assert_match(/invalid/, state.fetch(:error).message)
+      assert_equal({yes: 3, no: 1, maybe: 1}, state.fetch(:exactness))
+    end
+  end
+
+  def test_collections_continue_after_failures_and_retain_the_last_failure
+    cases = [
+      [
+        OpenAI::Internal::Type::ArrayOf[Item],
+        [{value: "first"}, {value: "2"}, {value: "last"}]
+      ],
+      [
+        OpenAI::Internal::Type::HashOf[Item],
+        {first: {value: "first"}, valid: {value: "2"}, last: {value: "last"}}
+      ]
+    ]
+
+    cases.each do |target, input|
+      value, state = coerce(target, input)
+      values = value.is_a?(Hash) ? value.values : value
+
+      assert(values.all? { _1.is_a?(Item) })
+      assert_instance_of(ArgumentError, state.fetch(:error))
+      assert_match(/last/, state.fetch(:error).message)
+      assert_equal({yes: 4, no: 2, maybe: 1}, state.fetch(:exactness))
+    end
+  end
+
+  def test_collections_preserve_parent_errors_unless_an_element_fails
+    cases = [
+      [OpenAI::Internal::Type::ArrayOf[Item], [{value: "1"}], [{value: "invalid"}]],
+      [OpenAI::Internal::Type::HashOf[Item], {item: {value: "1"}}, {item: {value: "invalid"}}]
+    ]
+
+    cases.each do |target, valid, invalid|
+      parent_error = RuntimeError.new("parent")
+      _, valid_state = coerce(target, valid, error: parent_error)
+
+      assert_same(parent_error, valid_state.fetch(:error))
+
+      _, invalid_state = coerce(target, invalid, error: parent_error)
+
+      assert_instance_of(ArgumentError, invalid_state.fetch(:error))
+      assert_match(/invalid/, invalid_state.fetch(:error).message)
+    end
+  end
+
+  private
+
+  def coerce(target, input, error: nil)
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    state[:error] = error
+    value = OpenAI::Internal::Type::Converter.coerce(target, input, state: state)
+    [value, state]
+  end
+end

--- a/test/openai/models/realtime/realtime_mcp_list_tools_test.rb
+++ b/test/openai/models/realtime/realtime_mcp_list_tools_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Models::Realtime::RealtimeMcpListToolsTest < Minitest::Test
+  def test_tool_errors_do_not_depend_on_collection_order
+    invalid = {input_schema: {}, name: Object.new}
+    valid = {input_schema: {}, name: "lookup"}
+
+    [[invalid, valid], [valid, invalid]].each do |tools|
+      request = OpenAI::Realtime::RealtimeMcpListTools.new(server_label: "server", tools: tools)
+
+      assert_same(tools, request[:tools])
+      assert_same(tools, request.to_h.fetch(:tools))
+      request_error = assert_raises(OpenAI::Errors::ConversionError) { request.tools }
+      assert_instance_of(TypeError, request_error.cause)
+
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+      parsed = OpenAI::Internal::Type::Converter.coerce(
+        OpenAI::Realtime::RealtimeMcpListTools,
+        {server_label: "server", tools: tools},
+        state: state
+      )
+
+      parsed_tools = parsed[:tools]
+      assert(parsed_tools.all? { _1.is_a?(OpenAI::Realtime::RealtimeMcpListTools::Tool) })
+      assert_same(parsed_tools, parsed.to_h.fetch(:tools))
+      assert_instance_of(TypeError, state.fetch(:error))
+      assert_match(/Object can't be coerced into String/, state.fetch(:error).message)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- isolate each `ArrayOf` / `HashOf` child conversion so a successful sibling cannot clear an earlier element failure
- retain the last actual child failure, preserving the existing single-error-slot behavior for multiple failures, and fall back to an incoming parent error when every child succeeds
- keep exactness accounting and full collection traversal unchanged
- add fail-first runtime coverage plus a representative generated Realtime model regression

Addresses the collection error-retention follow-up in #376. This intentionally does not close the tracking issue.

## Root cause and rule

Collection converters previously passed the shared state directly to every child. `BaseModel` clears `state[:error]` at each field boundary, so a failing model element followed by a successful model element could end with no collection error; reversing the elements retained the failure despite identical exactness.

The fix reuses `Converter.coerce_with_error` for each child. Exactness remains shared, but child errors are isolated from siblings. After every element has been converted, the collection commits the last child failure, or restores the incoming parent error if no child failed. This preserves current last-failure behavior for multiple invalid scalar/model elements while removing success-after-failure order dependence.

## Compatibility boundary

- no change to raw caller-owned request storage, `BaseModel#[]`, `#to_h`, or serialization
- no change to typed accessor behavior: invalid request fields still raise `ConversionError`
- no change to union matching/ranking or coercion breadth
- no RBI/RBS or public API changes

## Generated-code ownership

No Castiron generator or generated model changes are required. Castiron's Ruby exclusion policy keeps `lib/openai/internal/` and the non-resource test tree SDK-owned. The generated `RealtimeMcpListTools` type is used only as representative contract coverage; generated files are unchanged.

## Validation

- fail-first regressions reproduced on `origin/main`: 3 runtime failures and 1 generated-model failure
- focused collection/generated regressions: 5 runs, 56 assertions, 0 failures/errors
- related BaseModel/union suites: 44 runs, 436 assertions, 0 failures/errors
- full suite excluding one pre-existing environment failure: 1,091 runs, 9,844 assertions, 0 failures/errors/skips
  - `RealtimeNetworkInvariantsTest#test_http_proxy_uses_connect_and_isolates_proxy_and_origin_credentials` fails identically on a clean `origin/main` worktree in this environment
- RuboCop: 2,716 files, no offenses
- Sorbet: no errors
- RBS: 1,236 files valid
- rubyfmt and RuboCop directive validation: passed
- example inventory and gem packaging: passed
- required thermo-nuclear code-quality review: passed after removing an unnecessary test-only identity adapter
- `git diff --check`: passed
