### PR TITLE
ci: preserve fast-format arguments

### DIFF
--- a/scripts/fast-format
+++ b/scripts/fast-format
@@ -6,13 +6,18 @@ echo "Script started with $# arguments"
 echo "Arguments: $*"
 echo "Script location: $(dirname "$0")"
 
-cd -- "$(dirname "$0")/.."
-echo "Changed to directory: $PWD"
-
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <file-with-paths> [additional-formatter-args...]"
     echo "The file should contain one file path per line"
     exit 1
 fi
 
-exec -- bundle exec rake format FORMAT_FILE="$1"
+path_list="$1"
+if [[ "$path_list" != /* ]]; then
+    path_list="$PWD/$path_list"
+fi
+
+cd -- "$(dirname "$0")/.."
+echo "Changed to directory: $PWD"
+
+exec -- bundle exec rake format FORMAT_FILE="$path_list" "${@:2}"

--- a/test/scripts/fast_format_test.rb
+++ b/test/scripts/fast_format_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "fileutils"
+require "json"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+class FastFormatTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  FAST_FORMAT = File.join(ROOT, "scripts/fast-format")
+
+  def test_resolves_relative_path_list_from_callers_directory
+    with_bundle_probe do |directory, executable_path|
+      path_list = "paths.txt"
+      File.write(File.join(directory, path_list), "example.rb\n")
+
+      invocation = invoke_fast_format(executable_path, directory, path_list)
+
+      assert_equal(ROOT, invocation.fetch("directory"))
+      assert_equal(
+        ["exec", "rake", "format", "FORMAT_FILE=#{File.join(directory, path_list)}"],
+        invocation.fetch("arguments")
+      )
+    end
+  end
+
+  def test_forwards_all_arguments_after_path_list
+    with_bundle_probe do |directory, executable_path|
+      path_list = File.join(directory, "paths.txt")
+      File.write(path_list, "example.rb\n")
+      additional_arguments = ["--trace", "FORMATTER_OPTION=value with spaces"]
+
+      invocation = invoke_fast_format(
+        executable_path,
+        directory,
+        path_list,
+        *additional_arguments
+      )
+
+      assert_equal(
+        ["exec", "rake", "format", "FORMAT_FILE=#{path_list}", *additional_arguments],
+        invocation.fetch("arguments")
+      )
+    end
+  end
+
+  private
+
+  def invoke_fast_format(executable_path, directory, *arguments)
+    env = {"PATH" => [executable_path, ENV.fetch("PATH")].join(File::PATH_SEPARATOR)}
+    stdout, stderr, status = Open3.capture3(env, FAST_FORMAT, *arguments, chdir: directory)
+
+    assert(status.success?, stderr)
+    JSON.parse(stdout.lines.last)
+  end
+
+  def with_bundle_probe
+    Dir.mktmpdir do |temporary_directory|
+      directory = File.join(temporary_directory, "caller")
+      executable_path = File.join(temporary_directory, "bin")
+      FileUtils.mkdir_p([directory, executable_path])
+      bundle = File.join(executable_path, "bundle")
+      File.write(
+        bundle,
+        <<~RUBY
+          #!#{RbConfig.ruby}
+          require "json"
+
+          puts JSON.generate("arguments" => ARGV, "directory" => Dir.pwd)
+        RUBY
+      )
+      FileUtils.chmod(0o755, bundle)
+
+      yield directory, executable_path
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- resolve relative path-list inputs before changing to the repository root
- forward every formatter argument after the path-list file
- add process-level regression coverage for both behaviors

## Scope and compatibility

Affected paths are scripts/fast-format and test/scripts/fast_format_test.rb. The direct consumer is the developer fast-format workflow. Both files are handwritten repository artifacts, not generated output. This does not change the public SDK API, runtime transport, wire formats, dependencies, supported Ruby versions, or generated code.

## Validation

- focused regression test: 2 runs, 5 assertions, passing
- script subsystem: 76 runs, 611 assertions, passing
- repository lint: 2,715 files, no offenses
- Sorbet: no errors
- RBS validation: 1,236 files, no errors
- Bash syntax and git diff --check: passing
- thermo-nuclear code-quality review: no findings
- full suite with the documented mock: 1,089 runs, 9,793 assertions, 0 failures, 1 pre-existing realtime proxy error; the identical 7-test/26-assertion error reproduces on base commit 8977731a59da0bddf7098a5c62e1916c40bc4a7c