### PR TITLE
chore: restore generated webhook signature comments

### DIFF
--- a/rbi/openai/resources/webhooks.rbi
+++ b/rbi/openai/resources/webhooks.rbi
@@ -36,9 +36,9 @@ module OpenAI
       def unwrap(
         # The raw webhook payload as a string
         payload,
-        # The webhook headers
+        # The raw HTTP headers that came with the payload
         headers = {},
-        # The webhook secret (optional, will use ENV["OPENAI_WEBHOOK_SECRET"] if not provided)
+        # The webhook signing key
         webhook_secret = nil
       )
       end
@@ -54,13 +54,13 @@ module OpenAI
           .void
       }
       def verify_signature(
-        # The webhook payload as a string
+        # The raw webhook payload as a string
         payload,
-        # The webhook headers
+        # The raw HTTP headers that came with the payload
         headers,
-        # The webhook secret (optional, will use ENV["OPENAI_WEBHOOK_SECRET"] if not provided)
+        # The webhook signing key
         webhook_secret = nil,
-        # Maximum age of the webhook in seconds (default: 300 = 5 minutes)
+        # Maximum age of the webhook in seconds
         tolerance = 300
       )
       end


### PR DESCRIPTION
## Summary

Restore the six generated parameter comments in
`rbi/openai/resources/webhooks.rbi`. The file is now byte-identical to the
verified public generated snapshot.

This is comments-only: all Ruby/Sorbet tokens, parameter defaults, types,
visibility, and return types are unchanged. Runtime code, RBS, tests,
dependencies, and generation/API-reference metadata are untouched.

The verified custom-code report drops **50 → 49 mixed files** and
**2,809 → 2,797 custom-patch lines**. The other 49 customizations are unchanged.

## Validation

- Exact baseline-file comparison and normalized Ruby-token comparison pass.
- Ruby 4.0.6 / pinned rubyfmt 0.14.1; `./scripts/format` and full lint pass.
- Sorbet and all 1,237 RBS files pass.
- Existing webhook suite: **19 tests, 45 assertions**. No tests are replaced,
  moved, or deleted by this PR; #494 separately preserves the full suite in an
  SDK-owned file.
- Full suite against Steady 0.22.1: **1,091 tests, 9,892 assertions**, no failures
  or skips.
- Gem build, unchanged-runtime/metadata checks, and `git diff --check` pass.
