### PR TITLE
chore: set a 4,000-line custom-code budget

### DIFF
--- a/.castiron-ratchet.json
+++ b/.castiron-ratchet.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "max_custom_patch_lines": 4000
+}


### PR DESCRIPTION
## Summary

Set a 4,000-line ceiling on additions **plus** deletions in the remaining custom patch against verified generated output. This is the budget-only foundation for the same rollout approved in [Python #3714](https://github.com/openai/openai-python/pull/3714) and [Python #3715](https://github.com/openai/openai-python/pull/3715).

The verified current patch is **+2,020 / −246 = 2,266 lines**, leaving **1,734 lines** of headroom. This is a generous bound on accidental growth, not a target or permission to add custom code.

Only `.castiron-ratchet.json` changes here. The stacked tooling PR will use the base-branch allowance, so a PR cannot raise its own budget. Future increases require a separate budget-only PR, explicit justification, and a human approving review; agents cannot approve them.

No workflow, CODEOWNERS, or ruleset changes are included. Ruleset enforcement is a separate, later decision.

Tooling companion: https://github.com/openai/openai-ruby/pull/511
