### PR TITLE
refactor: isolate Responses structured-output parsing

### DIFF
--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module OpenAI
+  module Helpers
+    module StructuredOutput
+      # Request preparation and response coercion for the Responses API.
+      #
+      # @api private
+      module ResponseParser
+        # Post-processes raw API responses to parse and coerce structured outputs into typed Ruby objects.
+        #
+        # @api private
+        #
+        # @param raw [Hash] The raw API response hash that will be mutated with parsed data
+        # @param model [JsonSchemaConverter, nil] The converter for structured text output
+        # @param tool_models [Hash<String, JsonSchemaConverter>] Tool names and their converters
+        # @return [Hash] The same response with typed values in its :parsed fields
+        def self.parse!(raw, model, tool_models)
+          if model.is_a?(OpenAI::StructuredOutput::JsonSchemaConverter)
+            raw[:output]
+              &.flat_map do |output|
+                next [] unless output[:type] == "message"
+                output[:content].to_a
+              end
+              &.each do |content|
+                next unless content[:type] == "output_text"
+                begin
+                  parsed = JSON.parse(content.fetch(:text), symbolize_names: true)
+                rescue JSON::ParserError => e
+                  parsed = e
+                end
+
+                coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
+                content.store(:parsed, coerced)
+              end
+          end
+
+          raw[:output]&.each do |output|
+            next unless output[:type] == "function_call"
+            next if (model = tool_models[output.fetch(:name)]).nil?
+            begin
+              parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
+            rescue JSON::ParserError => e
+              parsed = e
+            end
+
+            coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
+            output.store(:parsed, coerced)
+          end
+
+          raw
+        end
+
+        # Extracts structured output models and replaces request values with JSON Schema.
+        #
+        # @api private
+        #
+        # @param parsed [Hash] Request parameters to update in place
+        # @return [Array<(JsonSchemaConverter|nil, Hash)>] Text model and named tool models
+        def self.get_models(parsed)
+          model = nil
+          tool_models = {}
+
+          case parsed
+          in {text: OpenAI::StructuredOutput::JsonSchemaConverter => model}
+            parsed.update(
+              text: {
+                format: {
+                  type: :json_schema,
+                  strict: true,
+                  name: model.name.split("::").last,
+                  schema: model.to_json_schema
+                }
+              }
+            )
+          in {text: {format: OpenAI::StructuredOutput::JsonSchemaConverter => model}}
+            parsed.fetch(:text).update(
+              format: {
+                type: :json_schema,
+                strict: true,
+                name: model.name.split("::").last,
+                schema: model.to_json_schema
+              }
+            )
+          in {
+              text: {
+                  format: {
+                      type: :json_schema,
+                      schema: OpenAI::StructuredOutput::JsonSchemaConverter => model
+                    }
+                }
+            }
+            parsed.dig(:text, :format).store(:schema, model.to_json_schema)
+          else
+          end
+
+          case parsed
+          in {tools: Array => tools}
+            # rubocop:disable Metrics/BlockLength
+            mapped = tools.map do |tool|
+              case tool
+              in OpenAI::StructuredOutput::JsonSchemaConverter
+                name = tool.name.split("::").last
+                tool_models.store(name, tool)
+                {
+                  type: :function,
+                  strict: true,
+                  name: name,
+                  parameters: tool.to_json_schema
+                }
+              in {type: :function, parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}
+                func = tool.fetch(:function)
+                name = func[:name] ||= params.name.split("::").last
+                tool_models.store(name, params)
+                func.update(parameters: params.to_json_schema)
+                tool
+              in {type: _, function: {parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params, **}}
+                name = tool[:function][:name] || params.name.split("::").last
+                tool_models.store(name, params)
+                tool[:function][:parameters] = params.to_json_schema
+                tool
+              in {type: _, function: Hash => func}
+                params = func[:parameters]
+                # rubyfmt 0.14.1 corrupts a long guarded `in` clause into `in if`.
+                # Keep the same guard in the existing handwritten branch instead.
+                next tool unless params.is_a?(Class) && params < OpenAI::Internal::Type::BaseModel
+                name = func[:name] || params.name.split("::").last
+                tool_models.store(name, params)
+                func[:parameters] = params.to_json_schema
+                tool
+              else
+                tool
+              end
+            end
+            # rubocop:enable Metrics/BlockLength
+            tools.replace(mapped)
+          else
+          end
+
+          [model, tool_models]
+        end
+      end
+    end
+  end
+end

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../helpers/structured_output/response_parser"
+
 module OpenAI
   module Resources
     class Responses
@@ -545,155 +547,12 @@ module OpenAI
 
       private
 
-      # Post-processes raw API responses to parse and coerce structured outputs into typed Ruby objects.
-      #
-      # This method enhances the raw API response by parsing JSON content in structured outputs
-      # (both text outputs and function/tool calls) and converting them to their corresponding
-      # Ruby types using the JsonSchemaConverter models identified during request preparation.
-      #
-      # @param raw [Hash] The raw API response hash that will be mutated with parsed data
-      # @param model [JsonSchemaConverter|nil] The converter for structured text output, if specified
-      # @param tool_models [Hash<String, JsonSchemaConverter>] Hash mapping tool names to their converters
-      # @return [Hash] The mutated raw response with added :parsed fields containing typed Ruby objects
-      #
-      # The method performs two main transformations:
-      # 1. For structured text outputs: Finds output_text content, parses the JSON, and coerces it
-      #    to the model type, adding the result as content[:parsed]
-      # 2. For function/tool calls: Looks up the tool's converter by name, parses the arguments JSON,
-      #    and coerces it to the appropriate type, adding the result as output[:parsed]
       def parse_structured_outputs!(raw, model, tool_models)
-        if model.is_a?(OpenAI::StructuredOutput::JsonSchemaConverter)
-          raw[:output]
-            &.flat_map do |output|
-              next [] unless output[:type] == "message"
-              output[:content].to_a
-            end
-            &.each do |content|
-              next unless content[:type] == "output_text"
-              begin
-                parsed = JSON.parse(content.fetch(:text), symbolize_names: true)
-              rescue JSON::ParserError => e
-                parsed = e
-              end
-
-              coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
-              content.store(:parsed, coerced)
-            end
-        end
-
-        raw[:output]&.each do |output|
-          next unless output[:type] == "function_call"
-          next if (model = tool_models[output.fetch(:name)]).nil?
-          begin
-            parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
-          rescue JSON::ParserError => e
-            parsed = e
-          end
-
-          coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
-          output.store(:parsed, coerced)
-        end
-
-        raw
+        OpenAI::Helpers::StructuredOutput::ResponseParser.parse!(raw, model, tool_models)
       end
 
-      # Extracts structured output models from request parameters and converts them to JSON Schema format.
-      #
-      # This method processes the parsed request parameters to identify any JsonSchemaConverter instances
-      # that define expected output schemas. It transforms these Ruby schema definitions into the JSON
-      # Schema format required by the OpenAI API, enabling type-safe structured outputs.
-      #
-      # @param parsed [Hash] The parsed request parameters that may contain structured output definitions
-      # @return [Array<(JsonSchemaConverter|nil, Hash)>] A tuple containing:
-      #   - model: The JsonSchemaConverter for structured text output (or nil if not specified)
-      #   - tool_models: Hash mapping tool names to their JsonSchemaConverter models
-      #
-      # The method handles multiple ways structured outputs can be specified:
-      # - Direct text format: { text: JsonSchemaConverter }
-      # - Nested text format: { text: { format: JsonSchemaConverter } }
-      # - Deep nested format: { text: { format: { type: :json_schema, schema: JsonSchemaConverter } } }
-      # - Tool parameters: { tools: [JsonSchemaConverter, ...] } or tools with parameters as converters
       def get_structured_output_models(parsed)
-        model = nil
-        tool_models = {}
-
-        case parsed
-        in {text: OpenAI::StructuredOutput::JsonSchemaConverter => model}
-          parsed.update(
-            text: {
-              format: {
-                type: :json_schema,
-                strict: true,
-                name: model.name.split("::").last,
-                schema: model.to_json_schema
-              }
-            }
-          )
-        in {text: {format: OpenAI::StructuredOutput::JsonSchemaConverter => model}}
-          parsed.fetch(:text).update(
-            format: {
-              type: :json_schema,
-              strict: true,
-              name: model.name.split("::").last,
-              schema: model.to_json_schema
-            }
-          )
-        in {
-            text: {
-                format: {
-                    type: :json_schema,
-                    schema: OpenAI::StructuredOutput::JsonSchemaConverter => model
-                  }
-              }
-          }
-          parsed.dig(:text, :format).store(:schema, model.to_json_schema)
-        else
-        end
-
-        case parsed
-        in {tools: Array => tools}
-          # rubocop:disable Metrics/BlockLength
-          mapped = tools.map do |tool|
-            case tool
-            in OpenAI::StructuredOutput::JsonSchemaConverter
-              name = tool.name.split("::").last
-              tool_models.store(name, tool)
-              {
-                type: :function,
-                strict: true,
-                name: name,
-                parameters: tool.to_json_schema
-              }
-            in {type: :function, parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}
-              func = tool.fetch(:function)
-              name = func[:name] ||= params.name.split("::").last
-              tool_models.store(name, params)
-              func.update(parameters: params.to_json_schema)
-              tool
-            in {type: _, function: {parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params, **}}
-              name = tool[:function][:name] || params.name.split("::").last
-              tool_models.store(name, params)
-              tool[:function][:parameters] = params.to_json_schema
-              tool
-            in {type: _, function: Hash => func}
-              params = func[:parameters]
-              # rubyfmt 0.14.1 corrupts a long guarded `in` clause into `in if`.
-              # Keep the same guard in the existing handwritten branch instead.
-              next tool unless params.is_a?(Class) && params < OpenAI::Internal::Type::BaseModel
-              name = func[:name] || params.name.split("::").last
-              tool_models.store(name, params)
-              func[:parameters] = params.to_json_schema
-              tool
-            else
-              tool
-            end
-          end
-          # rubocop:enable Metrics/BlockLength
-          tools.replace(mapped)
-        else
-        end
-
-        [model, tool_models]
+        OpenAI::Helpers::StructuredOutput::ResponseParser.get_models(parsed)
       end
     end
   end

--- a/rbi/openai/helpers/structured_output/response_parser.rbi
+++ b/rbi/openai/helpers/structured_output/response_parser.rbi
@@ -1,0 +1,33 @@
+# typed: strong
+
+module OpenAI
+  module Helpers
+    module StructuredOutput
+      # @api private
+      module ResponseParser
+        sig do
+          params(
+            raw: OpenAI::Internal::AnyHash,
+            model: T.nilable(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input),
+            tool_models: T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+          )
+            .returns(OpenAI::Internal::AnyHash)
+        end
+        def self.parse!(raw, model, tool_models)
+        end
+
+        sig do
+          params(parsed: OpenAI::Internal::AnyHash)
+            .returns(
+              [
+                T.nilable(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input),
+                T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+              ]
+            )
+        end
+        def self.get_models(parsed)
+        end
+      end
+    end
+  end
+end

--- a/sig/openai/helpers/structured_output/response_parser.rbs
+++ b/sig/openai/helpers/structured_output/response_parser.rbs
@@ -1,0 +1,17 @@
+module OpenAI
+  module Helpers
+    module StructuredOutput
+      module ResponseParser
+        def self.parse!: (
+          ::Hash[Symbol, top] raw,
+          top model,
+          ::Hash[String, top] tool_models
+        ) -> ::Hash[Symbol, top]
+
+        def self.get_models: (
+          ::Hash[Symbol, top] parsed
+        ) -> [top, ::Hash[String, top]]
+      end
+    end
+  end
+end

--- a/test/openai/helpers/response_parser_test.rb
+++ b/test/openai/helpers/response_parser_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResponseParserTest < Minitest::Test
+  class TextModel < OpenAI::BaseModel
+    required :value, String
+  end
+
+  class ToolModel < OpenAI::BaseModel
+    required :argument, Integer
+  end
+
+  class ResponsesProbe < OpenAI::Resources::Responses
+    def prepare(parsed) = get_structured_output_models(parsed)
+
+    def parse(raw, model, tool_models) = parse_structured_outputs!(raw, model, tool_models)
+  end
+
+  def test_all_text_forms_prepare_tools_and_preserve_nested_objects
+    forms = [
+      {text: TextModel},
+      {text: {format: TextModel, verbosity: :low}},
+      {text: {format: {type: :json_schema, name: "explicit", strict: false, schema: TextModel}}}
+    ]
+
+    forms.each do |params|
+      original_text = params[:text]
+      original_format = original_text[:format] if original_text.is_a?(Hash)
+      tools = [ToolModel]
+      params[:tools] = tools
+
+      model, tool_models = ResponsesProbe.allocate.prepare(params)
+
+      assert_same(TextModel, model)
+      assert_equal({"ToolModel" => ToolModel}, tool_models)
+      assert_same(tools, params[:tools])
+      assert_equal(
+        [{type: :function, strict: true, name: "ToolModel", parameters: ToolModel.to_json_schema}],
+        tools
+      )
+      format = params.fetch(:text).fetch(:format)
+      assert_equal(TextModel.to_json_schema, format[:schema])
+      if original_text.is_a?(Hash)
+        assert_same(original_text, params[:text])
+      end
+
+      if original_format.is_a?(Hash)
+        assert_same(original_format, format)
+        assert_equal("explicit", format[:name])
+        assert_equal(false, format[:strict])
+      else
+        assert_equal("TextModel", format[:name])
+        assert_equal(true, format[:strict])
+      end
+    end
+  end
+
+  def test_nested_tool_names_and_flat_tool_behavior_are_preserved
+    [nil, "explicit"].each do |name|
+      function = {parameters: ToolModel}
+      function[:name] = name unless name.nil?
+      tool = {type: :function, function: function}
+      tools = [tool]
+
+      model, tool_models = ResponsesProbe.allocate.prepare(tools: tools)
+
+      assert_nil(model)
+      assert_equal({(name || "ToolModel") => ToolModel}, tool_models)
+      assert_same(tool, tools.first)
+      assert_same(function, tool[:function])
+      assert_equal(ToolModel.to_json_schema, function[:parameters])
+      assert_equal(name, function[:name]) unless name.nil?
+      refute(function.key?(:name)) if name.nil?
+    end
+
+    function = {}
+    tool = {type: :function, parameters: ToolModel, function: function}
+    _model, tool_models = ResponsesProbe.allocate.prepare(tools: [tool])
+    assert_equal({"ToolModel" => ToolModel}, tool_models)
+    assert_equal("ToolModel", function[:name])
+    assert_equal(ToolModel.to_json_schema, function[:parameters])
+    assert_same(ToolModel, tool[:parameters])
+  end
+
+  def test_flat_converter_without_function_preserves_key_error
+    error = assert_raises(KeyError) do
+      ResponsesProbe.allocate.prepare(tools: [{type: :function, parameters: ToolModel}])
+    end
+
+    assert_equal(:function, error.key)
+  end
+
+  def test_parse_updates_known_outputs_in_place_and_leaves_other_types_alone
+    text = {type: "output_text", text: "{\"value\":\"hello\"}"}
+    refusal = {type: "refusal", refusal: "no"}
+    symbol_text = {type: :output_text, text: "{\"value\":\"ignored\"}"}
+    known_tool = {type: "function_call", name: "known", arguments: "{\"argument\":7}"}
+    unknown_tool = {type: "function_call", name: "unknown", arguments: "invalid"}
+    raw = {
+      output: [
+        {type: "message", content: [text, refusal, symbol_text]},
+        {type: :message, content: [{type: "output_text", text: "invalid"}]},
+        known_tool,
+        unknown_tool
+      ]
+    }
+
+    result = ResponsesProbe.allocate.parse(raw, TextModel, {"known" => ToolModel})
+
+    assert_same(raw, result)
+    assert_instance_of(TextModel, text[:parsed])
+    assert_equal("hello", text[:parsed].value)
+    assert_instance_of(ToolModel, known_tool[:parsed])
+    assert_equal(7, known_tool[:parsed].argument)
+    refute(refusal.key?(:parsed))
+    refute(symbol_text.key?(:parsed))
+    refute(unknown_tool.key?(:parsed))
+    refute(raw[:output][1][:content][0].key?(:parsed))
+  end
+
+  def test_parse_preserves_malformed_json_and_missing_key_errors
+    text = {type: "output_text", text: "not json"}
+    tool = {type: "function_call", name: "known", arguments: "not json"}
+    raw = {output: [{type: "message", content: [text]}, tool]}
+
+    assert_same(raw, ResponsesProbe.allocate.parse(raw, TextModel, {"known" => ToolModel}))
+    assert_instance_of(JSON::ParserError, text[:parsed])
+    assert_instance_of(JSON::ParserError, tool[:parsed])
+
+    [
+      [{output: [{type: "message", content: [{type: "output_text"}]}]}, :text],
+      [{output: [{type: "function_call"}]}, :name],
+      [{output: [{type: "function_call", name: "known"}]}, :arguments]
+    ].each do |payload, key|
+      error = assert_raises(KeyError) do
+        ResponsesProbe.allocate.parse(payload, TextModel, {"known" => ToolModel})
+      end
+
+      assert_equal(key, error.key)
+    end
+  end
+
+  def test_empty_outputs_and_private_delegate_visibility_are_preserved
+    [{}, {output: nil}, {output: []}].each do |raw|
+      assert_same(raw, ResponsesProbe.allocate.parse(raw, nil, {}))
+    end
+
+    assert_includes(OpenAI::Resources::Responses.private_instance_methods, :get_structured_output_models)
+    assert_includes(OpenAI::Resources::Responses.private_instance_methods, :parse_structured_outputs!)
+    refute_includes(OpenAI::Resources::Responses.public_instance_methods, :get_structured_output_models)
+    refute_includes(OpenAI::Resources::Responses.public_instance_methods, :parse_structured_outputs!)
+  end
+end

--- a/test/scripts/formatting_policy_test.rb
+++ b/test/scripts/formatting_policy_test.rb
@@ -111,6 +111,7 @@ class FormattingPolicyTest < Minitest::Test
   def test_pattern_workarounds_format_as_valid_idempotent_ruby
     %w[
       lib/openai/resources/responses.rb
+      lib/openai/helpers/structured_output/response_parser.rb
       test/openai/internal/type/base_model_test.rb
       rbi/openai/internal/type/base_model.rbi
     ]


### PR DESCRIPTION
## Summary

Move the Responses resource's two private structured-output methods into
`OpenAI::Helpers::StructuredOutput::ResponseParser`, with private RBI/RBS
declarations. Keep the original private methods as thin delegates so existing
request/streaming call sites and subclass behavior remain intact.

Both implementation bodies are token-identical to the original. This preserves
in-place mutation, accepted request shapes, tool names, JSON/coercion behavior,
existing exceptions, and current edge cases. Public methods and their RBI/RBS
signatures, the shared converter, request semantics, streaming, dependencies,
and generation/API-reference metadata are unchanged.

The verified report remains at **50 mixed files**, while custom-patch lines
drop **2,892 → 2,751**. The Responses resource changes from +305/−4 to +164/−4;
the other 49 customizations are unchanged.

## Tests and covered cases

New `OpenAI::Test::ResponseParserTest` in
`test/openai/helpers/response_parser_test.rb` passes against both the original
and extracted implementation: **6 tests, 71 assertions**.

- `test_all_text_forms_prepare_tools_and_preserve_nested_objects`: direct,
  nested, and schema-nested text formats; simultaneous tool conversion; names,
  strictness, and object identity.
- `test_nested_tool_names_and_flat_tool_behavior_are_preserved`: inferred and
  explicit names, nested hash identity, and the existing flat-tool branch.
- `test_flat_converter_without_function_preserves_key_error`: the existing
  `KeyError` contract is retained.
- `test_parse_updates_known_outputs_in_place_and_leaves_other_types_alone`:
  text/tool coercion, raw-object identity, unknown tools, refusals, and
  string-versus-symbol discriminator behavior.
- `test_parse_preserves_malformed_json_and_missing_key_errors`: parser-error
  values and missing text/name/arguments keys.
- `test_empty_outputs_and_private_delegate_visibility_are_preserved`: absent,
  nil, and empty outputs, plus the original private method visibility.

`FormattingPolicyTest#test_pattern_workarounds_format_as_valid_idempotent_ruby`
keeps every existing assertion and path and adds the relocated helper. This
continues to cover the rubyfmt 0.14.1 pattern-matching workaround. No handwritten
tests are removed.

## Validation

- Focused parser, existing tool-model/API-name, Responses streaming, and
  formatter suites: **54 tests, 450 assertions**.
- Ruby 4.0.6 / pinned rubyfmt 0.14.1; formatting and full lint pass.
- Sorbet and all 1,237 RBS files pass.
- Full suite against Steady 0.22.1: **1,093 tests, 9,879 assertions**, no failures
  or skips.
- Bedrock suite: 38 tests, 377 assertions, one live-test skip.
- Gem build and packed parser/signature/load checks pass.
- Exact moved-body comparison, unchanged public-signature/metadata checks, and
  `git diff --check` pass.
