### PR TITLE
fix: align nullable collection matchers

### DIFF
--- a/lib/openai/internal/type/array_of.rb
+++ b/lib/openai/internal/type/array_of.rb
@@ -38,7 +38,21 @@ module OpenAI
         # @param other [Object]
         #
         # @return [Boolean]
-        def ===(other) = other.is_a?(Array) && other.all?(item_type)
+        def ===(other)
+          return false unless other.is_a?(Array)
+
+          target = item_type
+          other.all? do |item|
+            case item
+            in ^target
+              true
+            in nil
+              nilable?
+            else
+              false
+            end
+          end
+        end
 
         # @api public
         #
@@ -52,7 +66,7 @@ module OpenAI
         # @api public
         #
         # @return [Integer]
-        def hash = [self.class, item_type].hash
+        def hash = [self.class, item_type, nilable?].hash
 
         # @api private
         #

--- a/lib/openai/internal/type/hash_of.rb
+++ b/lib/openai/internal/type/hash_of.rb
@@ -46,6 +46,8 @@ module OpenAI
               case [key, val]
               in [Symbol | String, ^type]
                 true
+              in [Symbol | String, nil]
+                nilable?
               else
                 false
               end
@@ -67,7 +69,7 @@ module OpenAI
         # @api public
         #
         # @return [Integer]
-        def hash = [self.class, item_type].hash
+        def hash = [self.class, item_type, nilable?].hash
 
         # @api private
         #
@@ -137,7 +139,9 @@ module OpenAI
         #
         # @return [Object]
         def to_sorbet_type
-          T::Hash[OpenAI::Internal::Util::SorbetRuntimeSupport.to_sorbet_type(item_type)]
+          type = OpenAI::Internal::Util::SorbetRuntimeSupport.to_sorbet_type(item_type)
+          type = T.nilable(type) if nilable?
+          T::Hash[Symbol, type]
         end
 
         # @api private

--- a/test/openai/internal/type/array_of_sorbet_type_test.rb
+++ b/test/openai/internal/type/array_of_sorbet_type_test.rb
@@ -5,8 +5,8 @@ require "rbconfig"
 
 require_relative "../../test_helper"
 
-class OpenAI::Test::ArrayOfSorbetTypeTest < Minitest::Test
-  def test_nullable_elements_are_preserved_in_sorbet_types
+class OpenAI::Test::CollectionSorbetTypeTest < Minitest::Test
+  def test_collection_element_nullability_is_preserved_in_sorbet_types
     stdout, stderr, status = Open3.capture3(
       {"RUBYOPT" => nil},
       RbConfig.ruby,
@@ -15,10 +15,48 @@ class OpenAI::Test::ArrayOfSorbetTypeTest < Minitest::Test
       "-rsorbet-runtime",
       "-ropenai",
       "-e",
-      "puts OpenAI::ArrayOf[Integer, nil?: true].to_sorbet_type"
+      <<~RUBY
+        puts OpenAI::ArrayOf[Integer].to_sorbet_type
+        puts OpenAI::ArrayOf[Integer, nil?: true].to_sorbet_type
+        puts OpenAI::Internal::Type::HashOf[Integer].to_sorbet_type
+        puts OpenAI::Internal::Type::HashOf[Integer, nil?: true].to_sorbet_type
+      RUBY
     )
 
     assert_predicate(status, :success?, stderr)
-    assert_equal("T::Array[T.nilable(Integer)]\n", stdout)
+    assert_equal(
+      <<~OUTPUT,
+        T::Array[Integer]
+        T::Array[T.nilable(Integer)]
+        T::Hash[Symbol, Integer]
+        T::Hash[Symbol, T.nilable(Integer)]
+      OUTPUT
+      stdout
+    )
+  end
+
+  def test_generated_collection_contracts_have_runtime_sorbet_types
+    stdout, stderr, status = Open3.capture3(
+      {"RUBYOPT" => nil},
+      RbConfig.ruby,
+      "-I",
+      File.expand_path("../../../../lib", __dir__),
+      "-rsorbet-runtime",
+      "-ropenai",
+      "-e",
+      <<~RUBY
+        puts OpenAI::Models::Metadata.to_sorbet_type
+        puts OpenAI::Models::CompletionCreateParams::Prompt::Variants
+      RUBY
+    )
+
+    assert_predicate(status, :success?, stderr)
+    assert_equal(
+      <<~OUTPUT,
+        T::Hash[Symbol, String]
+        T.any(String, T::Array[Integer], T::Array[String], T::Array[T::Array[Integer]])
+      OUTPUT
+      stdout
+    )
   end
 end

--- a/test/openai/internal/type/nullable_collection_test.rb
+++ b/test/openai/internal/type/nullable_collection_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class OpenAI::Test::NullableCollectionTest < Minitest::Test
+  ARRAY = OpenAI::Internal::Type::ArrayOf[Integer]
+  NULLABLE_ARRAY = OpenAI::Internal::Type::ArrayOf[Integer, nil?: true]
+  HASH = OpenAI::Internal::Type::HashOf[Integer]
+  NULLABLE_HASH = OpenAI::Internal::Type::HashOf[Integer, nil?: true]
+
+  class CollectionUnion
+    include OpenAI::Internal::Type::Union
+
+    def initialize(*variants) = variants.each { variant(_1) }
+  end
+
+  def test_nullable_array_matcher_agrees_with_coercion
+    assert_match_after_coercion(NULLABLE_ARRAY, [1, nil])
+    assert(NULLABLE_ARRAY === [1, nil])
+    refute(NULLABLE_ARRAY === [1, "one"])
+  end
+
+  def test_nullable_hash_matcher_agrees_with_coercion_for_supported_keys
+    [{one: 1, none: nil}, {"one" => 1, "none" => nil}].each do |value|
+      assert_match_after_coercion(NULLABLE_HASH, value)
+      assert(NULLABLE_HASH === value)
+    end
+
+    refute(NULLABLE_HASH === {1 => nil})
+  end
+
+  def test_non_nullable_matchers_keep_rejecting_nil_elements
+    assert(ARRAY === [1])
+    refute(ARRAY === [1, nil])
+    assert(HASH === {one: 1})
+    assert(HASH === {"one" => 1})
+    refute(HASH === {one: nil})
+    refute(HASH === {"one" => nil})
+
+    assert(OpenAI::Internal::Type::ArrayOf[NilClass] === [nil])
+    assert(OpenAI::Internal::Type::HashOf[NilClass] === {none: nil})
+  end
+
+  def test_nullable_elements_do_not_make_the_collection_nullable
+    [NULLABLE_ARRAY, NULLABLE_HASH].each do |type|
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+      refute(type === nil)
+      assert_nil(OpenAI::Internal::Type::Converter.coerce(type, nil, state: state))
+      assert_equal({yes: 0, no: 1, maybe: 0}, state.fetch(:exactness))
+      assert_instance_of(TypeError, state.fetch(:error))
+    end
+  end
+
+  def test_inspect_equality_and_hash_include_element_nullability
+    assert_equal("OpenAI::Internal::Type::ArrayOf[Integer]", ARRAY.inspect)
+    assert_equal("OpenAI::Internal::Type::ArrayOf[Integer | nil]", NULLABLE_ARRAY.inspect)
+    assert_equal("OpenAI::Internal::Type::HashOf[Integer]", HASH.inspect)
+    assert_equal("OpenAI::Internal::Type::HashOf[Integer | nil]", NULLABLE_HASH.inspect)
+
+    refute_equal(ARRAY, NULLABLE_ARRAY)
+    refute_equal(ARRAY.hash, NULLABLE_ARRAY.hash)
+    refute_equal(HASH, NULLABLE_HASH)
+    refute_equal(HASH.hash, NULLABLE_HASH.hash)
+  end
+
+  def test_union_dump_selects_nullable_array_variant_only_when_it_precedes_fallback
+    nullable = OpenAI::Internal::Type::ArrayOf[OpenAI::Internal::Type::FileInput, nil?: true]
+    fallback = OpenAI::Internal::Type::ArrayOf[OpenAI::Internal::Type::Unknown]
+    value = [nil, StringIO.new("contents")]
+
+    selected = dump_union(CollectionUnion.new(nullable, fallback), value)
+    assert_nil(selected.fetch(0))
+    assert_instance_of(OpenAI::FilePart, selected.fetch(1))
+
+    fallback_selected = dump_union(CollectionUnion.new(fallback, nullable), value)
+    assert_equal([nil, "contents"], fallback_selected)
+  end
+
+  def test_union_dump_selects_nullable_hash_variant_only_when_it_precedes_fallback
+    nullable = OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::FileInput, nil?: true]
+    fallback = OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::Unknown]
+    value = {none: nil, file: StringIO.new("contents")}
+
+    selected = dump_union(CollectionUnion.new(nullable, fallback), value)
+    assert_nil(selected.fetch(:none))
+    assert_instance_of(OpenAI::FilePart, selected.fetch(:file))
+
+    fallback_selected = dump_union(CollectionUnion.new(fallback, nullable), value)
+    assert_equal({none: nil, file: "contents"}, fallback_selected)
+  end
+
+  private
+
+  def assert_match_after_coercion(type, value)
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    coerced = OpenAI::Internal::Type::Converter.coerce(type, value, state: state)
+
+    assert(type === coerced)
+    assert_nil(state.fetch(:error))
+  end
+
+  def dump_union(union, value)
+    OpenAI::Internal::Type::Converter.dump(union, value)
+  end
+end


### PR DESCRIPTION
## Summary

- make nullable `ArrayOf` and `HashOf` element matchers agree with their existing coercion behavior
- keep collection-level `nil` distinct from nullable elements and preserve non-nullable matching
- make `HashOf#to_sorbet_type` return the symbol-keyed hash type produced by coercion, including nullable values
- include element nullability in collection converter hashes, matching equality and inspect semantics

## Compatibility

An executable differential compared the published `openai` 0.80.0 gem, the refreshed `origin/main` base, and this branch for nullable and non-nullable Array/Hash values, symbol and string hash keys, and unions with nullable collection and broad fallback variants in both orders.

The released gem and current main were identical. This branch changed only:

- nullable matcher results from false to true for values already accepted by coercion
- post-coercion matcher agreement from false to true
- nullable-first union dumping to use the now-matching nullable collection variant

Fallback-first unions, non-nil values, invalid element values, non-nullable variants, and `nil` collections were unchanged. `Union` itself is unchanged.

## Generator ownership

The runtime collection types and tests changed here are SDK-owned. Generated model, RBI, and RBS files were not edited. The handwritten contract test exercises generated `Metadata` and completion prompt declarations; the runtime Sorbet hash output now agrees with the generated symbol-keyed RBS type.

## Validation

- focused nullable collection, Sorbet, BaseModel, and structured output tests
- released gem / current main / branch compatibility differential
- `bundle exec rake lint`
- `bundle exec rake build:gem`
- Bedrock bundle check and test suite: 38 runs, 377 assertions, 0 failures, 1 existing skip
- primary suite: 1,094 of 1,095 tests pass locally; the remaining Realtime proxy invariant is blocked by the sandbox proxy stack and reproduces unchanged against untouched `origin/main`
- thermo-nuclear code quality review
- `git diff --check`

Refs #376
