### PR TITLE
examples: validate stream resume prerequisites

### DIFF
--- a/examples/responses/streaming_previous_response.rb
+++ b/examples/responses/streaming_previous_response.rb
@@ -39,6 +39,9 @@ begin
     end
   end
 
+  abort("The initial stream completed without events") if events.empty?
+  abort("The initial stream did not include a response ID") if response_id.empty?
+
   puts("Collected #{events.length} events")
   puts("Response ID: #{response_id}")
   puts("Last event sequence number: #{events.last.sequence_number}.\n")
@@ -120,6 +123,9 @@ begin
       break
     end
   end
+
+  abort("The structured initial stream completed without events") if events.empty?
+  abort("The structured initial stream did not include a response ID") if response_id.empty?
 
   puts("Waiting for the background response to complete...\n")
   sleep(3)

--- a/test/openai/streaming_previous_response_example_test.rb
+++ b/test/openai/streaming_previous_response_example_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
+  extend Minitest::Serial
+
+  EXAMPLE_PATH = File.expand_path("../../examples/responses/streaming_previous_response.rb", __dir__)
+
+  def setup
+    super
+    @mocks = []
+    @sleeps = []
+    Thread.current.thread_variable_set(:mock_sleep, @sleeps)
+  end
+
+  def teardown
+    Thread.current.thread_variable_set(:mock_sleep, nil)
+    super
+  end
+
+  def test_plain_stream_fails_before_waiting_when_initial_stream_is_empty
+    _stdout, stderr, error, requests = run_example([{stream: []}])
+
+    assert_failure(error, stderr, "The initial stream completed without events")
+    assert_equal(1, requests.length)
+    assert_empty(@sleeps)
+  end
+
+  def test_plain_stream_fails_before_waiting_when_created_event_is_missing
+    _stdout, stderr, error, requests = run_example([{stream: [in_progress_event(sequence_number: 1)]}])
+
+    assert_failure(error, stderr, "The initial stream did not include a response ID")
+    assert_equal(1, requests.length)
+    assert_empty(@sleeps)
+  end
+
+  def test_plain_stream_fails_before_waiting_when_response_id_is_empty
+    _stdout, stderr, error, requests = run_example([{stream: [created_event(id: "", sequence_number: 1)]}])
+
+    assert_failure(error, stderr, "The initial stream did not include a response ID")
+    assert_equal(1, requests.length)
+    assert_empty(@sleeps)
+  end
+
+  def test_structured_stream_fails_before_waiting_when_initial_stream_is_empty
+    streams = plain_successful_streams + [{stream: []}]
+    _stdout, stderr, error, requests = run_example(streams)
+
+    assert_failure(error, stderr, "The structured initial stream completed without events")
+    assert_equal(3, requests.length)
+    assert_equal([3], @sleeps)
+  end
+
+  def test_structured_stream_fails_before_waiting_when_created_event_is_missing
+    streams = plain_successful_streams + [{stream: [in_progress_event(sequence_number: 7)]}]
+    _stdout, stderr, error, requests = run_example(streams)
+
+    assert_failure(error, stderr, "The structured initial stream did not include a response ID")
+    assert_equal(3, requests.length)
+    assert_equal([3], @sleeps)
+  end
+
+  def test_structured_stream_fails_before_waiting_when_response_id_is_empty
+    streams = plain_successful_streams + [{stream: [created_event(id: "", sequence_number: 7)]}]
+    _stdout, stderr, error, requests = run_example(streams)
+
+    assert_failure(error, stderr, "The structured initial stream did not include a response ID")
+    assert_equal(3, requests.length)
+    assert_equal([3], @sleeps)
+  end
+
+  def test_both_streams_resume_with_captured_ids_and_preserve_structured_output
+    structured_stream = Minitest::Mock.new
+    final_response = Minitest::Mock.new
+    output_message = Minitest::Mock.new
+    output_content = Minitest::Mock.new
+    @mocks.push(structured_stream, final_response, output_message, output_content)
+
+    structured_stream.expect(:each, nil) do |&callback|
+      callback.call(in_progress_event(sequence_number: 8))
+      true
+    end
+
+    structured_stream.expect(:get_final_response, final_response)
+    final_response.expect(:output, [output_message])
+    output_message.expect(:content, [output_content])
+
+    streams = plain_successful_streams +
+      [
+        {stream: [created_event(id: "resp_structured", sequence_number: 7)]},
+        {
+          stream: structured_stream,
+          check: lambda do |params|
+            assert_equal("resp_structured", params.fetch(:response_id))
+            assert_equal(7, params.fetch(:starting_after))
+
+            math_response = params.fetch(:text).new(steps: [], final_answer: "-29/8")
+            output_content.expect(:parsed, math_response)
+          end
+        }
+      ]
+
+    stdout, stderr, error, requests = run_example(streams)
+
+    assert_nil(error)
+    assert_empty(stderr)
+    assert_equal(4, requests.length)
+    assert_equal([3, 3], @sleeps)
+    assert_includes(stdout, "Verified it is greater than the last initial event: 1")
+    assert_includes(stdout, "-29/8")
+  end
+
+  private
+
+  def run_example(streams)
+    responses = Minitest::Mock.new
+    client = Minitest::Mock.new
+    @mocks.push(responses, client)
+    requests = []
+
+    streams.each do |entry|
+      client.expect(:responses, responses)
+      responses.expect(:stream, entry.fetch(:stream)) do |**params|
+        requests << params
+        entry[:check]&.call(params)
+        true
+      end
+    end
+
+    exit_error = nil
+    stdout, stderr = capture_io do
+      OpenAI::Client.stub(:new, client) do
+        load(EXAMPLE_PATH, true)
+      rescue SystemExit => error
+        exit_error = error
+      end
+    end
+
+    @mocks.each(&:verify)
+
+    [stdout, stderr, exit_error, requests]
+  end
+
+  def plain_successful_streams
+    [
+      {stream: [created_event(id: "resp_plain", sequence_number: 1)]},
+      {
+        stream: [in_progress_event(sequence_number: 2)],
+        check: lambda do |params|
+          assert_equal("resp_plain", params.fetch(:response_id))
+          assert_equal(1, params.fetch(:starting_after))
+        end
+      }
+    ]
+  end
+
+  def created_event(id:, sequence_number:)
+    response = OpenAI::Models::Responses::Response.new(id: id)
+    OpenAI::Models::Responses::ResponseCreatedEvent.new(response: response, sequence_number: sequence_number)
+  end
+
+  def in_progress_event(sequence_number:)
+    OpenAI::Models::Responses::ResponseInProgressEvent.new(response: {}, sequence_number: sequence_number)
+  end
+
+  def assert_failure(error, stderr, message)
+    assert_instance_of(SystemExit, error)
+    assert_equal(1, error.status)
+    assert_equal("#{message}\n", stderr)
+  end
+end


### PR DESCRIPTION
## Summary

- Fail fast when either previous-response streaming example receives no initial events, before dereferencing the final event or sleeping.
- Require a captured, nonempty response ID in both the plain and structured examples before issuing a resumed request.
- Preserve successful resume sequencing and structured parsed-output validation with deterministic, network-free regression coverage.

## Evidence and scope

- Before the fix, the new regression suite produced six errors: empty initial streams raised `NoMethodError`, while missing created events or empty response IDs attempted an invalid resumed request.
- The existing successful plain/structured resume characterization passed before and after the fix.
- Blast radius: one handwritten, generator-exempt example and its own new example-specific test file; no generated SDK code, shared streaming/transport behavior, API contracts, dependencies, or serialization changes.
- Generator ownership: `CONTRIBUTING.md` explicitly identifies `examples/` as handwritten and never modified by the generator; wholly handwritten files are outside the Castiron custom-code budget.
- Compatibility: no public SDK/API changes; the successful example flows and parsed-output validation are unchanged.

## Verification

- Ruby 4.0.6 focused regression suite: `bundle exec ruby test/openai/streaming_previous_response_example_test.rb` — 7 tests, 52 assertions.
- Ruby 3.3.12 and 3.4.10 focused regression suites: the same 7 tests and 52 assertions pass on both supported minors.
- Responses streaming subsystem: `bundle exec ruby test/openai/resources/responses/streaming_test.rb` — 25 tests, 95 assertions.
- Existing handwritten-example characterization: `bundle exec ruby test/openai/structured_outputs_responses_function_calling_example_test.rb` — 3 tests, 17 assertions.
- Full suite: `TMPDIR=/private/tmp ./scripts/test` — 1,198 tests, 10,645 assertions, 0 failures/errors, 1 existing skip. Canonical `TMPDIR` avoids an unrelated existing macOS `/var` versus `/private/var` expectation in `FastFormatTest` without changing repository code.
- Complete lint/type checks: `bundle exec rake lint` — Sorbet clean, 1,239 RBS files validated, and 2,747 Ruby files inspected with no RuboCop offenses.
- Offline example inventory: `bundle exec rake test:examples:inventory`.
- Castiron custom-code checker regression suite: `python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'` — 51 tests passed, 1 existing skip.
- Trusted committed-head Castiron budget check: `python3 -B -I scripts/castiron/custom_code_budget.py check --repo /path/to/sdk --base edfb30b2973d68b4a19ce3f86f1de7313f730702 --head 579672e64a25c4c94fb068abe3ed4a65974a40db --public --fetch --out /tmp/custom-code-budget` — isolation passed; 2,659 custom lines under the 4,000-line limit, with 1,341 lines of headroom.
- Focused Ruby formatting and RuboCop checks, `git diff --check`, exact-base path/scope review, extensive general review, and thermo-nuclear maintainability review.
