### PR TITLE
examples: write streamed images in binary mode

### DIFF
--- a/examples/image_stream.rb
+++ b/examples/image_stream.rb
@@ -27,7 +27,7 @@ stream.each do |event|
     # Save partial image to file
     filename = "partial_#{event.partial_image_index + 1}.png"
     image_data = Base64.decode64(event.b64_json)
-    File.write(filename, image_data)
+    File.binwrite(filename, image_data)
     puts("  Saved to: #{File.expand_path(filename)}")
 
   when OpenAI::Models::ImageGenCompletedEvent
@@ -40,7 +40,7 @@ stream.each do |event|
 
     # Save final image to file
     filename = "final_image.png"
-    File.write(filename, image_data)
+    File.binwrite(filename, image_data)
     puts("  Saved to: #{File.expand_path(filename)}")
   end
 end

--- a/test/openai/image_stream_example_test.rb
+++ b/test/openai/image_stream_example_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "bundler"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+require_relative "test_helper"
+
+class OpenAI::Test::ImageStreamExampleTest < Minitest::Test
+  PNG_FIXTURE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+  PNG_BYTES = PNG_FIXTURE.unpack1("m0")
+  STUBBED_EXAMPLE_RUNNER = <<~'RUBY'
+    require ENV.fetch("OPENAI_LIBRARY")
+    require "minitest/mock"
+
+    StubImages = Data.define(:stream) do
+      def generate_stream_raw(**) = stream
+    end
+    StubClient = Data.define(:images)
+
+    encoded = ENV.fetch("OPENAI_IMAGE_FIXTURE")
+    events = [
+      OpenAI::Models::ImageGenPartialImageEvent.new(b64_json: encoded, partial_image_index: 0),
+      OpenAI::Models::ImageGenCompletedEvent.new(b64_json: encoded)
+    ]
+    client = StubClient.new(images: StubImages.new(stream: events.each))
+    text_writer = -> (*) { raise "image data was written in text mode" }
+
+    File.stub(:write, text_writer) do
+      OpenAI::Client.stub(:new, client) do
+        load(ENV.fetch("OPENAI_IMAGE_STREAM_EXAMPLE"))
+      end
+    end
+  RUBY
+
+  def test_example_preserves_decoded_png_bytes
+    Dir.mktmpdir("openai-image-stream-example") do |directory|
+      environment = {
+        "OPENAI_API_KEY" => nil,
+        "OPENAI_IMAGE_FIXTURE" => PNG_FIXTURE,
+        "OPENAI_IMAGE_STREAM_EXAMPLE" => File.expand_path("../../examples/image_stream.rb", __dir__),
+        "OPENAI_LIBRARY" => File.expand_path("../../lib/openai.rb", __dir__)
+      }
+      stdout, stderr, status = Bundler.with_unbundled_env do
+        Open3.capture3(
+          environment,
+          RbConfig.ruby,
+          "-e",
+          STUBBED_EXAMPLE_RUNNER,
+          chdir: directory
+        )
+      end
+
+      assert(status.success?, stderr)
+      assert_empty(stderr)
+      assert_includes(stdout, "Image streaming completed!")
+      assert_equal(PNG_BYTES, File.binread(File.join(directory, "partial_1.png")))
+      assert_equal(PNG_BYTES, File.binread(File.join(directory, "final_image.png")))
+    end
+
+    assert_includes(PNG_BYTES, "\r\n".b)
+    assert_includes(PNG_BYTES, "\x1A\n".b)
+  end
+end

--- a/test/openai/image_stream_example_test.rb
+++ b/test/openai/image_stream_example_test.rb
@@ -36,21 +36,21 @@ class OpenAI::Test::ImageStreamExampleTest < Minitest::Test
 
   def test_example_preserves_decoded_png_bytes
     Dir.mktmpdir("openai-image-stream-example") do |directory|
-      environment = {
+      environment = Bundler.unbundled_env.merge(
         "OPENAI_API_KEY" => nil,
         "OPENAI_IMAGE_FIXTURE" => PNG_FIXTURE,
         "OPENAI_IMAGE_STREAM_EXAMPLE" => File.expand_path("../../examples/image_stream.rb", __dir__),
-        "OPENAI_LIBRARY" => File.expand_path("../../lib/openai.rb", __dir__)
-      }
-      stdout, stderr, status = Bundler.with_unbundled_env do
-        Open3.capture3(
-          environment,
-          RbConfig.ruby,
-          "-e",
-          STUBBED_EXAMPLE_RUNNER,
-          chdir: directory
-        )
-      end
+        "OPENAI_LIBRARY" => File.expand_path("../../lib/openai.rb", __dir__),
+        "RUBYLIB" => $LOAD_PATH.join(File::PATH_SEPARATOR)
+      )
+      stdout, stderr, status = Open3.capture3(
+        environment,
+        RbConfig.ruby,
+        "-e",
+        STUBBED_EXAMPLE_RUNNER,
+        chdir: directory,
+        unsetenv_others: true
+      )
 
       assert(status.success?, stderr)
       assert_empty(stderr)


### PR DESCRIPTION
## Summary

- write decoded partial and completed image data with `File.binwrite`
- add an offline regression test that executes the real image streaming example and verifies exact PNG bytes

## Evidence

The example decodes base64 PNG data and previously passed the resulting binary string to `File.write`. Text-mode writes can translate byte sequences on platforms with text/binary distinctions. The fixture includes CRLF and control-byte sequences and verifies both generated files byte-for-byte.

## Blast radius and compatibility

This changes only the handwritten image streaming example and its focused test. It does not change the SDK runtime, generated code, public API, type signatures, dependencies, serialization, transport, or authentication behavior.

## Generator ownership

`examples/` and this test are handwritten repository artifacts and are not generator-owned.

## Validation

- `bundle exec ruby -Itest test/openai/image_stream_example_test.rb` — 1 run, 11 assertions, passed
- `bundle exec rake test:examples:inventory` — passed
- `bundle exec rake lint` — RuboCop, rubyfmt, RBI, and RBS validation passed
- `./scripts/test` with a private `TMPDIR` — 1,088 runs, 9,799 assertions, 0 failures, 1 unrelated local error in the unchanged realtime HTTP proxy invariant
- isolated formatting-policy and RBS-script tests — 22 runs, 275 assertions, passed
- `git diff --check` — passed
- thermo-nuclear code-quality review — no findings