### PR TITLE
examples: validate parsed chat completion events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Contributor instructions
 
+## Commit conventions
+
+- Use the `examples:` Conventional Commit prefix for changes whose primary
+  purpose is updating or fixing examples, including their dedicated tests. Apply
+  the same prefix to pull request titles; do not use `fix:` or `fix(examples):`
+  for these changes.
+
 ## Ruby implementation guidelines
 
 - Prefer direct method calls over Ruby reflection (`send`, `__send__`, or `public_send`) for internal SDK plumbing. When an internal method must be callable across components without becoming supported public API, keep the method public for direct dispatch and mark it `@api private`. Keep its RBI and RBS declarations at the same visibility.

--- a/examples/structured_outputs_chat_completions.rb
+++ b/examples/structured_outputs_chat_completions.rb
@@ -50,10 +50,16 @@ chat_completion = client.chat.completions.create(
   response_format: CalendarEvent
 )
 
-chat_completion
-  .choices
-  .reject { _1.message.refusal }
-  .each do |choice|
-    # parsed is an instance of `CalendarEvent`
-    pp(choice.message.parsed)
+parsed_events = chat_completion.choices.filter_map do |choice|
+  next if choice.message.refusal
+
+  parsed = choice.message.parsed
+  case parsed
+  when CalendarEvent
+    parsed
   end
+end
+
+abort("The response did not contain a parsed CalendarEvent") if parsed_events.empty?
+
+parsed_events.each { pp(_1) }

--- a/test/openai/structured_outputs_chat_completions_example_test.rb
+++ b/test/openai/structured_outputs_chat_completions_example_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::StructuredOutputsChatCompletionsExampleTest < Minitest::Test
+  extend Minitest::Serial
+
+  EXAMPLE_PATH = File.expand_path("../../examples/structured_outputs_chat_completions.rb", __dir__)
+
+  def test_prints_parsed_calendar_event
+    stdout, stderr, exit_error = run_example do |event_model|
+      [choice(parsed: calendar_event(event_model))]
+    end
+
+    assert_nil(exit_error)
+    assert_empty(stderr)
+    assert_includes(stdout, "CalendarEvent")
+    assert_includes(stdout, "Science fair")
+  end
+
+  def test_fails_clearly_when_completion_has_no_choices
+    assert_missing_calendar_event { [] }
+  end
+
+  def test_fails_clearly_when_every_choice_is_refused
+    assert_missing_calendar_event do |event_model|
+      [choice(parsed: calendar_event(event_model), refusal: "I cannot help with that")]
+    end
+  end
+
+  def test_fails_clearly_when_parsed_value_is_nil
+    assert_missing_calendar_event { [choice(parsed: nil)] }
+  end
+
+  def test_fails_clearly_when_parsed_value_has_the_wrong_shape
+    assert_missing_calendar_event { [choice(parsed: {name: "Science fair"})] }
+  end
+
+  def test_fails_clearly_when_parsed_value_is_another_model
+    assert_missing_calendar_event do
+      message = OpenAI::Models::Chat::ChatCompletionMessage.new(content: nil, refusal: nil)
+      [choice(parsed: message)]
+    end
+  end
+
+  def test_ignores_refused_and_invalid_choices_and_prints_each_calendar_event
+    stdout, stderr, exit_error = run_example do |event_model|
+      [
+        choice(parsed: calendar_event(event_model, name: "Refused event"), refusal: "No"),
+        choice(parsed: nil),
+        choice(parsed: {name: "Wrong shape"}),
+        choice(parsed: calendar_event(event_model, name: "Science fair")),
+        choice(parsed: calendar_event(event_model, name: "Team lunch"))
+      ]
+    end
+
+    assert_nil(exit_error)
+    assert_empty(stderr)
+    assert_equal(2, stdout.scan("CalendarEvent").length)
+    assert_includes(stdout, "Science fair")
+    assert_includes(stdout, "Team lunch")
+    refute_includes(stdout, "Refused event")
+    refute_includes(stdout, "Wrong shape")
+  end
+
+  def test_fails_clearly_when_mixed_choices_have_no_valid_calendar_event
+    assert_missing_calendar_event do |event_model|
+      [
+        choice(parsed: calendar_event(event_model), refusal: "No"),
+        choice(parsed: nil),
+        choice(parsed: {name: "Wrong shape"})
+      ]
+    end
+  end
+
+  private
+
+  def assert_missing_calendar_event(&choices)
+    stdout, stderr, exit_error = run_example(&choices)
+
+    assert_instance_of(SystemExit, exit_error)
+    assert_equal(1, exit_error.status)
+    assert_empty(stdout)
+    assert_equal("The response did not contain a parsed CalendarEvent\n", stderr)
+  end
+
+  def run_example(&choices)
+    mocks = []
+    constructor = lambda do
+      response = Minitest::Mock.new
+
+      completions = Minitest::Mock.new
+      completions.expect(:create, response) do |**params|
+        response.expect(:choices, choices.call(params.fetch(:response_format)))
+        true
+      end
+
+      chat = Minitest::Mock.new
+      chat.expect(:completions, completions)
+
+      client = Minitest::Mock.new
+      client.expect(:chat, chat)
+      mocks.push(response, completions, chat, client)
+      client
+    end
+
+    exit_error = nil
+    stdout, stderr = capture_io do
+      OpenAI::Client.stub(:new, constructor) do
+        load(EXAMPLE_PATH, true)
+      rescue SystemExit => error
+        exit_error = error
+      end
+    end
+
+    mocks.each(&:verify)
+
+    [stdout, stderr, exit_error]
+  end
+
+  def choice(parsed:, refusal: nil)
+    OpenAI::Models::Chat::ParsedChoice.new(
+      finish_reason: :stop,
+      index: 0,
+      logprobs: nil,
+      message: OpenAI::Models::Chat::ChatCompletionMessage.new(
+        content: nil,
+        parsed: parsed,
+        refusal: refusal
+      )
+    )
+  end
+
+  def calendar_event(event_model, name: "Science fair")
+    event_model.new(
+      name: name,
+      date: "Friday",
+      participants: [],
+      optional_participants: nil,
+      is_virtual: false,
+      location: nil
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- Print only actual `CalendarEvent` instances from the handwritten structured-output Chat Completions example, preserving existing successful output and refusal handling.
- Exit with `The response did not contain a parsed CalendarEvent` when choices are empty, all refused, or contain only nil/wrong-type parsed values.
- Add eight isolated regression and characterization tests using the existing example-loading conventions, Minitest client mocks, and real SDK choice/message models.
- Document `examples:` as the required Conventional Commit prefix for example-focused commits and pull request titles.

## Evidence and scope

The new regression suite failed 7 of 8 tests against the unchanged example: empty choices and refused/invalid values exited successfully, while mixed invalid values were printed. This change is limited to one handwritten, generator-independent example, its dedicated new test, and a concise `AGENTS.md` contributor-guidance clarification. It does not modify generated SDK code, response parsing, model behavior, transport, authentication, serialization, public APIs, dependencies, or CI.

## Validation

- `mise exec ruby@3.3.12 -- ./scripts/test` — 1,199 tests, 10,642 assertions, 0 failures, 1 existing skip.
- `mise exec ruby@3.4.10 -- ./scripts/test` — 1,199 tests, 10,642 assertions, 0 failures, 1 existing skip.
- `mise exec ruby@4.0.6 -- ./scripts/test` — 1,199 tests, 10,642 assertions, 0 failures, 1 existing skip.
- Focused example regression suite on Ruby 3.3, 3.4, and 4.0 — 8 tests, 49 assertions each.
- `TEST='test/openai/structured_outputs*_test.rb' mise exec ruby@4.0.6 -- bundle exec rake test` — 11 tests, 66 assertions.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop, rubyfmt, directive validation, Sorbet, and 1,239 RBS files pass.
- `python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'` — 51 tests pass, 1 existing skip.
- `python3 -B -I scripts/castiron/custom_code_budget.py check --repo . --base edfb30b2973d68b4a19ce3f86f1de7313f730702 --head c6d841f36e78e318841df10735dce2e187ed310e --public --out /private/tmp/openai-ruby-calendar-event-custom-budget-v2` — 2,659 / 4,000 custom lines; budget and isolation pass.
- `bundle exec rake test:examples:inventory`, `git diff --check`, pinned-base scope review, extensive general review, and thermo-nuclear maintainability review all pass.

Local runs used the existing cached bundle for each Ruby version and `TMPDIR=/private/tmp` to avoid the pre-existing macOS `/var` versus `/private/var` path-alias issue in formatter tests.
