### PR TITLE
fix(ci): update Bedrock lockfile during releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 
 - Prefer direct method calls over Ruby reflection (`send`, `__send__`, or `public_send`) for internal SDK plumbing. When an internal method must be callable across components without becoming supported public API, keep the method public for direct dispatch and mark it `@api private`. Keep its RBI and RBS declarations at the same visibility.
 
+## Release maintenance
+
+When regenerating `gemfiles/bedrock.gemfile.lock`, preserve the
+`x-release-please` markers around the local `openai` version. Release Please
+uses them to update this lockfile; Bundler can remove them when rewriting it.
+
 ## Security requirements
 
 - Never commit real API keys, access tokens, signing keys, credentials, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,10 @@ $ BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle install
 $ BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec rake test:bedrock
 ```
 
+When regenerating `gemfiles/bedrock.gemfile.lock`, preserve the
+`x-release-please` markers around the local `openai` version. Release Please
+uses them to update this lockfile; Bundler can remove them when rewriting it.
+
 ### Running examples end-to-end
 
 The live example suite executes every example marked as `covered` in

--- a/gemfiles/bedrock.gemfile.lock
+++ b/gemfiles/bedrock.gemfile.lock
@@ -11,7 +11,9 @@ GIT
 PATH
   remote: ..
   specs:
+  # x-release-please-start-version
     openai (0.80.0)
+  # x-release-please-end
       connection_pool (>= 2.2.3)
       logger
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -62,6 +62,7 @@
   "release-type": "ruby",
   "version-file": "lib/openai/version.rb",
   "extra-files": [
-    "README.md"
+    "README.md",
+    "gemfiles/bedrock.gemfile.lock"
   ]
 }

--- a/test/scripts/release_workflow_test.rb
+++ b/test/scripts/release_workflow_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "json"
+
+require_relative "../../lib/openai/version"
+
+class ReleaseWorkflowTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  BEDROCK_LOCKFILE = "gemfiles/bedrock.gemfile.lock"
+
+  def test_release_please_updates_bedrock_lockfile
+    config = JSON.parse(File.read(File.join(ROOT, "release-please-config.json")))
+    package = config.merge(config.fetch("packages").fetch("."))
+
+    assert_includes(package.fetch("extra-files"), BEDROCK_LOCKFILE)
+  end
+
+  def test_bedrock_release_markers_update_only_the_sdk_version
+    lockfile = File.read(File.join(ROOT, BEDROCK_LOCKFILE))
+    markers = %w[x-release-please-start-version x-release-please-end]
+    sdk_entry = "    openai (#{OpenAI::VERSION})"
+
+    assert_equal(markers, lockfile.scan(/x-release-please-[\w-]+/))
+    assert_includes(
+      lockfile,
+      "  # #{markers.first}\n#{sdk_entry}\n  # #{markers.last}\n",
+      "Restore the release-please markers around only the openai version after regenerating the lockfile"
+    )
+
+    # Simulate the generic updater's stable-version replacement inside marked blocks.
+    next_version = "#{OpenAI::VERSION.split(".").first.to_i + 1}.0.0"
+    updated = lockfile.gsub(/x-release-please-start-version\n.*?x-release-please-end/m) do |block|
+      block.gsub(/\d+\.\d+\.\d+/, next_version)
+    end
+
+    assert_equal(lockfile.sub(sdk_entry, "    openai (#{next_version})"), updated)
+  end
+end


### PR DESCRIPTION
## Summary

Release PR #434 bumps the SDK to 0.81.0, but leaves the Bedrock bundle's local `openai` gem at 0.80.0. Its [Bedrock CI job](https://github.com/openai/openai-ruby/actions/runs/32487334575/job/96788847028) fails during Ruby setup because Bundler refuses to change path-gem versions in frozen mode.

Register `gemfiles/bedrock.gemfile.lock` in Release Please's `extra-files` and mark only the local SDK version for replacement. The pinned Ruby strategy already updates the root lockfile; extra files use the generic, annotation-based updater. No runtime code or dependency versions change in this PR.

The contribution guide and agent instructions note that the markers must be preserved after a Bundler lockfile rewrite. Two small tests in `test/scripts/release_workflow_test.rb` enforce the effective `extra-files` entry, marker placement around only the SDK version, and stable-version replacement without dependency changes. The existing `rake test` discovery runs them in the regular Ruby CI jobs; no new dependencies or workflow steps are needed. After this merges into `main`, the next Release Please run can refresh #434 with the matching Bedrock version. This PR does not publish a release.

