### PR TITLE
examples: validate parsed chat function tool calls

### DIFF
--- a/examples/structured_outputs_chat_completions_function_calling.rb
+++ b/examples/structured_outputs_chat_completions_function_calling.rb
@@ -23,6 +23,7 @@ chat_completion = client.chat.completions.create(
   tool_choice: {type: :function, function: {name: "GetWeather"}}
 )
 
+parsed_tool_call_count = 0
 chat_completion
   .choices
   .reject { _1.message.refusal }
@@ -31,8 +32,12 @@ chat_completion
     case tool_call
     when OpenAI::Chat::ChatCompletionMessageFunctionToolCall
       # parsed is an instance of `GetWeather`
-      pp(tool_call.function.parsed)
-    else
-      puts("Unexpected tool call type: #{tool_call.type}")
+      parsed = tool_call.function.parsed
+      next unless GetWeather === parsed
+
+      parsed_tool_call_count += 1
+      pp(parsed)
     end
   end
+
+abort("The chat completion did not contain a parsed GetWeather tool call") if parsed_tool_call_count.zero?

--- a/test/openai/structured_outputs_chat_completions_function_calling_example_test.rb
+++ b/test/openai/structured_outputs_chat_completions_function_calling_example_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::StructuredOutputsChatCompletionsFunctionCallingExampleTest < Minitest::Test
+  extend Minitest::Serial
+
+  EXAMPLE_PATH = File.expand_path(
+    "../../examples/structured_outputs_chat_completions_function_calling.rb",
+    __dir__
+  )
+  FAILURE_MESSAGE = "The chat completion did not contain a parsed GetWeather tool call\n"
+
+  def test_prints_parsed_get_weather_function_tool_calls
+    stdout, stderr, exit_error = run_example do |weather_model|
+      [choice(tool_calls: [function_tool_call(parsed: weather_model.new(location: "Paris, France"))])]
+    end
+
+    assert_nil(exit_error)
+    assert_empty(stderr)
+    assert_includes(stdout, "GetWeather")
+    assert_includes(stdout, "Paris, France")
+  end
+
+  def test_fails_clearly_when_chat_completion_has_no_choices
+    assert_missing_parsed_tool_call { [] }
+  end
+
+  def test_fails_clearly_when_every_choice_is_refused
+    assert_missing_parsed_tool_call do |weather_model|
+      [
+        choice(
+          refusal: "I cannot provide a weather forecast.",
+          tool_calls: [function_tool_call(parsed: weather_model.new(location: "Paris, France"))]
+        )
+      ]
+    end
+  end
+
+  def test_fails_clearly_when_choices_have_no_tool_calls
+    assert_missing_parsed_tool_call { [choice] }
+  end
+
+  def test_fails_clearly_when_function_tool_call_has_the_wrong_parsed_type
+    assert_missing_parsed_tool_call do
+      [choice(tool_calls: [function_tool_call(parsed: {location: "Paris, France"})])]
+    end
+  end
+
+  def test_fails_clearly_when_tool_calls_do_not_include_a_function
+    assert_missing_parsed_tool_call do
+      [choice(tool_calls: [custom_tool_call])]
+    end
+  end
+
+  def test_ignores_refusals_nonmatching_calls_and_wrong_parsed_values
+    stdout, stderr, exit_error = run_example do |weather_model|
+      [
+        choice(
+          refusal: "I cannot provide a weather forecast.",
+          tool_calls: [function_tool_call(parsed: weather_model.new(location: "Refused City"))]
+        ),
+        choice(
+          tool_calls: [
+            custom_tool_call,
+            function_tool_call(parsed: {location: "Wrong City"}),
+            function_tool_call(parsed: weather_model.new(location: "Paris, France"))
+          ]
+        )
+      ]
+    end
+
+    assert_nil(exit_error)
+    assert_empty(stderr)
+    assert_includes(stdout, "GetWeather")
+    assert_includes(stdout, "Paris, France")
+    refute_includes(stdout, "Refused City")
+    refute_includes(stdout, "Wrong City")
+    refute_includes(stdout, "Unexpected tool call type")
+  end
+
+  private
+
+  def assert_missing_parsed_tool_call(&choices)
+    stdout, stderr, exit_error = run_example(&choices)
+
+    assert_instance_of(SystemExit, exit_error)
+    assert_equal(1, exit_error.status)
+    assert_empty(stdout)
+    assert_equal(FAILURE_MESSAGE, stderr)
+  end
+
+  def run_example(&choices)
+    mocks = []
+    constructor = lambda do
+      chat_completion = Minitest::Mock.new
+
+      completions = Minitest::Mock.new
+      completions.expect(:create, chat_completion) do |**params|
+        chat_completion.expect(:choices, choices.call(params.fetch(:tools).fetch(0)))
+        true
+      end
+
+      chat = Minitest::Mock.new
+      chat.expect(:completions, completions)
+
+      client = Minitest::Mock.new
+      client.expect(:chat, chat)
+
+      mocks.push(chat_completion, completions, chat, client)
+      client
+    end
+
+    exit_error = nil
+    stdout, stderr = capture_io do
+      OpenAI::Client.stub(:new, constructor) do
+        load(EXAMPLE_PATH, true)
+      rescue SystemExit => error
+        exit_error = error
+      end
+    end
+
+    mocks.each(&:verify)
+
+    [stdout, stderr, exit_error]
+  end
+
+  def choice(tool_calls: [], refusal: nil)
+    message = OpenAI::Chat::ChatCompletionMessage.new(
+      content: nil,
+      refusal: refusal,
+      tool_calls: tool_calls
+    )
+
+    OpenAI::Chat::ChatCompletion::Choice.new(
+      finish_reason: :tool_calls,
+      index: 0,
+      logprobs: nil,
+      message: message
+    )
+  end
+
+  def function_tool_call(parsed:)
+    OpenAI::Chat::ChatCompletionMessageFunctionToolCall.new(
+      id: "function_1",
+      function: OpenAI::Chat::ChatCompletionMessageFunctionToolCall::Function.new(
+        arguments: JSON.generate(location: "Paris, France"),
+        name: "GetWeather",
+        parsed: parsed
+      )
+    )
+  end
+
+  def custom_tool_call
+    OpenAI::Chat::ChatCompletionMessageCustomToolCall.new(
+      id: "custom_1",
+      custom: {input: "ignored", name: "OtherTool"}
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- Require the handwritten structured-output Chat Completions function-calling example to observe at least one real function tool call whose parsed arguments are a `GetWeather` instance.
- Preserve successful weather output and refusal filtering while silently ignoring custom tools and incorrectly parsed values; abort with a deterministic explanation when no matching call exists.
- Add seven isolated, offline regression cases using the existing Responses sibling's wrapped-example loading and verified Minitest mocking patterns.

## Evidence and scope

- The new regression suite failed six of seven cases before the example fix: empty choices, all-refused choices, absent tool calls, incorrect parsed values, custom-only calls, and mixed/nonmatching output.
- Only `examples/structured_outputs_chat_completions_function_calling.rb` and its uniquely named regression-test file change.
- `CONTRIBUTING.md` explicitly identifies `examples/` as handwritten and never modified by the generator; no generated SDK, API contract, transport, authentication, serialization, dependency, or shared example code changes.
- Existing successful function-call output is preserved. `GetWeather === parsed` keeps normal Ruby class matching compatible with this example's `# typed: strong` Sorbet contract.

## Validation

- `bundle exec ruby test/openai/structured_outputs_chat_completions_function_calling_example_test.rb` on Ruby 3.3.12, 3.4.10, and 4.0.6: seven tests and 45 assertions pass on every supported minor.
- `TEST='test/openai/structured_outputs_*function_calling_example_test.rb' bundle exec rake test`: 10 Chat/Responses sibling tests and 62 assertions pass; the offline example inventory also passes.
- `TMPDIR=/private/tmp bundle exec rake test`: 1,198 tests and 10,638 assertions pass, with one existing skip. The explicit temporary directory avoids an unrelated existing macOS `/var` versus `/private/var` path comparison.
- `TMPDIR=/private/tmp bundle exec rake lint`: full rubyfmt, RuboCop (2,747 files), suppression guard, Sorbet, and 1,239 RBS signature validations pass.
- `python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'`: 51 Castiron tests pass, with one existing skip.
- Trusted-main custom-code budget check against base `edfb30b2973d68b4a19ce3f86f1de7313f730702` and head `ddb6323202c067245cad9658002a345d27849f8f`: isolation and budget pass at 2,659 / 4,000 lines.
- Focused Ruby formatting/RuboCop checks, extensive general review, thermo-nuclear maintainability review, `git diff --check`, and protected-base scope review all pass.
