### PR TITLE
refactor: isolate file polling status loops

### DIFF
--- a/lib/openai/helpers/resource_polling.rb
+++ b/lib/openai/helpers/resource_polling.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module OpenAI
+  module Helpers
+    # Product-specific status handling for file and vector-store polling.
+    #
+    # @api private
+    module ResourcePolling
+      # @api private
+      #
+      # @return [OpenAI::Models::FileObject]
+      def self.wait_for_file(resource, file_id, poll_interval:, timeout:, request_options:)
+        poller = OpenAI::Internal::Poller.new(
+          operation: "file #{file_id}",
+          poll_interval: poll_interval,
+          timeout: timeout
+        )
+        file = nil
+
+        begin
+          loop do
+            file = poller.request(request_options, resource: file) do |options|
+              resource.retrieve(file_id, request_options: options)
+            end
+
+            case file.status
+            when OpenAI::FileObject::Status::UPLOADED
+              poller.wait(file)
+            when
+                OpenAI::FileObject::Status::PROCESSED,
+                OpenAI::FileObject::Status::ERROR,
+                :deleted,
+                "deleted"
+              return file
+            else
+              raise(
+                OpenAI::Errors::PollingError,
+                "Unexpected status while waiting for file #{file_id}: #{file.status.inspect}"
+              )
+            end
+          end
+
+        rescue OpenAI::Errors::APITimeoutError
+          poller.check_deadline!(file)
+          raise
+        end
+      end
+
+      # @api private
+      #
+      # @return [OpenAI::Models::VectorStores::VectorStoreFile]
+      def self.poll_vector_store_file(
+        resource,
+        file_id,
+        vector_store_id:,
+        poll_interval:,
+        timeout:,
+        request_options:
+      )
+        poller = OpenAI::Internal::Poller.new(
+          operation: "vector store file #{file_id}",
+          poll_interval: poll_interval,
+          timeout: timeout
+        )
+        file = nil
+
+        begin
+          loop do
+            file = poller
+              .request(
+                request_options,
+                extra_headers: {"OpenAI-Beta" => "assistants=v2"},
+                resource: file
+              ) do |options|
+                resource.retrieve(file_id, vector_store_id: vector_store_id, request_options: options)
+              end
+
+            case file.status
+            when OpenAI::VectorStores::VectorStoreFile::Status::IN_PROGRESS
+              poller.wait(file)
+            when
+                OpenAI::VectorStores::VectorStoreFile::Status::COMPLETED,
+                OpenAI::VectorStores::VectorStoreFile::Status::FAILED,
+                OpenAI::VectorStores::VectorStoreFile::Status::CANCELLED
+              return file
+            else
+              raise(
+                OpenAI::Errors::PollingError,
+                "Unexpected status while waiting for vector store file " \
+                  "#{file_id}: #{file.status.inspect}"
+              )
+            end
+          end
+
+        rescue OpenAI::Errors::APITimeoutError
+          poller.check_deadline!(file)
+          raise
+        end
+      end
+
+      # @api private
+      #
+      # @return [OpenAI::Models::VectorStores::VectorStoreFileBatch]
+      def self.poll_vector_store_file_batch(
+        resource,
+        batch_id,
+        vector_store_id:,
+        poll_interval:,
+        timeout:,
+        request_options:
+      )
+        poller = OpenAI::Internal::Poller.new(
+          operation: "vector store file batch #{batch_id}",
+          poll_interval: poll_interval,
+          timeout: timeout
+        )
+        batch = nil
+
+        begin
+          loop do
+            batch = poller
+              .request(
+                request_options,
+                extra_headers: {"OpenAI-Beta" => "assistants=v2"},
+                resource: batch
+              ) do |options|
+                resource.retrieve(batch_id, vector_store_id: vector_store_id, request_options: options)
+              end
+
+            case batch.status
+            when OpenAI::VectorStores::VectorStoreFileBatch::Status::IN_PROGRESS
+              poller.wait(batch)
+            when
+                OpenAI::VectorStores::VectorStoreFileBatch::Status::COMPLETED,
+                OpenAI::VectorStores::VectorStoreFileBatch::Status::FAILED,
+                OpenAI::VectorStores::VectorStoreFileBatch::Status::CANCELLED
+              return batch
+            else
+              raise(
+                OpenAI::Errors::PollingError,
+                "Unexpected status while waiting for vector store file batch " \
+                  "#{batch_id}: #{batch.status.inspect}"
+              )
+            end
+          end
+
+        rescue OpenAI::Errors::APITimeoutError
+          poller.check_deadline!(batch)
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/openai/resources/files.rb
+++ b/lib/openai/resources/files.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../helpers/resource_polling"
+
 module OpenAI
   module Resources
     # Files are used to upload documents that can be used with features like
@@ -192,40 +194,13 @@ module OpenAI
         timeout: OpenAI::Internal::Poller::DEFAULT_TIMEOUT,
         request_options: {}
       )
-        poller = OpenAI::Internal::Poller.new(
-          operation: "file #{file_id}",
+        OpenAI::Helpers::ResourcePolling.wait_for_file(
+          self,
+          file_id,
           poll_interval: poll_interval,
-          timeout: timeout
+          timeout: timeout,
+          request_options: request_options
         )
-        file = nil
-
-        begin
-          loop do
-            file = poller.request(request_options, resource: file) do |options|
-              retrieve(file_id, request_options: options)
-            end
-
-            case file.status
-            when OpenAI::FileObject::Status::UPLOADED
-              poller.wait(file)
-            when
-                OpenAI::FileObject::Status::PROCESSED,
-                OpenAI::FileObject::Status::ERROR,
-                :deleted,
-                "deleted"
-              return file
-            else
-              raise(
-                OpenAI::Errors::PollingError,
-                "Unexpected status while waiting for file #{file_id}: #{file.status.inspect}"
-              )
-            end
-          end
-
-        rescue OpenAI::Errors::APITimeoutError
-          poller.check_deadline!(file)
-          raise
-        end
       end
 
       # @api private

--- a/lib/openai/resources/vector_stores/file_batches.rb
+++ b/lib/openai/resources/vector_stores/file_batches.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../helpers/resource_polling"
+
 module OpenAI
   module Resources
     class VectorStores
@@ -231,45 +233,14 @@ module OpenAI
           timeout: OpenAI::Internal::Poller::DEFAULT_TIMEOUT,
           request_options: {}
         )
-          poller = OpenAI::Internal::Poller.new(
-            operation: "vector store file batch #{batch_id}",
+          OpenAI::Helpers::ResourcePolling.poll_vector_store_file_batch(
+            self,
+            batch_id,
+            vector_store_id: vector_store_id,
             poll_interval: poll_interval,
-            timeout: timeout
+            timeout: timeout,
+            request_options: request_options
           )
-          batch = nil
-
-          begin
-            loop do
-              batch = poller
-                .request(
-                  request_options,
-                  extra_headers: {"OpenAI-Beta" => "assistants=v2"},
-                  resource: batch
-                ) do |options|
-                  retrieve(batch_id, vector_store_id: vector_store_id, request_options: options)
-                end
-
-              case batch.status
-              when OpenAI::VectorStores::VectorStoreFileBatch::Status::IN_PROGRESS
-                poller.wait(batch)
-              when
-                  OpenAI::VectorStores::VectorStoreFileBatch::Status::COMPLETED,
-                  OpenAI::VectorStores::VectorStoreFileBatch::Status::FAILED,
-                  OpenAI::VectorStores::VectorStoreFileBatch::Status::CANCELLED
-                return batch
-              else
-                raise(
-                  OpenAI::Errors::PollingError,
-                  "Unexpected status while waiting for vector store file batch " \
-                    "#{batch_id}: #{batch.status.inspect}"
-                )
-              end
-            end
-
-          rescue OpenAI::Errors::APITimeoutError
-            poller.check_deadline!(batch)
-            raise
-          end
         end
 
         # Upload files concurrently, create a vector store file batch, and wait for

--- a/lib/openai/resources/vector_stores/files.rb
+++ b/lib/openai/resources/vector_stores/files.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../helpers/resource_polling"
+
 module OpenAI
   module Resources
     class VectorStores
@@ -256,45 +258,14 @@ module OpenAI
           timeout: OpenAI::Internal::Poller::DEFAULT_TIMEOUT,
           request_options: {}
         )
-          poller = OpenAI::Internal::Poller.new(
-            operation: "vector store file #{file_id}",
+          OpenAI::Helpers::ResourcePolling.poll_vector_store_file(
+            self,
+            file_id,
+            vector_store_id: vector_store_id,
             poll_interval: poll_interval,
-            timeout: timeout
+            timeout: timeout,
+            request_options: request_options
           )
-          file = nil
-
-          begin
-            loop do
-              file = poller
-                .request(
-                  request_options,
-                  extra_headers: {"OpenAI-Beta" => "assistants=v2"},
-                  resource: file
-                ) do |options|
-                  retrieve(file_id, vector_store_id: vector_store_id, request_options: options)
-                end
-
-              case file.status
-              when OpenAI::VectorStores::VectorStoreFile::Status::IN_PROGRESS
-                poller.wait(file)
-              when
-                  OpenAI::VectorStores::VectorStoreFile::Status::COMPLETED,
-                  OpenAI::VectorStores::VectorStoreFile::Status::FAILED,
-                  OpenAI::VectorStores::VectorStoreFile::Status::CANCELLED
-                return file
-              else
-                raise(
-                  OpenAI::Errors::PollingError,
-                  "Unexpected status while waiting for vector store file " \
-                    "#{file_id}: #{file.status.inspect}"
-                )
-              end
-            end
-
-          rescue OpenAI::Errors::APITimeoutError
-            poller.check_deadline!(file)
-            raise
-          end
         end
 
         # Upload a file and attach it to a vector store.

--- a/rbi/openai/helpers/resource_polling.rbi
+++ b/rbi/openai/helpers/resource_polling.rbi
@@ -1,0 +1,63 @@
+# typed: strong
+
+module OpenAI
+  module Helpers
+    # @api private
+    module ResourcePolling
+      sig do
+        params(
+          resource: OpenAI::Resources::Files,
+          file_id: String,
+          poll_interval: T.nilable(T.any(Integer, Float)),
+          timeout: T.nilable(T.any(Integer, Float)),
+          request_options: T.nilable(OpenAI::RequestOptions::OrHash)
+        )
+          .returns(OpenAI::Models::FileObject)
+      end
+      def self.wait_for_file(resource, file_id, poll_interval:, timeout:, request_options:)
+      end
+
+      sig do
+        params(
+          resource: OpenAI::Resources::VectorStores::Files,
+          file_id: String,
+          vector_store_id: String,
+          poll_interval: T.nilable(T.any(Integer, Float)),
+          timeout: T.nilable(T.any(Integer, Float)),
+          request_options: T.nilable(OpenAI::RequestOptions::OrHash)
+        )
+          .returns(OpenAI::Models::VectorStores::VectorStoreFile)
+      end
+      def self.poll_vector_store_file(
+        resource,
+        file_id,
+        vector_store_id:,
+        poll_interval:,
+        timeout:,
+        request_options:
+      )
+      end
+
+      sig do
+        params(
+          resource: OpenAI::Resources::VectorStores::FileBatches,
+          batch_id: String,
+          vector_store_id: String,
+          poll_interval: T.nilable(T.any(Integer, Float)),
+          timeout: T.nilable(T.any(Integer, Float)),
+          request_options: T.nilable(OpenAI::RequestOptions::OrHash)
+        )
+          .returns(OpenAI::Models::VectorStores::VectorStoreFileBatch)
+      end
+      def self.poll_vector_store_file_batch(
+        resource,
+        batch_id,
+        vector_store_id:,
+        poll_interval:,
+        timeout:,
+        request_options:
+      )
+      end
+    end
+  end
+end

--- a/sig/openai/helpers/resource_polling.rbs
+++ b/sig/openai/helpers/resource_polling.rbs
@@ -1,0 +1,31 @@
+module OpenAI
+  module Helpers
+    module ResourcePolling
+      def self.wait_for_file: (
+        OpenAI::Resources::Files resource,
+        String file_id,
+        poll_interval: (Integer | Float)?,
+        timeout: (Integer | Float)?,
+        request_options: OpenAI::request_opts?
+      ) -> OpenAI::Models::FileObject
+
+      def self.poll_vector_store_file: (
+        OpenAI::Resources::VectorStores::Files resource,
+        String file_id,
+        vector_store_id: String,
+        poll_interval: (Integer | Float)?,
+        timeout: (Integer | Float)?,
+        request_options: OpenAI::request_opts?
+      ) -> OpenAI::Models::VectorStores::VectorStoreFile
+
+      def self.poll_vector_store_file_batch: (
+        OpenAI::Resources::VectorStores::FileBatches resource,
+        String batch_id,
+        vector_store_id: String,
+        poll_interval: (Integer | Float)?,
+        timeout: (Integer | Float)?,
+        request_options: OpenAI::request_opts?
+      ) -> OpenAI::Models::VectorStores::VectorStoreFileBatch
+    end
+  end
+end

--- a/test/openai/helpers/resource_polling_test.rb
+++ b/test/openai/helpers/resource_polling_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResourcePollingTest < Minitest::Test
+  Result = Data.define(:status, :last_response)
+
+  def test_polling_preserves_retrieve_overrides_and_result_identity
+    polling_cases.each do |test_case|
+      [false, true].each do |async|
+        pending = Result.new(test_case.fetch(:pending), nil)
+        terminal = Result.new(test_case.fetch(:terminal), nil)
+        responses = [pending, terminal]
+        requests = []
+        resource = overridden_resource(test_case.fetch(:resource_class)) do |id, **params|
+          requests << [id, params]
+          responses.shift
+        end
+
+        options = {extra_headers: {"X-Test" => "yes"}, max_retries: 7}
+        original_options = {extra_headers: options.fetch(:extra_headers).dup, max_retries: 7}
+        sleeps = []
+        Thread.current.thread_variable_set(:mock_sleep, sleeps)
+
+        operation = -> do
+          test_case.fetch(:call).call(
+            resource,
+            poll_interval: 0.02,
+            timeout: nil,
+            request_options: options
+          )
+        end
+
+        result = async ? Sync { Async { operation.call }.wait } : operation.call
+
+        assert_same(terminal, result)
+        assert_equal([0.02], sleeps)
+        assert_equal(2, requests.length)
+        requests.each do |id, params|
+          assert_equal(test_case.fetch(:id), id)
+          assert_equal(test_case.fetch(:retrieve_params), params.except(:request_options))
+          request_options = params.fetch(:request_options)
+          assert_equal(7, request_options.fetch(:max_retries))
+          assert_equal(
+            {
+              **test_case.fetch(:headers),
+              "x-test" => "yes",
+              "x-stainless-poll-helper" => "true",
+              "x-stainless-custom-poll-interval" => "20"
+            },
+            request_options.fetch(:extra_headers)
+          )
+        end
+
+        assert_equal(original_options, options)
+      ensure
+        Thread.current.thread_variable_set(:mock_sleep, nil)
+      end
+    end
+  end
+
+  def test_polling_preserves_shorter_request_timeout_error_identity
+    polling_cases.each do |test_case|
+      error = OpenAI::Errors::APITimeoutError.new(url: URI("http://example.test/v1/resource"))
+      timeouts = []
+      resource = overridden_resource(test_case.fetch(:resource_class)) do |_id, **params|
+        timeouts << params.fetch(:request_options).fetch(:timeout)
+        raise error
+      end
+
+      raised = assert_raises(OpenAI::Errors::APITimeoutError) do
+        test_case.fetch(:call).call(resource, timeout: 10, request_options: {timeout: 0.01})
+      end
+
+      assert_same(error, raised)
+      assert_equal([0.01], timeouts)
+    end
+  end
+
+  def test_polling_preserves_unknown_status_error_messages
+    polling_cases.each do |test_case|
+      resource = overridden_resource(test_case.fetch(:resource_class)) do |_id, **_params|
+        Result.new("mystery", nil)
+      end
+
+      error = assert_raises(OpenAI::Errors::PollingError) do
+        test_case.fetch(:call).call(resource, timeout: nil)
+      end
+
+      assert_equal(
+        "Unexpected status while waiting for #{test_case.fetch(:operation)}: \"mystery\"",
+        error.message
+      )
+    end
+  end
+
+  def test_public_polling_method_parameters_are_unchanged
+    optional_keywords = [[:key, :poll_interval], [:key, :timeout], [:key, :request_options]]
+
+    assert_equal(
+      [[:req, :file_id], *optional_keywords],
+      OpenAI::Resources::Files.instance_method(:wait_for_processing).parameters
+    )
+    assert_equal(
+      [[:req, :file_id], [:keyreq, :vector_store_id], *optional_keywords],
+      OpenAI::Resources::VectorStores::Files.instance_method(:poll).parameters
+    )
+    assert_equal(
+      [[:req, :batch_id], [:keyreq, :vector_store_id], *optional_keywords],
+      OpenAI::Resources::VectorStores::FileBatches.instance_method(:poll).parameters
+    )
+  end
+
+  private def overridden_resource(resource_class, &retrieve)
+    Class
+      .new(resource_class) do
+        define_method(:retrieve, retrieve)
+      end
+      .new(client: OpenAI::Client.new(api_key: "test-api-key"))
+  end
+
+  private def polling_cases
+    [
+      {
+        resource_class: OpenAI::Resources::Files,
+        id: "file_123",
+        retrieve_params: {},
+        headers: {},
+        pending: :uploaded,
+        terminal: :processed,
+        operation: "file file_123",
+        call: -> (resource, **options) { resource.wait_for_processing("file_123", **options) }
+      },
+      {
+        resource_class: OpenAI::Resources::VectorStores::Files,
+        id: "file_123",
+        retrieve_params: {vector_store_id: "vs_123"},
+        headers: {"openai-beta" => "assistants=v2"},
+        pending: :in_progress,
+        terminal: :completed,
+        operation: "vector store file file_123",
+        call: -> (resource, **options) { resource.poll("file_123", vector_store_id: "vs_123", **options) }
+      },
+      {
+        resource_class: OpenAI::Resources::VectorStores::FileBatches,
+        id: "batch_123",
+        retrieve_params: {vector_store_id: "vs_123"},
+        headers: {"openai-beta" => "assistants=v2"},
+        pending: :in_progress,
+        terminal: :completed,
+        operation: "vector store file batch batch_123",
+        call: -> (resource, **options) { resource.poll("batch_123", vector_store_id: "vs_123", **options) }
+      }
+    ]
+  end
+end


### PR DESCRIPTION
## Summary

Move the existing file and vector-store polling status loops into the SDK-owned
`OpenAI::Helpers::ResourcePolling` helper, with matching private RBI/RBS
declarations. The three public resource methods retain their exact signatures
and delegate to the helper.

This is an extraction only. The shared `Internal::Poller`, terminal states,
request options and headers, timeout/error behavior, upload concurrency,
composite methods, and all existing public RBI/RBS declarations are unchanged.
The helper calls the original resource's `retrieve`, preserving subclass
overrides. A token-level comparison confirms each moved loop body is identical
after accounting for that explicit receiver.

The verified custom-code report remains at **50 mixed files**, while the
generated-file patch shrinks **2,892 → 2,809 lines**. Only the three intended
resource customizations change; the other 47 are unchanged. No compiler,
schema/config, generation metadata, API reference, or dependency changes.

## Tests and covered cases

The existing `OpenAI::Test::Resources::PollingHelpersTest` is unchanged:
37 tests cover server/custom intervals, all terminal states, unknown states,
strict and unbounded deadlines, workload-identity replay, shorter request
timeouts, headers/options, upload concurrency, idempotency, and composite
validation.

New `OpenAI::Test::ResourcePollingTest` in
`test/openai/helpers/resource_polling_test.rb`:

- `test_polling_preserves_retrieve_overrides_and_result_identity`: all three
  methods in synchronous and Async execution; pending-to-terminal transitions,
  exact returned object, direct override dispatch, headers, retries, intervals,
  and unmodified caller options.
- `test_polling_preserves_shorter_request_timeout_error_identity`: all three
  methods preserve the same timeout exception and shorter request timeout.
- `test_polling_preserves_unknown_status_error_messages`: exact error text for
  each resource.
- `test_public_polling_method_parameters_are_unchanged`: positional and keyword
  parameter contracts for all three public methods.

The four new tests pass against both the original and extracted implementation
(90 assertions). Combined focused suite: **41 tests, 281 assertions**.

## Validation

- Ruby 4.0.6, pinned rubyfmt 0.14.1, `./scripts/format`.
- `bundle exec rake lint`: 2,717 Ruby files, Sorbet, 1,237 RBS files; all pass.
- Full suite against pinned Steady 0.22.1: **1,091 tests, 9,892 assertions**,
  no failures or skips.
- Separate Bedrock suite: 38 tests, 377 assertions, one live-test skip.
- Gem build and packed-helper/signature/load checks pass.
- Existing public signatures and generation/API-reference metadata are
  byte-identical to the base; `git diff --check` passes.
