### PR TITLE
chore(api): refresh SDK generation metadata

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: 583272a0-0fce-4844-ac39-e45c70a15e7c
+generation_id: 5ab7c0df-1b0e-4726-b330-66fc16a4d92e
 openapi_spec_hash: 92700e1a33a4f6174a01b46648c8186a
 openapi_transformed_spec_hash: e37bbe0f04caa6093f1cb5d65d23ad03
-config_hash: d13c582815d0db08c374985806be7352
-codegen_sha: f6a3920247f03ab2a428fcd90c0b4628f9f91c53
+config_hash: beab4f058e80bab30085bb6c8467b65f
+codegen_sha: ee84ff7196fb28135d30ebe7a1c9fb86097a0c6e
 codegen_hash: 5d7050df9f0d5edfe18c060ff9755376b15be0ed7dabc1d09ddb0062dcdf8143
-public_codegen_sha: b57abc2f84a9c31d4651fc41d04f21d9d04fe6f9
+public_codegen_sha: e0ac50e69382b43efbc0e605a37b56d10dd65e83


### PR DESCRIPTION
## Summary

Refresh the SDK generation metadata after compiler and configuration updates. The only changed file is `.castiron.stats.yml`; Ruby source, tests, API-reference content, public types, and runtime behavior are unchanged.
