### PR TITLE
refactor: isolate Chat Completions structured-output parsing

### DIFF
--- a/lib/openai/helpers/structured_output/chat_completion_parser.rb
+++ b/lib/openai/helpers/structured_output/chat_completion_parser.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module OpenAI
+  module Helpers
+    module StructuredOutput
+      # Request preparation and response coercion for Chat Completions.
+      #
+      # @api private
+      module ChatCompletionParser
+        # @api private
+        def self.build_unwrap(model, tool_models)
+          # rubocop:disable Metrics/BlockLength
+          -> (raw) do
+            if model.is_a?(OpenAI::StructuredOutput::JsonSchemaConverter)
+              raw[:choices]&.each do |choice|
+                message = choice.fetch(:message)
+                begin
+                  content = message.fetch(:content)
+                  parsed = content.nil? ? nil : JSON.parse(content, symbolize_names: true)
+                rescue JSON::ParserError => e
+                  parsed = e
+                end
+
+                coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
+                message.store(:parsed, coerced)
+              end
+            end
+
+            raw[:choices]&.each do |choice|
+              choice.dig(:message, :tool_calls)&.each do |tool_call|
+                func = tool_call.fetch(:function)
+                next if (model = tool_models[func.fetch(:name)]).nil?
+
+                begin
+                  arguments = func.fetch(:arguments)
+                  parsed = arguments.nil? ? nil : JSON.parse(arguments, symbolize_names: true)
+                rescue JSON::ParserError => e
+                  parsed = e
+                end
+
+                coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
+                func.store(:parsed, coerced)
+              end
+            end
+
+            raw
+          end
+          # rubocop:enable Metrics/BlockLength
+        end
+
+        # @api private
+        def self.get_models(parsed)
+          model = nil
+          tool_models = {}
+          case parsed
+          in {response_format: OpenAI::StructuredOutput::JsonSchemaConverter => model}
+            parsed.update(
+              response_format: {
+                type: :json_schema,
+                json_schema: {
+                  strict: true,
+                  name: model.name.split("::").last,
+                  schema: model.to_json_schema
+                }
+              }
+            )
+          in {
+              response_format: {type: :json_schema, json_schema: OpenAI::StructuredOutput::JsonSchemaConverter => model}
+            }
+            parsed.fetch(:response_format).update(
+              json_schema: {
+                strict: true,
+                name: model.name.split("::").last,
+                schema: model.to_json_schema
+              }
+            )
+          in {
+              response_format: {
+                  type: :json_schema,
+                  json_schema: {schema: OpenAI::StructuredOutput::JsonSchemaConverter => model}
+                }
+            }
+            parsed.dig(:response_format, :json_schema).store(:schema, model.to_json_schema)
+          in {tools: Array => tools}
+            mapped = tools.map do |tool|
+              case tool
+              in OpenAI::StructuredOutput::JsonSchemaConverter
+                name = tool.name.split("::").last
+                tool_models.store(name, tool)
+                {
+                  type: :function,
+                  function: {
+                    strict: true,
+                    name: name,
+                    parameters: tool.to_json_schema
+                  }
+                }
+              in {function: {parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}}
+                func = tool.fetch(:function)
+                name = func[:name] ||= params.name.split("::").last
+                tool_models.store(name, params)
+                func.update(parameters: params.to_json_schema)
+                tool
+              else
+                tool
+              end
+            end
+
+            tools.replace(mapped)
+          else
+          end
+
+          [model, tool_models]
+        end
+
+        # @api private
+        def self.build_tools(tools, tool_models)
+          return [] if tools.nil?
+
+          tools.map do |tool|
+            next tool unless tool[:type] == :function
+
+            function_name = tool.dig(:function, :name)
+            model = tool_models[function_name]
+
+            model ? tool.merge(model: model) : tool
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openai/resources/chat/completions.rb
+++ b/lib/openai/resources/chat/completions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../helpers/structured_output/chat_completion_parser"
+
 module OpenAI
   module Resources
     class Chat
@@ -125,43 +127,7 @@ module OpenAI
 
           model, tool_models = get_structured_output_models(parsed)
 
-          # rubocop:disable Metrics/BlockLength
-          unwrap = -> (raw) do
-            if model.is_a?(OpenAI::StructuredOutput::JsonSchemaConverter)
-              raw[:choices]&.each do |choice|
-                message = choice.fetch(:message)
-                begin
-                  content = message.fetch(:content)
-                  parsed = content.nil? ? nil : JSON.parse(content, symbolize_names: true)
-                rescue JSON::ParserError => e
-                  parsed = e
-                end
-
-                coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
-                message.store(:parsed, coerced)
-              end
-            end
-
-            raw[:choices]&.each do |choice|
-              choice.dig(:message, :tool_calls)&.each do |tool_call|
-                func = tool_call.fetch(:function)
-                next if (model = tool_models[func.fetch(:name)]).nil?
-
-                begin
-                  arguments = func.fetch(:arguments)
-                  parsed = arguments.nil? ? nil : JSON.parse(arguments, symbolize_names: true)
-                rescue JSON::ParserError => e
-                  parsed = e
-                end
-
-                coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
-                func.store(:parsed, coerced)
-              end
-            end
-
-            raw
-          end
-          # rubocop:enable Metrics/BlockLength
+          unwrap = OpenAI::Helpers::StructuredOutput::ChatCompletionParser.build_unwrap(model, tool_models)
 
           @client.request(
             method: :post,
@@ -175,80 +141,11 @@ module OpenAI
         end
 
         def get_structured_output_models(parsed)
-          model = nil
-          tool_models = {}
-          case parsed
-          in {response_format: OpenAI::StructuredOutput::JsonSchemaConverter => model}
-            parsed.update(
-              response_format: {
-                type: :json_schema,
-                json_schema: {
-                  strict: true,
-                  name: model.name.split("::").last,
-                  schema: model.to_json_schema
-                }
-              }
-            )
-          in {
-              response_format: {type: :json_schema, json_schema: OpenAI::StructuredOutput::JsonSchemaConverter => model}
-            }
-            parsed.fetch(:response_format).update(
-              json_schema: {
-                strict: true,
-                name: model.name.split("::").last,
-                schema: model.to_json_schema
-              }
-            )
-          in {
-              response_format: {
-                  type: :json_schema,
-                  json_schema: {schema: OpenAI::StructuredOutput::JsonSchemaConverter => model}
-                }
-            }
-            parsed.dig(:response_format, :json_schema).store(:schema, model.to_json_schema)
-          in {tools: Array => tools}
-            mapped = tools.map do |tool|
-              case tool
-              in OpenAI::StructuredOutput::JsonSchemaConverter
-                name = tool.name.split("::").last
-                tool_models.store(name, tool)
-                {
-                  type: :function,
-                  function: {
-                    strict: true,
-                    name: name,
-                    parameters: tool.to_json_schema
-                  }
-                }
-              in {function: {parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}}
-                func = tool.fetch(:function)
-                name = func[:name] ||= params.name.split("::").last
-                tool_models.store(name, params)
-                func.update(parameters: params.to_json_schema)
-                tool
-              else
-                tool
-              end
-            end
-
-            tools.replace(mapped)
-          else
-          end
-
-          [model, tool_models]
+          OpenAI::Helpers::StructuredOutput::ChatCompletionParser.get_models(parsed)
         end
 
         def build_tools_with_models(tools, tool_models)
-          return [] if tools.nil?
-
-          tools.map do |tool|
-            next tool unless tool[:type] == :function
-
-            function_name = tool.dig(:function, :name)
-            model = tool_models[function_name]
-
-            model ? tool.merge(model: model) : tool
-          end
+          OpenAI::Helpers::StructuredOutput::ChatCompletionParser.build_tools(tools, tool_models)
         end
 
         def stream(params)

--- a/rbi/openai/helpers/structured_output/chat_completion_parser.rbi
+++ b/rbi/openai/helpers/structured_output/chat_completion_parser.rbi
@@ -1,0 +1,42 @@
+# typed: strong
+
+module OpenAI
+  module Helpers
+    module StructuredOutput
+      # @api private
+      module ChatCompletionParser
+        sig do
+          params(
+            model: T.nilable(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input),
+            tool_models: T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+          )
+            .returns(T.proc.params(raw: OpenAI::Internal::AnyHash).returns(OpenAI::Internal::AnyHash))
+        end
+        def self.build_unwrap(model, tool_models)
+        end
+
+        sig do
+          params(parsed: OpenAI::Internal::AnyHash)
+            .returns(
+              [
+                T.nilable(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input),
+                T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+              ]
+            )
+        end
+        def self.get_models(parsed)
+        end
+
+        sig do
+          params(
+            tools: T.nilable(T::Array[OpenAI::Internal::AnyHash]),
+            tool_models: T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+          )
+            .returns(T::Array[OpenAI::Internal::AnyHash])
+        end
+        def self.build_tools(tools, tool_models)
+        end
+      end
+    end
+  end
+end

--- a/sig/openai/helpers/structured_output/chat_completion_parser.rbs
+++ b/sig/openai/helpers/structured_output/chat_completion_parser.rbs
@@ -1,0 +1,21 @@
+module OpenAI
+  module Helpers
+    module StructuredOutput
+      module ChatCompletionParser
+        def self.build_unwrap: (
+          top model,
+          ::Hash[String, top] tool_models
+        ) -> (^(::Hash[Symbol, top]) -> ::Hash[Symbol, top])
+
+        def self.get_models: (
+          ::Hash[Symbol, top] parsed
+        ) -> [top, ::Hash[String, top]]
+
+        def self.build_tools: (
+          ::Array[::Hash[Symbol, top]]? tools,
+          ::Hash[String, top] tool_models
+        ) -> ::Array[::Hash[Symbol, top]]
+      end
+    end
+  end
+end

--- a/test/openai/helpers/chat_completion_parser_test.rb
+++ b/test/openai/helpers/chat_completion_parser_test.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
+  class TextModel < OpenAI::BaseModel
+    required :value, String
+  end
+
+  class ToolModel < OpenAI::BaseModel
+    required :argument, Integer
+  end
+
+  class CaptureClient
+    def request(**options) = options
+  end
+
+  class CombinedModels < OpenAI::Resources::Chat::Completions
+    def get_structured_output_models(_parsed) = [TextModel, {"known" => ToolModel}]
+  end
+
+  def test_response_format_forms_keep_their_precedence_over_tools
+    forms = [
+      {response_format: TextModel},
+      {response_format: {type: :json_schema, json_schema: TextModel}},
+      {
+        response_format: {
+          type: :json_schema,
+          json_schema: {name: "explicit", strict: false, schema: TextModel}
+        }
+      }
+    ]
+    resource = OpenAI::Resources::Chat::Completions.allocate
+
+    forms.each do |params|
+      tools = [ToolModel]
+      params[:tools] = tools
+      original = params[:response_format]
+      original_schema = original[:json_schema] if original.is_a?(Hash)
+
+      model, tool_models = resource.get_structured_output_models(params)
+
+      assert_same(TextModel, model)
+      assert_empty(tool_models)
+      assert_same(tools, params[:tools])
+      assert_same(ToolModel, tools.first)
+      schema = params.fetch(:response_format).fetch(:json_schema)
+      assert_equal(TextModel.to_json_schema, schema[:schema])
+      assert_same(original, params[:response_format]) if original.is_a?(Hash)
+      if original_schema.is_a?(Hash)
+        assert_same(original_schema, schema)
+        assert_equal("explicit", schema[:name])
+        assert_equal(false, schema[:strict])
+      else
+        assert_equal("TextModel", schema[:name])
+        assert_equal(true, schema[:strict])
+      end
+    end
+  end
+
+  def test_tool_conversion_preserves_names_and_input_identity
+    [nil, "explicit"].each do |name|
+      function = {parameters: ToolModel}
+      function[:name] = name unless name.nil?
+      nested = {type: :function, function: function}
+      untouched = {type: :custom, custom: {name: "other"}}
+      tools = [ToolModel, nested, untouched]
+
+      model, tool_models = OpenAI::Resources::Chat::Completions
+        .allocate
+        .get_structured_output_models(tools: tools)
+
+      assert_nil(model)
+      assert_equal(
+        {"ToolModel" => ToolModel, (name || "ToolModel") => ToolModel},
+        tool_models
+      )
+      assert_equal(
+        {
+          type: :function,
+          function: {strict: true, name: "ToolModel", parameters: ToolModel.to_json_schema}
+        },
+        tools.first
+      )
+      assert_same(nested, tools[1])
+      assert_same(function, nested[:function])
+      assert_equal(name || "ToolModel", function[:name])
+      assert_equal(ToolModel.to_json_schema, function[:parameters])
+      assert_same(untouched, tools.last)
+    end
+  end
+
+  def test_build_tools_only_copies_matching_symbol_function_tools
+    resource = OpenAI::Resources::Chat::Completions.allocate
+    known = {type: :function, function: {name: "known"}}
+    unknown = {type: :function, function: {name: "unknown"}}
+    string_type = {type: "function", function: {name: "known"}}
+    other = {type: :custom}
+    tools = [known, unknown, string_type, other]
+
+    assert_empty(resource.build_tools_with_models(nil, {}))
+    mapped = resource.build_tools_with_models(tools, {"known" => ToolModel})
+
+    refute_same(tools, mapped)
+    refute_same(known, mapped.first)
+    assert_equal(known.merge(model: ToolModel), mapped.first)
+    refute(known.key?(:model))
+    [unknown, string_type, other].each_with_index do |tool, index|
+      assert_same(tool, mapped[index + 1])
+    end
+  end
+
+  def test_create_preserves_request_shape_and_unwrap_contract
+    request = OpenAI::Resources::Chat::Completions.new(client: CaptureClient.new).create(
+      messages: [{role: :user, content: "test"}],
+      model: "gpt-4o-mini",
+      response_format: TextModel,
+      request_options: {extra_headers: {"X-Test" => "yes"}}
+    )
+    unwrap = request.fetch(:unwrap)
+    message = {content: "{\"value\":\"hello\"}"}
+    raw = {choices: [{message: message}]}
+
+    assert_equal(:post, request[:method])
+    assert_equal("chat/completions", request[:path])
+    assert_equal(OpenAI::Chat::ChatCompletion, request[:model])
+    assert_equal({bearer_auth: true}, request[:security])
+    assert_equal({"X-Test" => "yes"}, request.dig(:options, :extra_headers))
+    assert_equal(TextModel.to_json_schema, request.dig(:body, :response_format, :json_schema, :schema))
+    assert_predicate(unwrap, :lambda?)
+    assert_equal(1, unwrap.arity)
+    assert_same(raw, unwrap.call(raw))
+    assert_instance_of(TextModel, message[:parsed])
+    assert_equal("hello", message[:parsed].value)
+  end
+
+  def test_reused_unwrap_retains_its_captured_model_state
+    unwrap = combined_unwrap
+    function = {name: "known", arguments: "{\"argument\":7}"}
+    first_message = {content: "{\"value\":\"first\"}", tool_calls: [{function: function}]}
+    first = {choices: [{message: first_message}]}
+
+    assert_same(first, unwrap.call(first))
+    assert_instance_of(TextModel, first_message[:parsed])
+    assert_instance_of(ToolModel, function[:parsed])
+    assert_equal(7, function[:parsed].argument)
+
+    second_message = {
+      content: "{\"argument\":8}",
+      tool_calls: [{function: {name: "unknown", arguments: "invalid"}}]
+    }
+    unwrap.call(choices: [{message: second_message}])
+    assert_instance_of(ToolModel, second_message[:parsed])
+    assert_equal(8, second_message[:parsed].argument)
+
+    third_message = {content: "not json"}
+    unwrap.call(choices: [{message: third_message}])
+    refute(third_message.key?(:parsed))
+  end
+
+  def test_unwrap_preserves_nil_malformed_json_and_missing_key_behavior
+    [nil, "not json"].each do |value|
+      function = {name: "known", arguments: value}
+      message = {content: value, tool_calls: [{function: function}]}
+      raw = {choices: [{message: message}]}
+
+      assert_same(raw, combined_unwrap.call(raw))
+      if value.nil?
+        assert_nil(message[:parsed])
+        assert_nil(function[:parsed])
+      else
+        assert_instance_of(JSON::ParserError, message[:parsed])
+        assert_instance_of(JSON::ParserError, function[:parsed])
+      end
+    end
+
+    [
+      [{choices: [{}]}, :message],
+      [{choices: [{message: {}}]}, :content],
+      [{choices: [{message: {content: nil, tool_calls: [{}]}}]}, :function],
+      [{choices: [{message: {content: nil, tool_calls: [{function: {}}]}}]}, :name],
+      [
+        {choices: [{message: {content: nil, tool_calls: [{function: {name: "known"}}]}}]},
+        :arguments
+      ]
+    ].each do |raw, key|
+      error = assert_raises(KeyError) { combined_unwrap.call(raw) }
+      assert_equal(key, error.key)
+    end
+  end
+
+  def test_existing_resource_helper_parameters_and_visibility_are_unchanged
+    resource = OpenAI::Resources::Chat::Completions
+
+    assert_includes(resource.public_instance_methods, :get_structured_output_models)
+    assert_includes(resource.public_instance_methods, :build_tools_with_models)
+    assert_equal([[:req, :parsed]], resource.instance_method(:get_structured_output_models).parameters)
+    assert_equal(
+      [[:req, :tools], [:req, :tool_models]],
+      resource.instance_method(:build_tools_with_models).parameters
+    )
+  end
+
+  private def combined_unwrap
+    CombinedModels
+      .new(client: CaptureClient.new)
+      .create(
+        messages: [{role: :user, content: "test"}],
+        model: "gpt-4o-mini"
+      )
+      .fetch(:unwrap)
+  end
+end


### PR DESCRIPTION
## Summary

Move Chat Completions structured-output preparation, tool-model decoration, and
the response-unwrapping callback into the SDK-owned
`OpenAI::Helpers::StructuredOutput::ChatCompletionParser`, with private RBI/RBS
declarations.

The existing public `get_structured_output_models` and
`build_tools_with_models` methods remain at the same visibility and with the
same parameters. The callback remains a stateful lambda; its captured-model
behavior is intentionally preserved. Both moved methods and the lambda are
token-identical to the original. Public request/streaming methods, signatures,
shared converters, dependencies, and generation/API-reference metadata are
unchanged.

The verified report remains at **50 mixed files**, while custom-patch lines
drop **2,809 → 2,706** against current public main. The Chat Completions resource
changes from +145 to +42 lines; the other 49 customizations are unchanged.

## Tests and covered cases

New `OpenAI::Test::ChatCompletionParserTest` in
`test/openai/helpers/chat_completion_parser_test.rb` passes against the original
and extracted implementation: **7 tests, 93 assertions**.

- `test_response_format_forms_keep_their_precedence_over_tools`: all three
  response-format forms, existing branch precedence, names/strictness, and
  nested object identity.
- `test_tool_conversion_preserves_names_and_input_identity`: direct and nested
  tool models, inferred/explicit names, and untouched tools.
- `test_build_tools_only_copies_matching_symbol_function_tools`: nil tools,
  matching functions, unknown names, string discriminators, and copy identity.
- `test_create_preserves_request_shape_and_unwrap_contract`: method/path/body,
  security/options/model, lambda arity, raw identity, and typed parsed content.
- `test_reused_unwrap_retains_its_captured_model_state`: repeated callback use,
  known and unknown tools, and the original model-state transitions.
- `test_unwrap_preserves_nil_malformed_json_and_missing_key_behavior`: nil and
  malformed JSON plus missing message/content/function/name/arguments keys.
- `test_existing_resource_helper_parameters_and_visibility_are_unchanged`:
  both existing public helper contracts.

No existing tests are removed or modified.

## Validation

- Focused structured-output suites: **27 tests, 205 assertions**.
- Ruby 4.0.6 / rubyfmt 0.14.1; formatting, 2,720-file RuboCop, Sorbet, and
  1,238 RBS files pass.
- Full suite against Steady 0.22.1 on current public main: **1,098 tests,
  9,985 assertions**, no failures or skips.
- Bedrock suite and gem build pass; packed helper/signature/load check passes.
- Exact moved-body/lambda comparison, unchanged public-signature/metadata
  checks, and `git diff --check` pass.
