### PR TITLE
test: harden mock server lifecycle checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,8 @@ $ bundle exec rake
 ## Running tests
 
 Most tests require you to [set up a mock server](https://github.com/dgellow/steady) against the OpenAPI spec to run the tests.
+Install `lsof` and ensure it is available on `PATH`; the daemon launcher uses it
+to verify that the mock process group owns its listening socket before tests run.
 
 ```sh
 $ ./scripts/mock

--- a/scripts/mock
+++ b/scripts/mock
@@ -70,6 +70,12 @@ mock_process_is_running() {
   return 1
 }
 
+mock_owns_listener() {
+  local expected_process_group="$1"
+
+  lsof -nP -a -g "$expected_process_group" -iTCP@127.0.0.1:4010 -sTCP:LISTEN >/dev/null 2>&1
+}
+
 # Run steady mock on the given spec
 if [ "$1" == "--daemon" ]; then
   # Pre-install the package so the download doesn't eat into the startup timeout
@@ -93,13 +99,15 @@ if [ "$1" == "--daemon" ]; then
   attempts=0
   while true; do
     if curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1; then
-      # A concurrent launcher may own the healthy endpoint. Accept readiness
-      # only while the process group created by this invocation is still live.
-      if mock_process_is_running "$mock_pid"; then
+      # A concurrent launcher may own the healthy endpoint while this
+      # invocation is still alive but failing to bind. Require the listener
+      # itself to belong to the process group created by this invocation.
+      if mock_process_is_running "$mock_pid" && mock_owns_listener "$mock_pid"; then
         break
       fi
 
       echo
+      echo "Mock process group $mock_pid does not own the healthy listener on 127.0.0.1:4010"
       cat .stdy.log
       exit 1
     fi

--- a/scripts/mock
+++ b/scripts/mock
@@ -29,20 +29,44 @@ fi
 
 echo "==> Starting mock server with URL ${URL}"
 
+stop_mock_process_group() {
+  local pid="$1"
+
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then
+    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  fi
+}
+
+clear_mock_pid_file() {
+  if [ -n "${STEADY_PID_FILE:-}" ]; then
+    rm -f "$STEADY_PID_FILE"
+  fi
+}
+
 # Run steady mock on the given spec
 if [ "$1" == "--daemon" ]; then
   # Pre-install the package so the download doesn't eat into the startup timeout
   npm exec --package=@stdy/cli@0.22.1 -- steady --version
 
-  npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL" &> .stdy.log &
+  mock_pid=$(ruby -e '
+    log = File.open(".stdy.log", "w")
+    pid = Process.spawn(*ARGV, pgroup: true, out: log, err: [:child, :out])
+    puts(pid)
+  ' npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL")
+
+  if [ -n "${STEADY_PID_FILE:-}" ]; then
+    printf '%s\n' "$mock_pid" > "$STEADY_PID_FILE"
+  fi
 
   # Wait for server to come online via health endpoint (max 30s)
   echo -n "Waiting for server"
   attempts=0
   while ! curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1; do
-    if ! kill -0 $! 2>/dev/null; then
+    if ! kill -0 "$mock_pid" 2>/dev/null; then
       echo
       cat .stdy.log
+      stop_mock_process_group "$mock_pid"
+      clear_mock_pid_file
       exit 1
     fi
     attempts=$((attempts + 1))
@@ -50,6 +74,8 @@ if [ "$1" == "--daemon" ]; then
       echo
       echo "Timed out waiting for Steady server to start"
       cat .stdy.log
+      stop_mock_process_group "$mock_pid"
+      clear_mock_pid_file
       exit 1
     fi
     echo -n "."

--- a/scripts/mock
+++ b/scripts/mock
@@ -76,8 +76,17 @@ mock_owns_listener() {
   lsof -nP -a -g "$expected_process_group" -iTCP@127.0.0.1:4010 -sTCP:LISTEN >/dev/null 2>&1
 }
 
+require_lsof() {
+  if ! command -v lsof >/dev/null 2>&1 || ! lsof -v >/dev/null 2>&1; then
+    echo "Error: lsof is required for --daemon mock startup; install it and ensure it is available on PATH" >&2
+    return 1
+  fi
+}
+
 # Run steady mock on the given spec
 if [ "$1" == "--daemon" ]; then
+  require_lsof
+
   # Pre-install the package so the download doesn't eat into the startup timeout
   npm exec --package=@stdy/cli@0.22.1 -- steady --version
 

--- a/scripts/mock
+++ b/scripts/mock
@@ -43,6 +43,20 @@ clear_mock_pid_file() {
   fi
 }
 
+cleanup_mock_process() {
+  trap - EXIT INT TERM
+  stop_mock_process_group "$mock_pid"
+  wait "$mock_pid" 2>/dev/null || true
+  clear_mock_pid_file
+}
+
+cleanup_mock_on_exit() {
+  local status="$?"
+
+  cleanup_mock_process
+  exit "$status"
+}
+
 mock_process_is_running() {
   local expected_pid="$1"
   local running_pid
@@ -64,6 +78,12 @@ if [ "$1" == "--daemon" ]; then
   ruby -e 'Process.setpgrp; exec(*ARGV)' npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL" &> .stdy.log &
   mock_pid=$!
 
+  # Until readiness is confirmed, every exit path owns cleanup. Once the
+  # daemon is ready, scripts/test assumes ownership through STEADY_PID_FILE.
+  trap cleanup_mock_on_exit EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
   if [ -n "${STEADY_PID_FILE:-}" ]; then
     printf '%s\n' "$mock_pid" > "$STEADY_PID_FILE"
   fi
@@ -71,13 +91,23 @@ if [ "$1" == "--daemon" ]; then
   # Wait for server to come online via health endpoint (max 30s)
   echo -n "Waiting for server"
   attempts=0
-  while ! curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1; do
+  while true; do
+    if curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1; then
+      # A concurrent launcher may own the healthy endpoint. Accept readiness
+      # only while the process group created by this invocation is still live.
+      if mock_process_is_running "$mock_pid"; then
+        break
+      fi
+
+      echo
+      cat .stdy.log
+      exit 1
+    fi
+
     if ! mock_process_is_running "$mock_pid"; then
       wait "$mock_pid" 2>/dev/null || true
       echo
       cat .stdy.log
-      stop_mock_process_group "$mock_pid"
-      clear_mock_pid_file
       exit 1
     fi
     attempts=$((attempts + 1))
@@ -85,14 +115,13 @@ if [ "$1" == "--daemon" ]; then
       echo
       echo "Timed out waiting for Steady server to start"
       cat .stdy.log
-      stop_mock_process_group "$mock_pid"
-      clear_mock_pid_file
       exit 1
     fi
     echo -n "."
     sleep 0.1
   done
 
+  trap - EXIT INT TERM
   echo
 else
   npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL"

--- a/scripts/mock
+++ b/scripts/mock
@@ -43,16 +43,26 @@ clear_mock_pid_file() {
   fi
 }
 
+mock_process_is_running() {
+  local expected_pid="$1"
+  local running_pid
+
+  while IFS= read -r running_pid; do
+    if [ "$running_pid" = "$expected_pid" ]; then
+      return 0
+    fi
+  done < <(jobs -pr)
+
+  return 1
+}
+
 # Run steady mock on the given spec
 if [ "$1" == "--daemon" ]; then
   # Pre-install the package so the download doesn't eat into the startup timeout
   npm exec --package=@stdy/cli@0.22.1 -- steady --version
 
-  mock_pid=$(ruby -e '
-    log = File.open(".stdy.log", "w")
-    pid = Process.spawn(*ARGV, pgroup: true, out: log, err: [:child, :out])
-    puts(pid)
-  ' npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL")
+  ruby -e 'Process.setpgrp; exec(*ARGV)' npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL" &> .stdy.log &
+  mock_pid=$!
 
   if [ -n "${STEADY_PID_FILE:-}" ]; then
     printf '%s\n' "$mock_pid" > "$STEADY_PID_FILE"
@@ -62,7 +72,8 @@ if [ "$1" == "--daemon" ]; then
   echo -n "Waiting for server"
   attempts=0
   while ! curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1; do
-    if ! kill -0 "$mock_pid" 2>/dev/null; then
+    if ! mock_process_is_running "$mock_pid"; then
+      wait "$mock_pid" 2>/dev/null || true
       echo
       cat .stdy.log
       stop_mock_process_group "$mock_pid"

--- a/scripts/test
+++ b/scripts/test
@@ -14,7 +14,7 @@ function steady_is_running() {
 }
 
 kill_server_on_port() {
-  pids=$(lsof -t -i tcp:"$1" || echo "")
+  pids=$(lsof -t -i tcp:"$1" -sTCP:LISTEN || echo "")
   if [ "$pids" != "" ]; then
     while IFS= read -r pid; do
       kill "$pid" 2>/dev/null || true

--- a/scripts/test
+++ b/scripts/test
@@ -10,13 +10,15 @@ YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 function steady_is_running() {
-  curl --silent "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1
+  curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1
 }
 
 kill_server_on_port() {
   pids=$(lsof -t -i tcp:"$1" || echo "")
   if [ "$pids" != "" ]; then
-    kill "$pids"
+    while IFS= read -r pid; do
+      kill "$pid" 2>/dev/null || true
+    done <<< "$pids"
     echo "Stopped $pids."
   fi
 }

--- a/scripts/test
+++ b/scripts/test
@@ -13,13 +13,18 @@ function steady_is_running() {
   curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1
 }
 
-kill_server_on_port() {
-  pids=$(lsof -t -i tcp:"$1" -sTCP:LISTEN || echo "")
-  if [ "$pids" != "" ]; then
-    while IFS= read -r pid; do
-      kill "$pid" 2>/dev/null || true
-    done <<< "$pids"
-    echo "Stopped $pids."
+stop_owned_mock() {
+  local pid_file="$1"
+  local pid=""
+
+  if [ -s "$pid_file" ]; then
+    read -r pid < "$pid_file"
+  fi
+  rm -f "$pid_file"
+
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then
+    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    echo "Stopped mock process group $pid."
   fi
 }
 
@@ -28,11 +33,14 @@ function is_overriding_api_base_url() {
 }
 
 if ! is_overriding_api_base_url && ! steady_is_running ; then
-  # Start the dev server
-  ./scripts/mock --daemon
+  mock_pid_file=$(mktemp)
 
-  # When we exit this script, make sure to kill the background mock server process
-  trap 'kill_server_on_port 4010' EXIT
+  # The mock launcher records only the process group created by this invocation.
+  # Arming this before startup also covers a server that binds but never becomes ready.
+  trap 'stop_owned_mock "$mock_pid_file"' EXIT
+
+  # Start the dev server
+  STEADY_PID_FILE="$mock_pid_file" ./scripts/mock --daemon
 fi
 
 if is_overriding_api_base_url ; then

--- a/scripts/test
+++ b/scripts/test
@@ -28,11 +28,11 @@ function is_overriding_api_base_url() {
 }
 
 if ! is_overriding_api_base_url && ! steady_is_running ; then
-  # When we exit this script, make sure to kill the background mock server process
-  trap 'kill_server_on_port 4010' EXIT
-
   # Start the dev server
   ./scripts/mock --daemon
+
+  # When we exit this script, make sure to kill the background mock server process
+  trap 'kill_server_on_port 4010' EXIT
 fi
 
 if is_overriding_api_base_url ; then

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -122,37 +122,7 @@ class TestWorkflowTest < Minitest::Test
 
   def test_mock_launcher_cleans_up_its_process_group_after_readiness_timeout
     owned_pid = nil
-    project = File.join(@directory, "mock-project")
-    bin = File.join(@directory, "mock-bin")
-    pid_record = File.join(@directory, "mock-pid")
-    pid_file = File.join(@directory, "mock-pid-file")
-    spec = File.join(project, "openapi.yml")
-    FileUtils.mkdir_p(File.join(project, "scripts"))
-    FileUtils.mkdir_p(bin)
-    File.symlink(File.join(ROOT, "scripts/mock"), File.join(project, "scripts/mock"))
-    File.write(spec, "openapi: 3.0.0\n")
-    write_executable(File.join(bin, "curl"), "#!/usr/bin/env bash\nexit 22\n")
-    write_executable(File.join(bin, "sleep"), "#!/usr/bin/env bash\nexit 0\n")
-    write_executable(
-      File.join(bin, "npm"),
-      <<~BASH
-        #!/usr/bin/env bash
-        if [[ " $* " == *" --version "* ]]; then
-          exit 0
-        fi
-        printf '%s\n' "$$" > "$MOCK_PID_RECORD"
-        exec "$RUBY" -e 'sleep 60'
-      BASH
-    )
-
-    env = {
-      "MOCK_PID_RECORD" => pid_record,
-      "PATH" => [bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
-      "RUBY" => RbConfig.ruby,
-      "STEADY_PID_FILE" => pid_file
-    }
-    stdout, stderr, status = Open3.capture3(env, File.join(project, "scripts/mock"), spec, "--daemon")
-    owned_pid = Integer(File.read(pid_record), 10)
+    stdout, stderr, status, owned_pid, pid_file = run_mock_launcher(mode: "hang")
 
     refute(status.success?, "#{stdout}\n#{stderr}")
     assert_includes(stdout, "Timed out waiting for Steady server to start")
@@ -162,6 +132,29 @@ class TestWorkflowTest < Minitest::Test
     begin
       Process.kill("TERM", -owned_pid)
     rescue Errno::ESRCH, TypeError
+      nil
+    end
+  end
+
+  def test_mock_launcher_reaps_a_crashed_child_without_waiting_for_readiness_timeout
+    stdout, stderr, status, owned_pid, pid_file = run_mock_launcher(mode: "crash")
+
+    refute(status.success?, "#{stdout}\n#{stderr}")
+    refute_includes(stdout, "Timed out waiting for Steady server to start")
+    assert(wait_for_process_exit(owned_pid, timeout: 5), "expected crashed process #{owned_pid} to be reaped")
+    refute(File.exist?(pid_file), "expected child failure to clear PID file")
+  end
+
+  def test_process_exit_wait_treats_zombie_as_exited
+    skip("requires Linux procfs") unless File.directory?("/proc/self")
+
+    pid = Process.spawn(RbConfig.ruby, "-e", "exit")
+
+    assert(wait_for_process_exit(pid, timeout: 5), "expected zombie PID #{pid} to count as exited")
+  ensure
+    begin
+      Process.wait(pid)
+    rescue Errno::ECHILD, TypeError
       nil
     end
   end
@@ -241,6 +234,44 @@ class TestWorkflowTest < Minitest::Test
     Open3.capture3(env, File.join(@project, "scripts/test"), chdir: @project)
   end
 
+  def run_mock_launcher(mode:)
+    project = File.join(@directory, "mock-project")
+    bin = File.join(@directory, "mock-bin")
+    pid_record = File.join(@directory, "mock-pid")
+    pid_file = File.join(@directory, "mock-pid-file")
+    spec = File.join(project, "openapi.yml")
+    FileUtils.mkdir_p(File.join(project, "scripts"))
+    FileUtils.mkdir_p(bin)
+    File.symlink(File.join(ROOT, "scripts/mock"), File.join(project, "scripts/mock"))
+    File.write(spec, "openapi: 3.0.0\n")
+    write_executable(File.join(bin, "curl"), "#!/usr/bin/env bash\nexit 22\n")
+    write_executable(File.join(bin, "sleep"), "#!/usr/bin/env bash\nexit 0\n")
+    write_executable(
+      File.join(bin, "npm"),
+      <<~BASH
+        #!/usr/bin/env bash
+        if [[ " $* " == *" --version "* ]]; then
+          exit 0
+        fi
+        printf '%s\n' "$$" > "$MOCK_PID_RECORD"
+        if [ "$MOCK_NPM_MODE" = "crash" ]; then
+          exit 42
+        fi
+        exec "$RUBY" -e 'sleep 60'
+      BASH
+    )
+
+    env = {
+      "MOCK_NPM_MODE" => mode,
+      "MOCK_PID_RECORD" => pid_record,
+      "PATH" => [bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
+      "RUBY" => RbConfig.ruby,
+      "STEADY_PID_FILE" => pid_file
+    }
+    stdout, stderr, status = Open3.capture3(env, File.join(project, "scripts/mock"), spec, "--daemon")
+    [stdout, stderr, status, Integer(File.read(pid_record), 10), pid_file]
+  end
+
   def wait_for_exit(pid, timeout:)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
     loop do
@@ -263,10 +294,19 @@ class TestWorkflowTest < Minitest::Test
         return true
       end
 
+      return true if zombie_process?(pid)
+
       return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
 
       sleep(0.01)
     end
+  end
+
+  def zombie_process?(pid)
+    stat = File.read("/proc/#{pid}/stat")
+    stat.rpartition(") ").last.start_with?("Z ")
+  rescue Errno::EACCES, Errno::ENOENT, Errno::ENOTDIR
+    false
   end
 
   def write_bundle

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -24,7 +24,6 @@ class TestWorkflowTest < Minitest::Test
     write_mock
     write_bundle
     write_curl
-    write_lsof
   end
 
   def teardown
@@ -44,7 +43,6 @@ class TestWorkflowTest < Minitest::Test
     listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
     stdout, stderr, status = run_test_script(
       curl_mode: "http_error",
-      lsof_pids: listener_pid.to_s,
       mock_mode: "fail"
     )
 
@@ -70,38 +68,110 @@ class TestWorkflowTest < Minitest::Test
     end
   end
 
-  def test_cleanup_stops_every_process_listening_on_mock_port
-    stale_pid = Process.spawn(RbConfig.ruby, "-e", "exit")
-    Process.wait(stale_pid)
-    pids = 2.times.map { Process.spawn(RbConfig.ruby, "-e", "sleep 60") }
+  def test_cleanup_stops_only_the_mock_owned_by_this_invocation
+    owned_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
+    preexisting_ipv6_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
     stdout, stderr, status = run_test_script(
       curl_mode: "unavailable_until_mock",
-      lsof_pids: [stale_pid, *pids].join("\n")
+      mock_owned_pid: owned_pid.to_s
     )
 
     assert(status.success?, "#{stdout}\n#{stderr}")
-    pids.each { assert(wait_for_exit(_1, timeout: 5), "expected cleanup to stop PID #{_1}") }
+    assert(wait_for_exit(owned_pid, timeout: 5), "expected cleanup to stop owned PID #{owned_pid}")
+    refute(
+      wait_for_exit(preexisting_ipv6_pid, timeout: 1),
+      "expected cleanup to preserve pre-existing IPv6 listener PID #{preexisting_ipv6_pid}"
+    )
   ensure
-    Array(pids).each do |pid|
+    [owned_pid, preexisting_ipv6_pid].compact.each do |pid|
       Process.kill("TERM", pid)
     rescue Errno::ESRCH
       nil
     end
 
-    Array(pids).each do |pid|
+    [owned_pid, preexisting_ipv6_pid].compact.each do |pid|
       Process.wait(pid)
     rescue Errno::ECHILD
       nil
     end
   end
 
+  def test_failed_mock_readiness_cleans_up_the_owned_process_group
+    owned_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
+    stdout, stderr, status = run_test_script(
+      curl_mode: "unavailable_until_mock",
+      mock_mode: "fail",
+      mock_owned_pid: owned_pid.to_s
+    )
+
+    refute(status.success?, "#{stdout}\n#{stderr}")
+    assert(wait_for_exit(owned_pid, timeout: 5), "expected failed startup to stop owned PID #{owned_pid}")
+  ensure
+    begin
+      Process.kill("TERM", owned_pid)
+    rescue Errno::ESRCH, TypeError
+      nil
+    end
+
+    begin
+      Process.wait(owned_pid)
+    rescue Errno::ECHILD, TypeError
+      nil
+    end
+  end
+
+  def test_mock_launcher_cleans_up_its_process_group_after_readiness_timeout
+    owned_pid = nil
+    project = File.join(@directory, "mock-project")
+    bin = File.join(@directory, "mock-bin")
+    pid_record = File.join(@directory, "mock-pid")
+    pid_file = File.join(@directory, "mock-pid-file")
+    spec = File.join(project, "openapi.yml")
+    FileUtils.mkdir_p(File.join(project, "scripts"))
+    FileUtils.mkdir_p(bin)
+    File.symlink(File.join(ROOT, "scripts/mock"), File.join(project, "scripts/mock"))
+    File.write(spec, "openapi: 3.0.0\n")
+    write_executable(File.join(bin, "curl"), "#!/usr/bin/env bash\nexit 22\n")
+    write_executable(File.join(bin, "sleep"), "#!/usr/bin/env bash\nexit 0\n")
+    write_executable(
+      File.join(bin, "npm"),
+      <<~BASH
+        #!/usr/bin/env bash
+        if [[ " $* " == *" --version "* ]]; then
+          exit 0
+        fi
+        printf '%s\n' "$$" > "$MOCK_PID_RECORD"
+        exec "$RUBY" -e 'sleep 60'
+      BASH
+    )
+
+    env = {
+      "MOCK_PID_RECORD" => pid_record,
+      "PATH" => [bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
+      "RUBY" => RbConfig.ruby,
+      "STEADY_PID_FILE" => pid_file
+    }
+    stdout, stderr, status = Open3.capture3(env, File.join(project, "scripts/mock"), spec, "--daemon")
+    owned_pid = Integer(File.read(pid_record), 10)
+
+    refute(status.success?, "#{stdout}\n#{stderr}")
+    assert_includes(stdout, "Timed out waiting for Steady server to start")
+    assert(wait_for_process_exit(owned_pid, timeout: 5), "expected timeout to stop process group #{owned_pid}")
+    refute(File.exist?(pid_file), "expected timeout to clear PID file")
+  ensure
+    begin
+      Process.kill("TERM", -owned_pid)
+    rescue Errno::ESRCH, TypeError
+      nil
+    end
+  end
+
   def test_cleanup_leaves_non_listening_connections_running
-    listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
+    listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
     client_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
     stdout, stderr, status = run_test_script(
       curl_mode: "unavailable_until_mock",
-      lsof_pids: listener_pid.to_s,
-      lsof_connected_pids: client_pid.to_s
+      mock_owned_pid: listener_pid.to_s
     )
 
     assert(status.success?, "#{stdout}\n#{stderr}")
@@ -151,15 +221,19 @@ class TestWorkflowTest < Minitest::Test
     File.exist?(path) ? File.readlines(path, chomp: true) : []
   end
 
-  def run_test_script(curl_mode:, api_base_url: nil, lsof_pids: nil, lsof_connected_pids: nil, mock_mode: nil)
+  def run_test_script(
+    curl_mode:,
+    api_base_url: nil,
+    mock_mode: nil,
+    mock_owned_pid: nil
+  )
     env = {
       "BUNDLE_CALLS" => @bundle_calls,
       "CURL_CALLS" => @curl_calls,
       "CURL_MODE" => curl_mode,
-      "LSOF_CONNECTED_PIDS" => lsof_connected_pids,
-      "LSOF_PIDS" => lsof_pids,
       "MOCK_CALLS" => @mock_calls,
       "MOCK_MODE" => mock_mode,
+      "MOCK_OWNED_PID" => mock_owned_pid,
       "MOCK_STARTED" => @mock_started,
       "PATH" => [@bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
       "TEST_API_BASE_URL" => api_base_url
@@ -178,6 +252,21 @@ class TestWorkflowTest < Minitest::Test
 
   rescue Errno::ECHILD
     true
+  end
+
+  def wait_for_process_exit(pid, timeout:)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      begin
+        Process.kill(0, pid)
+      rescue Errno::ESRCH
+        return true
+      end
+
+      return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep(0.01)
+    end
   end
 
   def write_bundle
@@ -221,33 +310,15 @@ class TestWorkflowTest < Minitest::Test
     )
   end
 
-  def write_lsof
-    write_executable(
-      File.join(@bin, "lsof"),
-      <<~BASH
-        #!/usr/bin/env bash
-        found=false
-        if [ -n "$LSOF_PIDS" ]; then
-          printf '%s\n' "$LSOF_PIDS"
-          found=true
-        fi
-        if [[ " $* " != *" -sTCP:LISTEN "* ]] && [ -n "$LSOF_CONNECTED_PIDS" ]; then
-          printf '%s\n' "$LSOF_CONNECTED_PIDS"
-          found=true
-        fi
-        if [ "$found" = false ]; then
-          exit 1
-        fi
-      BASH
-    )
-  end
-
   def write_mock
     write_executable(
       File.join(@project, "scripts/mock"),
       <<~BASH
         #!/usr/bin/env bash
         printf '%s\n' "$*" > "$MOCK_CALLS"
+        if [ -n "$MOCK_OWNED_PID" ] && [ -n "$STEADY_PID_FILE" ]; then
+          printf '%s\n' "$MOCK_OWNED_PID" > "$STEADY_PID_FILE"
+        fi
         if [ "$MOCK_MODE" = "fail" ]; then
           exit 1
         fi

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -50,7 +50,7 @@ class TestWorkflowTest < Minitest::Test
     )
 
     assert(status.success?, "#{stdout}\n#{stderr}")
-    pids.each { assert(wait_for_exit(_1), "expected cleanup to stop PID #{_1}") }
+    pids.each { assert(wait_for_exit(_1, timeout: 5), "expected cleanup to stop PID #{_1}") }
   ensure
     Array(pids).each do |pid|
       Process.kill("TERM", pid)
@@ -75,8 +75,8 @@ class TestWorkflowTest < Minitest::Test
     )
 
     assert(status.success?, "#{stdout}\n#{stderr}")
-    assert(wait_for_exit(listener_pid), "expected cleanup to stop listener PID #{listener_pid}")
-    refute(wait_for_exit(client_pid), "expected cleanup to leave client PID #{client_pid} running")
+    assert(wait_for_exit(listener_pid, timeout: 5), "expected cleanup to stop listener PID #{listener_pid}")
+    refute(wait_for_exit(client_pid, timeout: 1), "expected cleanup to leave client PID #{client_pid} running")
   ensure
     [listener_pid, client_pid].compact.each do |pid|
       Process.kill("TERM", pid)
@@ -136,14 +136,15 @@ class TestWorkflowTest < Minitest::Test
     Open3.capture3(env, File.join(@project, "scripts/test"), chdir: @project)
   end
 
-  def wait_for_exit(pid)
-    100.times do
+  def wait_for_exit(pid, timeout:)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
       return true if Process.waitpid(pid, Process::WNOHANG)
+      return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
 
       sleep(0.01)
     end
 
-    false
   rescue Errno::ECHILD
     true
   end

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -65,6 +65,32 @@ class TestWorkflowTest < Minitest::Test
     end
   end
 
+  def test_cleanup_leaves_non_listening_connections_running
+    listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
+    client_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
+    stdout, stderr, status = run_test_script(
+      curl_mode: "unavailable_until_mock",
+      lsof_pids: listener_pid.to_s,
+      lsof_connected_pids: client_pid.to_s
+    )
+
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    assert(wait_for_exit(listener_pid), "expected cleanup to stop listener PID #{listener_pid}")
+    refute(wait_for_exit(client_pid), "expected cleanup to leave client PID #{client_pid} running")
+  ensure
+    [listener_pid, client_pid].compact.each do |pid|
+      Process.kill("TERM", pid)
+    rescue Errno::ESRCH
+      nil
+    end
+
+    [listener_pid, client_pid].compact.each do |pid|
+      Process.wait(pid)
+    rescue Errno::ECHILD
+      nil
+    end
+  end
+
   def test_healthy_local_mock_is_reused
     stdout, stderr, status = run_test_script(curl_mode: "healthy")
 
@@ -95,11 +121,12 @@ class TestWorkflowTest < Minitest::Test
     File.exist?(path) ? File.readlines(path, chomp: true) : []
   end
 
-  def run_test_script(curl_mode:, api_base_url: nil, lsof_pids: nil)
+  def run_test_script(curl_mode:, api_base_url: nil, lsof_pids: nil, lsof_connected_pids: nil)
     env = {
       "BUNDLE_CALLS" => @bundle_calls,
       "CURL_CALLS" => @curl_calls,
       "CURL_MODE" => curl_mode,
+      "LSOF_CONNECTED_PIDS" => lsof_connected_pids,
       "LSOF_PIDS" => lsof_pids,
       "MOCK_CALLS" => @mock_calls,
       "MOCK_STARTED" => @mock_started,
@@ -167,10 +194,18 @@ class TestWorkflowTest < Minitest::Test
       File.join(@bin, "lsof"),
       <<~BASH
         #!/usr/bin/env bash
-        if [ -z "$LSOF_PIDS" ]; then
+        found=false
+        if [ -n "$LSOF_PIDS" ]; then
+          printf '%s\n' "$LSOF_PIDS"
+          found=true
+        fi
+        if [[ " $* " != *" -sTCP:LISTEN "* ]] && [ -n "$LSOF_CONNECTED_PIDS" ]; then
+          printf '%s\n' "$LSOF_CONNECTED_PIDS"
+          found=true
+        fi
+        if [ "$found" = false ]; then
           exit 1
         fi
-        printf '%s\n' "$LSOF_PIDS"
       BASH
     )
   end

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+class TestWorkflowTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def setup
+    @directory = Dir.mktmpdir
+    @project = File.join(@directory, "project")
+    @bin = File.join(@directory, "bin")
+    @bundle_calls = File.join(@directory, "bundle-calls")
+    @curl_calls = File.join(@directory, "curl-calls")
+    @mock_calls = File.join(@directory, "mock-calls")
+    @mock_started = File.join(@directory, "mock-started")
+
+    FileUtils.mkdir_p(File.join(@project, "scripts"))
+    FileUtils.mkdir_p(@bin)
+    File.symlink(File.join(ROOT, "scripts/test"), File.join(@project, "scripts/test"))
+    write_mock
+    write_bundle
+    write_curl
+    write_lsof
+  end
+
+  def teardown
+    FileUtils.remove_entry(@directory)
+  end
+
+  def test_http_error_at_health_endpoint_starts_local_mock
+    stdout, stderr, status = run_test_script(curl_mode: "http_error_until_mock")
+
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    assert_equal(["--daemon"], calls(@mock_calls))
+    assert(calls(@curl_calls).all? { _1.split.include?("--fail") })
+    assert_bundle_ran
+  end
+
+  def test_cleanup_stops_every_process_listening_on_mock_port
+    stale_pid = Process.spawn(RbConfig.ruby, "-e", "exit")
+    Process.wait(stale_pid)
+    pids = 2.times.map { Process.spawn(RbConfig.ruby, "-e", "sleep 60") }
+    stdout, stderr, status = run_test_script(
+      curl_mode: "unavailable_until_mock",
+      lsof_pids: [stale_pid, *pids].join("\n")
+    )
+
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    pids.each { assert(wait_for_exit(_1), "expected cleanup to stop PID #{_1}") }
+  ensure
+    Array(pids).each do |pid|
+      Process.kill("TERM", pid)
+    rescue Errno::ESRCH
+      nil
+    end
+
+    Array(pids).each do |pid|
+      Process.wait(pid)
+    rescue Errno::ECHILD
+      nil
+    end
+  end
+
+  def test_healthy_local_mock_is_reused
+    stdout, stderr, status = run_test_script(curl_mode: "healthy")
+
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    assert_empty(calls(@mock_calls))
+    assert_equal(2, calls(@curl_calls).length)
+    assert_bundle_ran
+  end
+
+  def test_explicit_api_base_url_skips_local_mock_probe
+    api_base_url = "http://example.test/v1"
+    stdout, stderr, status = run_test_script(curl_mode: "unexpected", api_base_url: api_base_url)
+
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    assert_includes(stdout, "Running tests against #{api_base_url}")
+    assert_empty(calls(@curl_calls))
+    assert_empty(calls(@mock_calls))
+    assert_bundle_ran
+  end
+
+  private
+
+  def assert_bundle_ran
+    assert_equal(["exec rake test"], calls(@bundle_calls))
+  end
+
+  def calls(path)
+    File.exist?(path) ? File.readlines(path, chomp: true) : []
+  end
+
+  def run_test_script(curl_mode:, api_base_url: nil, lsof_pids: nil)
+    env = {
+      "BUNDLE_CALLS" => @bundle_calls,
+      "CURL_CALLS" => @curl_calls,
+      "CURL_MODE" => curl_mode,
+      "LSOF_PIDS" => lsof_pids,
+      "MOCK_CALLS" => @mock_calls,
+      "MOCK_STARTED" => @mock_started,
+      "PATH" => [@bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
+      "TEST_API_BASE_URL" => api_base_url
+    }
+    Open3.capture3(env, File.join(@project, "scripts/test"), chdir: @project)
+  end
+
+  def wait_for_exit(pid)
+    100.times do
+      return true if Process.waitpid(pid, Process::WNOHANG)
+
+      sleep(0.01)
+    end
+
+    false
+  rescue Errno::ECHILD
+    true
+  end
+
+  def write_bundle
+    write_executable(
+      File.join(@bin, "bundle"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf '%s\n' "$*" > "$BUNDLE_CALLS"
+      BASH
+    )
+  end
+
+  def write_curl
+    write_executable(
+      File.join(@bin, "curl"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf '%s\n' "$*" >> "$CURL_CALLS"
+
+        if [ "$CURL_MODE" = "healthy" ]; then
+          exit 0
+        fi
+        if [ "$CURL_MODE" = "unexpected" ]; then
+          exit 64
+        fi
+        if [ -f "$MOCK_STARTED" ]; then
+          exit 0
+        fi
+        if [ "$CURL_MODE" = "unavailable_until_mock" ]; then
+          exit 7
+        fi
+
+        # Match curl: HTTP error responses only fail when --fail is present.
+        for argument in "$@"; do
+          if [ "$argument" = "--fail" ]; then
+            exit 22
+          fi
+        done
+        exit 0
+      BASH
+    )
+  end
+
+  def write_lsof
+    write_executable(
+      File.join(@bin, "lsof"),
+      <<~BASH
+        #!/usr/bin/env bash
+        if [ -z "$LSOF_PIDS" ]; then
+          exit 1
+        fi
+        printf '%s\n' "$LSOF_PIDS"
+      BASH
+    )
+  end
+
+  def write_mock
+    write_executable(
+      File.join(@project, "scripts/mock"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf '%s\n' "$*" > "$MOCK_CALLS"
+        : > "$MOCK_STARTED"
+      BASH
+    )
+  end
+
+  def write_executable(path, contents)
+    File.write(path, contents)
+    File.chmod(0o755, path)
+  end
+end

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -130,7 +130,7 @@ class TestWorkflowTest < Minitest::Test
     refute(File.exist?(pid_file), "expected timeout to clear PID file")
   ensure
     begin
-      Process.kill("TERM", -owned_pid)
+      Process.kill("TERM", -owned_pid) if owned_pid
     rescue Errno::ESRCH, TypeError
       nil
     end
@@ -143,6 +143,70 @@ class TestWorkflowTest < Minitest::Test
     refute_includes(stdout, "Timed out waiting for Steady server to start")
     assert(wait_for_process_exit(owned_pid, timeout: 5), "expected crashed process #{owned_pid} to be reaped")
     refute(File.exist?(pid_file), "expected child failure to clear PID file")
+  end
+
+  def test_mock_launcher_rejects_an_unrelated_healthy_endpoint_after_its_child_exits
+    stdout, stderr, status, owned_pid, pid_file = run_mock_launcher(
+      mode: "crash",
+      curl_mode: "healthy_after_child_exit"
+    )
+
+    refute(status.success?, "#{stdout}\n#{stderr}")
+    assert(wait_for_process_exit(owned_pid, timeout: 5), "expected crashed process #{owned_pid} to be reaped")
+    refute(File.exist?(pid_file), "expected child failure to clear PID file")
+  end
+
+  def test_mock_launcher_transfers_a_healthy_process_group_to_its_caller
+    owned_pid = nil
+    stdout, stderr, status, owned_pid, pid_file = run_mock_launcher(mode: "hang", curl_mode: "healthy")
+
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    refute(wait_for_process_exit(owned_pid, timeout: 1), "expected healthy process group #{owned_pid} to remain")
+    assert_equal("#{owned_pid}\n", File.read(pid_file))
+  ensure
+    begin
+      Process.kill("TERM", -owned_pid) if owned_pid
+    rescue Errno::ESRCH, TypeError
+      nil
+    end
+  end
+
+  def test_mock_launcher_cleans_up_its_process_group_when_interrupted
+    fixture = mock_launcher_fixture(mode: "hang")
+    launcher_pid = Process.spawn(
+      fixture.fetch(:env),
+      fixture.fetch(:script),
+      fixture.fetch(:spec),
+      "--daemon",
+      out: fixture.fetch(:stdout_path),
+      err: fixture.fetch(:stderr_path)
+    )
+    wait_for_file(fixture.fetch(:pid_record), timeout: 10)
+    owned_pid = Integer(File.read(fixture.fetch(:pid_record)), 10)
+
+    Process.kill("TERM", launcher_pid)
+    Process.wait(launcher_pid)
+
+    assert(wait_for_process_exit(owned_pid, timeout: 5), "expected interrupt to stop process group #{owned_pid}")
+    refute(File.exist?(fixture.fetch(:pid_file)), "expected interrupt to clear PID file")
+  ensure
+    begin
+      Process.kill("TERM", launcher_pid)
+    rescue Errno::ESRCH, TypeError
+      nil
+    end
+
+    begin
+      Process.kill("TERM", -owned_pid) if owned_pid
+    rescue Errno::ESRCH, TypeError
+      nil
+    end
+
+    begin
+      Process.wait(launcher_pid)
+    rescue Errno::ECHILD, TypeError
+      nil
+    end
   end
 
   def test_process_exit_wait_treats_zombie_as_exited
@@ -234,17 +298,52 @@ class TestWorkflowTest < Minitest::Test
     Open3.capture3(env, File.join(@project, "scripts/test"), chdir: @project)
   end
 
-  def run_mock_launcher(mode:)
+  def run_mock_launcher(mode:, curl_mode: "unavailable")
+    fixture = mock_launcher_fixture(mode: mode, curl_mode: curl_mode)
+    stdout, stderr, status = Open3.capture3(
+      fixture.fetch(:env),
+      fixture.fetch(:script),
+      fixture.fetch(:spec),
+      "--daemon"
+    )
+    [
+      stdout,
+      stderr,
+      status,
+      Integer(File.read(fixture.fetch(:pid_record)), 10),
+      fixture.fetch(:pid_file)
+    ]
+  end
+
+  def mock_launcher_fixture(mode:, curl_mode: "unavailable")
     project = File.join(@directory, "mock-project")
     bin = File.join(@directory, "mock-bin")
     pid_record = File.join(@directory, "mock-pid")
+    exited_record = File.join(@directory, "mock-exited")
     pid_file = File.join(@directory, "mock-pid-file")
+    stdout_path = File.join(@directory, "mock-stdout")
+    stderr_path = File.join(@directory, "mock-stderr")
     spec = File.join(project, "openapi.yml")
     FileUtils.mkdir_p(File.join(project, "scripts"))
     FileUtils.mkdir_p(bin)
     File.symlink(File.join(ROOT, "scripts/mock"), File.join(project, "scripts/mock"))
     File.write(spec, "openapi: 3.0.0\n")
-    write_executable(File.join(bin, "curl"), "#!/usr/bin/env bash\nexit 22\n")
+    write_executable(
+      File.join(bin, "curl"),
+      <<~BASH
+        #!/usr/bin/env bash
+        if [ "$MOCK_CURL_MODE" = "healthy" ]; then
+          exit 0
+        fi
+        if [ "$MOCK_CURL_MODE" = "healthy_after_child_exit" ]; then
+          while [ ! -f "$MOCK_EXITED_RECORD" ]; do
+            sleep 0.01
+          done
+          exit 0
+        fi
+        exit 22
+      BASH
+    )
     write_executable(File.join(bin, "sleep"), "#!/usr/bin/env bash\nexit 0\n")
     write_executable(
       File.join(bin, "npm"),
@@ -254,6 +353,7 @@ class TestWorkflowTest < Minitest::Test
           exit 0
         fi
         printf '%s\n' "$$" > "$MOCK_PID_RECORD"
+        trap ': > "$MOCK_EXITED_RECORD"' EXIT
         if [ "$MOCK_NPM_MODE" = "crash" ]; then
           exit 42
         fi
@@ -262,14 +362,32 @@ class TestWorkflowTest < Minitest::Test
     )
 
     env = {
+      "MOCK_CURL_MODE" => curl_mode,
+      "MOCK_EXITED_RECORD" => exited_record,
       "MOCK_NPM_MODE" => mode,
       "MOCK_PID_RECORD" => pid_record,
       "PATH" => [bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
       "RUBY" => RbConfig.ruby,
       "STEADY_PID_FILE" => pid_file
     }
-    stdout, stderr, status = Open3.capture3(env, File.join(project, "scripts/mock"), spec, "--daemon")
-    [stdout, stderr, status, Integer(File.read(pid_record), 10), pid_file]
+    {
+      env: env,
+      pid_file: pid_file,
+      pid_record: pid_record,
+      script: File.join(project, "scripts/mock"),
+      spec: spec,
+      stderr_path: stderr_path,
+      stdout_path: stdout_path
+    }
+  end
+
+  def wait_for_file(path, timeout:)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until File.exist?(path)
+      raise "timed out waiting for #{path}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep(0.01)
+    end
   end
 
   def wait_for_exit(pid, timeout:)

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -167,6 +167,35 @@ class TestWorkflowTest < Minitest::Test
     refute(File.exist?(pid_file), "expected rejected ownership to clear PID file")
   end
 
+  def test_mock_launcher_requires_lsof_before_spawning_mock
+    owned_pid = nil
+    fixture = mock_launcher_fixture(
+      mode: "hang",
+      curl_mode: "healthy",
+      lsof_mode: "unavailable"
+    )
+    stdout, stderr, status = Open3.capture3(
+      fixture.fetch(:env),
+      fixture.fetch(:script),
+      fixture.fetch(:spec),
+      "--daemon"
+    )
+    if File.exist?(fixture.fetch(:pid_record))
+      owned_pid = Integer(File.read(fixture.fetch(:pid_record)), 10)
+    end
+
+    refute(status.success?, stdout)
+    assert_includes(stderr, "lsof is required for --daemon mock startup")
+    refute(File.exist?(fixture.fetch(:pid_record)), "expected dependency validation before spawning mock")
+    refute(File.exist?(fixture.fetch(:pid_file)), "expected dependency failure before recording ownership")
+  ensure
+    begin
+      Process.kill("TERM", -owned_pid) if owned_pid
+    rescue Errno::ESRCH, TypeError
+      nil
+    end
+  end
+
   def test_mock_launcher_transfers_a_healthy_process_group_to_its_caller
     owned_pid = nil
     stdout, stderr, status, owned_pid, pid_file, lsof_calls = run_mock_launcher(
@@ -333,7 +362,12 @@ class TestWorkflowTest < Minitest::Test
     ]
   end
 
-  def mock_launcher_fixture(mode:, curl_mode: "unavailable", listener_mode: "unrelated")
+  def mock_launcher_fixture(
+    mode:,
+    curl_mode: "unavailable",
+    listener_mode: "unrelated",
+    lsof_mode: "available"
+  )
     project = File.join(@directory, "mock-project")
     bin = File.join(@directory, "mock-bin")
     pid_record = File.join(@directory, "mock-pid")
@@ -371,6 +405,12 @@ class TestWorkflowTest < Minitest::Test
       File.join(bin, "lsof"),
       <<~BASH
         #!/usr/bin/env bash
+        if [ "$MOCK_LSOF_MODE" = "unavailable" ]; then
+          exit 127
+        fi
+        if [ "$1" = "-v" ]; then
+          exit 0
+        fi
         printf '%s\n' "$*" > "$MOCK_LSOF_CALLS"
         [ "$MOCK_LISTENER_MODE" = "owned" ]
       BASH
@@ -399,6 +439,7 @@ class TestWorkflowTest < Minitest::Test
       "MOCK_EXITED_RECORD" => exited_record,
       "MOCK_LISTENER_MODE" => listener_mode,
       "MOCK_LSOF_CALLS" => lsof_calls,
+      "MOCK_LSOF_MODE" => lsof_mode,
       "MOCK_NPM_MODE" => mode,
       "MOCK_PID_RECORD" => pid_record,
       "PATH" => [bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -156,13 +156,29 @@ class TestWorkflowTest < Minitest::Test
     refute(File.exist?(pid_file), "expected child failure to clear PID file")
   end
 
+  def test_mock_launcher_rejects_an_unrelated_healthy_endpoint_while_its_child_is_alive
+    stdout, stderr, status, owned_pid, pid_file = run_mock_launcher(
+      mode: "hang",
+      curl_mode: "healthy"
+    )
+
+    refute(status.success?, "#{stdout}\n#{stderr}")
+    assert(wait_for_process_exit(owned_pid, timeout: 5), "expected unbound process group #{owned_pid} to stop")
+    refute(File.exist?(pid_file), "expected rejected ownership to clear PID file")
+  end
+
   def test_mock_launcher_transfers_a_healthy_process_group_to_its_caller
     owned_pid = nil
-    stdout, stderr, status, owned_pid, pid_file = run_mock_launcher(mode: "hang", curl_mode: "healthy")
+    stdout, stderr, status, owned_pid, pid_file, lsof_calls = run_mock_launcher(
+      mode: "delayed_start",
+      curl_mode: "healthy",
+      listener_mode: "owned"
+    )
 
     assert(status.success?, "#{stdout}\n#{stderr}")
     refute(wait_for_process_exit(owned_pid, timeout: 1), "expected healthy process group #{owned_pid} to remain")
     assert_equal("#{owned_pid}\n", File.read(pid_file))
+    assert_includes(File.read(lsof_calls), "-g #{owned_pid} -iTCP@127.0.0.1:4010 -sTCP:LISTEN")
   ensure
     begin
       Process.kill("TERM", -owned_pid) if owned_pid
@@ -298,28 +314,31 @@ class TestWorkflowTest < Minitest::Test
     Open3.capture3(env, File.join(@project, "scripts/test"), chdir: @project)
   end
 
-  def run_mock_launcher(mode:, curl_mode: "unavailable")
-    fixture = mock_launcher_fixture(mode: mode, curl_mode: curl_mode)
+  def run_mock_launcher(mode:, curl_mode: "unavailable", listener_mode: "unrelated")
+    fixture = mock_launcher_fixture(mode: mode, curl_mode: curl_mode, listener_mode: listener_mode)
     stdout, stderr, status = Open3.capture3(
       fixture.fetch(:env),
       fixture.fetch(:script),
       fixture.fetch(:spec),
       "--daemon"
     )
+    wait_for_file(fixture.fetch(:pid_record), timeout: 10)
     [
       stdout,
       stderr,
       status,
       Integer(File.read(fixture.fetch(:pid_record)), 10),
-      fixture.fetch(:pid_file)
+      fixture.fetch(:pid_file),
+      fixture.fetch(:lsof_calls)
     ]
   end
 
-  def mock_launcher_fixture(mode:, curl_mode: "unavailable")
+  def mock_launcher_fixture(mode:, curl_mode: "unavailable", listener_mode: "unrelated")
     project = File.join(@directory, "mock-project")
     bin = File.join(@directory, "mock-bin")
     pid_record = File.join(@directory, "mock-pid")
     exited_record = File.join(@directory, "mock-exited")
+    lsof_calls = File.join(@directory, "lsof-calls")
     pid_file = File.join(@directory, "mock-pid-file")
     stdout_path = File.join(@directory, "mock-stdout")
     stderr_path = File.join(@directory, "mock-stderr")
@@ -333,6 +352,9 @@ class TestWorkflowTest < Minitest::Test
       <<~BASH
         #!/usr/bin/env bash
         if [ "$MOCK_CURL_MODE" = "healthy" ]; then
+          while [ ! -f "$MOCK_PID_RECORD" ]; do
+            "$RUBY" -e 'sleep 0.01'
+          done
           exit 0
         fi
         if [ "$MOCK_CURL_MODE" = "healthy_after_child_exit" ]; then
@@ -346,11 +368,22 @@ class TestWorkflowTest < Minitest::Test
     )
     write_executable(File.join(bin, "sleep"), "#!/usr/bin/env bash\nexit 0\n")
     write_executable(
+      File.join(bin, "lsof"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf '%s\n' "$*" > "$MOCK_LSOF_CALLS"
+        [ "$MOCK_LISTENER_MODE" = "owned" ]
+      BASH
+    )
+    write_executable(
       File.join(bin, "npm"),
       <<~BASH
         #!/usr/bin/env bash
         if [[ " $* " == *" --version "* ]]; then
           exit 0
+        fi
+        if [ "$MOCK_NPM_MODE" = "delayed_start" ]; then
+          "$RUBY" -e 'sleep 0.2'
         fi
         printf '%s\n' "$$" > "$MOCK_PID_RECORD"
         trap ': > "$MOCK_EXITED_RECORD"' EXIT
@@ -364,6 +397,8 @@ class TestWorkflowTest < Minitest::Test
     env = {
       "MOCK_CURL_MODE" => curl_mode,
       "MOCK_EXITED_RECORD" => exited_record,
+      "MOCK_LISTENER_MODE" => listener_mode,
+      "MOCK_LSOF_CALLS" => lsof_calls,
       "MOCK_NPM_MODE" => mode,
       "MOCK_PID_RECORD" => pid_record,
       "PATH" => [bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
@@ -372,6 +407,7 @@ class TestWorkflowTest < Minitest::Test
     }
     {
       env: env,
+      lsof_calls: lsof_calls,
       pid_file: pid_file,
       pid_record: pid_record,
       script: File.join(project, "scripts/mock"),

--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -40,6 +40,36 @@ class TestWorkflowTest < Minitest::Test
     assert_bundle_ran
   end
 
+  def test_failed_mock_start_leaves_preexisting_listener_running
+    listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
+    stdout, stderr, status = run_test_script(
+      curl_mode: "http_error",
+      lsof_pids: listener_pid.to_s,
+      mock_mode: "fail"
+    )
+
+    refute(status.success?, "#{stdout}\n#{stderr}")
+    assert_equal(["--daemon"], calls(@mock_calls))
+    refute(
+      wait_for_exit(listener_pid, timeout: 1),
+      "expected failed startup to leave listener PID #{listener_pid} running"
+    )
+  ensure
+    if listener_pid
+      begin
+        Process.kill("TERM", listener_pid)
+      rescue Errno::ESRCH
+        nil
+      end
+
+      begin
+        Process.wait(listener_pid)
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+  end
+
   def test_cleanup_stops_every_process_listening_on_mock_port
     stale_pid = Process.spawn(RbConfig.ruby, "-e", "exit")
     Process.wait(stale_pid)
@@ -121,7 +151,7 @@ class TestWorkflowTest < Minitest::Test
     File.exist?(path) ? File.readlines(path, chomp: true) : []
   end
 
-  def run_test_script(curl_mode:, api_base_url: nil, lsof_pids: nil, lsof_connected_pids: nil)
+  def run_test_script(curl_mode:, api_base_url: nil, lsof_pids: nil, lsof_connected_pids: nil, mock_mode: nil)
     env = {
       "BUNDLE_CALLS" => @bundle_calls,
       "CURL_CALLS" => @curl_calls,
@@ -129,6 +159,7 @@ class TestWorkflowTest < Minitest::Test
       "LSOF_CONNECTED_PIDS" => lsof_connected_pids,
       "LSOF_PIDS" => lsof_pids,
       "MOCK_CALLS" => @mock_calls,
+      "MOCK_MODE" => mock_mode,
       "MOCK_STARTED" => @mock_started,
       "PATH" => [@bin, ENV.fetch("PATH")].join(File::PATH_SEPARATOR),
       "TEST_API_BASE_URL" => api_base_url
@@ -217,6 +248,9 @@ class TestWorkflowTest < Minitest::Test
       <<~BASH
         #!/usr/bin/env bash
         printf '%s\n' "$*" > "$MOCK_CALLS"
+        if [ "$MOCK_MODE" = "fail" ]; then
+          exit 1
+        fi
         : > "$MOCK_STARTED"
       BASH
     )


### PR DESCRIPTION
## Summary

- treat HTTP error responses from the Steady health endpoint as unhealthy
- stop every process listening on the mock port while tolerating stale PIDs
- add focused regression coverage for startup, reuse, override, and cleanup behavior

## Evidence

Without `curl --fail`, an HTTP error response can be mistaken for a healthy mock server. `lsof -t` can also return multiple newline-delimited PIDs, and listeners can exit between discovery and cleanup.

## Blast radius and ownership

This changes only the handwritten local test launcher and its new workflow tests. It does not affect generated code, SDK runtime behavior, public APIs, type signatures, dependencies, serialization, transport, or release behavior.

## Validation

- `bash -n scripts/test`
- `bundle exec ruby -w test/scripts/test_workflow_test.rb` — 4 tests, 20 assertions
- script subsystem — 78 tests, 626 assertions
- `bundle exec rake lint` — RuboCop, rubyfmt, Sorbet, RBS, and directive validation passed
- `./scripts/test` — 1,091 tests, 9,822 assertions, 0 failures, 0 errors
- `git diff --check`
- thermo-nuclear code-quality review — no remaining findings