### PR TITLE
examples: validate E2E manifest mappings

### DIFF
--- a/scripts/examples-e2e.rb
+++ b/scripts/examples-e2e.rb
@@ -174,14 +174,31 @@ module OpenAIExamplesE2E
     private
 
     def document
-      @document ||= YAML.safe_load_file(manifest_path, aliases: false)
+      @document ||= YAML.safe_load_file(manifest_path, aliases: false).tap do |value|
+        unless value.is_a?(Hash)
+          raise ConfigurationError, "#{manifest_path}: manifest root must be a mapping"
+        end
+      end
+
     rescue Errno::ENOENT
       raise ConfigurationError, "example E2E manifest not found: #{manifest_path}"
     end
 
     def configured_examples
       value = document["examples"]
-      raise ConfigurationError, "manifest examples must be a mapping" unless value.is_a?(Hash)
+      unless value.is_a?(Hash)
+        raise ConfigurationError, "#{manifest_path}: manifest examples must be a mapping"
+      end
+
+      value.each do |path, configuration|
+        next if configuration.is_a?(Hash)
+
+        raise(
+          ConfigurationError,
+          "#{manifest_path}: #{path}: example configuration must be a mapping"
+        )
+      end
+
       value
     end
 

--- a/test/scripts/examples_e2e_test.rb
+++ b/test/scripts/examples_e2e_test.rb
@@ -11,6 +11,34 @@ require "yaml"
 require_relative "../../scripts/examples-e2e"
 
 class ExamplesE2EInventoryTest < Minitest::Test
+  def test_rejects_non_mapping_manifest_roots
+    [nil, [], "invalid"].each do |document|
+      with_manifest(document) do |inventory, manifest_path|
+        error = assert_raises(OpenAIExamplesE2E::ConfigurationError) { inventory.validate! }
+
+        assert_equal("#{manifest_path}: manifest root must be a mapping", error.message)
+      end
+    end
+  end
+
+  def test_rejects_non_mapping_example_configurations
+    [nil, [], "invalid"].each do |configuration|
+      document = {
+        "version" => 1,
+        "examples" => {"examples/example.rb" => configuration}
+      }
+
+      with_manifest(document) do |inventory, manifest_path|
+        error = assert_raises(OpenAIExamplesE2E::ConfigurationError) { inventory.validate! }
+
+        assert_equal(
+          "#{manifest_path}: examples/example.rb: example configuration must be a mapping",
+          error.message
+        )
+      end
+    end
+  end
+
   def test_rejects_non_string_exclusion_reasons
     [nil, false, 1, []].each do |reason|
       with_inventory(status: "excluded", reason: reason) do |inventory|
@@ -30,6 +58,17 @@ class ExamplesE2EInventoryTest < Minitest::Test
   private
 
   def with_inventory(status:, reason:)
+    document = {
+      "version" => 1,
+      "examples" => {
+        "examples/example.rb" => {"status" => status, "reason" => reason}
+      }
+    }
+
+    with_manifest(document) { |inventory, _manifest_path| yield(inventory) }
+  end
+
+  def with_manifest(document)
     Dir.mktmpdir("openai-examples-e2e-test") do |directory|
       root = Pathname(directory)
       example_path = root.join("examples/example.rb")
@@ -37,16 +76,10 @@ class ExamplesE2EInventoryTest < Minitest::Test
       example_path.write("# frozen_string_literal: true\n")
 
       manifest_path = root.join("examples/e2e.yml")
-      manifest_path.write(
-        YAML.dump(
-          "version" => 1,
-          "examples" => {
-            "examples/example.rb" => {"status" => status, "reason" => reason}
-          }
-        )
-      )
+      manifest_path.write(YAML.dump(document))
 
-      yield(OpenAIExamplesE2E::Inventory.new(root: root, manifest_path: manifest_path))
+      inventory = OpenAIExamplesE2E::Inventory.new(root: root, manifest_path: manifest_path)
+      yield(inventory, manifest_path)
     end
   end
 end


### PR DESCRIPTION
## Summary

- validate that the examples E2E YAML root is a mapping before reading manifest fields
- validate that every per-example configuration is a mapping before constructing inventory entries
- include manifest and example paths in configuration errors

## Evidence

Malformed YAML shapes currently reach hash access and fail with incidental exceptions. The focused tests cover nil, array, and string roots and per-example configurations, and assert stable `ConfigurationError` messages.

## Blast radius and compatibility

This is limited to the handwritten examples E2E inventory script and its dedicated tests. It does not change the public SDK API, generated code, request transport, wire behavior, dependencies, RBI/RBS contracts, or supported Ruby versions. Valid manifests retain existing behavior.

## Generator ownership

Both changed files are handwritten repository tooling and tests; no generator-owned source or output is modified.

## Validation

- `bundle exec rake test TEST=test/scripts/examples_e2e_test.rb` — 17 runs, 199 assertions, 0 failures, 0 errors
- offline examples E2E inventory validation — passes for all 30 classified examples
- `bundle exec rake lint` — 2,728 Ruby files inspected with no offenses; 1,239 RBS files validated; Sorbet, rubyfmt, and directive validation pass
- thermo-nuclear code-quality review — no findings
- `git diff --check` — clean
- full non-Bedrock suite — 1,089 runs, 9,800 assertions, with one unrelated realtime proxy socket error that reproduces in isolation before any assertion

Because this touches manifest deserialization validation, please include `@openai/sdks-team` in review routing.