### PR TITLE
fix(auth): harden X.509 refresh and request credential boundaries

### DIFF
--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -29,6 +29,8 @@ module OpenAI
         @cached_token_expires_at_monotonic = nil
         @cached_token_refresh_at_monotonic = nil
         @refreshing = false
+        @refresh_generation = nil
+        @refresh_error = nil
         @mutex = Mutex.new
         @cond_var = ConditionVariable.new
       end
@@ -41,6 +43,7 @@ module OpenAI
         check_deadline!(deadline)
         action = nil
         token = nil
+        generation = nil
 
         # Installing refresh cleanup is part of the state transition. No async
         # exception may observe @refreshing after it changes but before the ensure.
@@ -49,12 +52,15 @@ module OpenAI
             if @refreshing
               if token_unusable?
                 action = :wait
+                generation = @refresh_generation
               else
                 token = @cached_token
                 action = :return
               end
             elsif token_unusable? || needs_refresh?
               @refreshing = true
+              generation = {complete: false, error: nil, token: nil, expires_at: nil}
+              @refresh_generation = generation
               action = :refresh
             else
               token = @cached_token
@@ -68,8 +74,21 @@ module OpenAI
                 perform_refresh(deadline: deadline)
               end
 
+            rescue StandardError => error
+              @mutex.synchronize do
+                @refresh_error = error unless @token_exchange.nil?
+                generation[:error] = error
+              end
+
+              raise
             ensure
               @mutex.synchronize do
+                if generation[:error].nil?
+                  generation[:token] = @cached_token
+                  generation[:expires_at] = @cached_token_expires_at_monotonic
+                end
+
+                generation[:complete] = true
                 @refreshing = false
                 @cond_var.broadcast
               end
@@ -78,18 +97,27 @@ module OpenAI
         end
 
         return token if action == :return
-        return wait_for_refresh(deadline) if action == :wait
+        return wait_for_refresh(deadline, generation) if action == :wait
 
         current_token(deadline)
       end
 
       # @api private
-      def invalidate_token
+      def invalidate_token(rejected_token = nil)
         @mutex.synchronize do
+          return nil unless rejected_token.nil? || rejected_token == @cached_token
+
           @cached_token = nil
           @cached_token_expires_at_monotonic = nil
           @cached_token_refresh_at_monotonic = nil
         end
+      end
+
+      # Avoid exposing cached access tokens or identity configuration in diagnostics.
+      #
+      # @return [String]
+      def inspect
+        "#<#{self.class.name}:0x#{object_id.to_s(16)}>"
       end
 
       private def current_token(deadline)
@@ -101,9 +129,9 @@ module OpenAI
         end
       end
 
-      private def wait_for_refresh(deadline)
+      private def wait_for_refresh(deadline, generation)
         @mutex.synchronize do
-          while @refreshing
+          until generation.fetch(:complete)
             remaining = remaining_timeout(deadline)
             if remaining.nil?
               @cond_var.wait(@mutex)
@@ -113,6 +141,22 @@ module OpenAI
           end
 
           check_deadline!(deadline)
+          if @token_exchange
+            raise generation.fetch(:error) if generation[:error]
+            if generation[:token]
+              unless generation[:token] == @cached_token
+                raise_refresh_error! if token_unusable?
+
+                return @cached_token
+              end
+
+              expires_at = generation.fetch(:expires_at)
+              raise_refresh_error! if expires_at.nil? || OpenAI::Internal::Util.monotonic_secs >= expires_at
+
+              return generation.fetch(:token)
+            end
+          end
+
           raise_refresh_error! if token_unusable?
 
           @cached_token
@@ -139,6 +183,7 @@ module OpenAI
         expires_in = token_data.fetch(:expires_in)
 
         @mutex.synchronize do
+          @refresh_error = nil
           @cached_token = token_data.fetch(:id)
           @cached_token_expires_at_monotonic = now + expires_in
           @cached_token_refresh_at_monotonic = now + refresh_delay_seconds(expires_in)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -175,22 +175,31 @@ module OpenAI
     #
 
     # @api private
-    private def prepare_request(request, redirect_count:, retry_count:)
-      if @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
-        canonical_headers = @requester.validate_api_request!(
-          url: request.fetch(:url),
-          headers: request.fetch(:headers)
-        )
-        authorization = canonical_headers["authorization"]
-        expected = "Bearer #{WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}"
-        admin_authorization = @admin_api_key && "Bearer #{@admin_api_key}"
-        unless authorization == expected || (admin_authorization && authorization == admin_authorization)
-          raise OpenAI::Errors::Error, "X.509 requests cannot override the selected authorization credential"
-        end
-
-        request = request.merge(headers: canonical_headers)
+    private def build_request(request, options)
+      unless @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
+        return super
       end
 
+      selected = request.fetch(:security, {bearer_auth: true, admin_api_key_auth: true})
+      security = {
+        bearer_auth: selected[:bearer_auth] == true,
+        admin_api_key_auth: selected[:admin_api_key_auth] == true
+      }.freeze
+      expected = auth_headers(security: security)["authorization"]
+      built = super(request.merge(security: security), options)
+      canonical_headers = @requester.validate_api_request!(
+        url: built.fetch(:url),
+        headers: built.fetch(:headers)
+      )
+      unless expected == canonical_headers["authorization"]
+        raise OpenAI::Errors::Error, "X.509 requests cannot override the selected authorization credential"
+      end
+
+      built.merge(headers: canonical_headers)
+    end
+
+    # @api private
+    private def prepare_request(request, redirect_count:, retry_count:)
       request = prepare_workload_identity_request(request) if workload_identity_request?(request)
       preparer = @provider_runtime&.prepare_request
       return super(request, redirect_count: redirect_count, retry_count: retry_count) unless preparer
@@ -198,11 +207,61 @@ module OpenAI
     end
 
     # @api private
+    private def validate_prepared_request(request, original_request:)
+      prepared_request = super
+      return prepared_request unless @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
+
+      canonical_headers = @requester.validate_api_request!(
+        url: prepared_request.fetch(:url),
+        headers: prepared_request.fetch(:headers)
+      )
+      expected = if (context = original_request[:x509_request_context])
+        "Bearer #{context.fetch(:token)}"
+      else
+        original_request.fetch(:headers)["authorization"]
+      end
+
+      unless canonical_headers["authorization"] == expected
+        raise OpenAI::Errors::Error, "X.509 requests cannot override the selected authorization credential"
+      end
+
+      prepared_request.merge(headers: canonical_headers)
+    end
+
+    # @api private
     private def send_request(request, redirect_count:, retry_count:, send_retry_header:)
+      if @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
+        canonical_headers = @requester.validate_api_request!(
+          url: request.fetch(:url),
+          headers: request.fetch(:headers)
+        )
+        request = request.merge(headers: canonical_headers)
+        authorization = canonical_headers["authorization"]
+        expected = "Bearer #{WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}"
+        admin_authorization = @admin_api_key && "Bearer #{@admin_api_key}"
+        unless authorization.nil? || authorization == expected || authorization == admin_authorization
+          raise OpenAI::Errors::Error, "X.509 requests cannot override the selected authorization credential"
+        end
+      end
+
       return super unless workload_identity_request?(request)
 
-      deadline = request[:timeout]&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
+      x509_request = @requester.instance_of?(OpenAI::Auth::X509Transport)
+      previous_context = request[:x509_request_context]
+      deadline = if x509_request
+        previous_context&.fetch(:deadline) ||
+          request[:workload_identity_deadline] ||
+          request[:timeout]&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
+      else
+        request[:timeout]&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
+      end
+
       request = request.merge(workload_identity_deadline: deadline)
+      if x509_request
+        replay_state = previous_context&.fetch(:replay_state) || []
+        context = {deadline: deadline, replay_state: replay_state, token: nil}
+        request = request.merge(x509_request_context: context)
+      end
 
       begin
         super(
@@ -212,15 +271,31 @@ module OpenAI
           send_retry_header: send_retry_header
         )
       rescue OpenAI::Errors::AuthenticationError
-        raise unless retry_count.zero? && request_replayable?(request)
-        @workload_identity_auth.invalidate_token
+        @workload_identity_auth.invalidate_token(context.fetch(:token)) if x509_request
+        replay_allowed = retry_count.zero? && request_replayable?(request)
+        replay_allowed &&= replay_state.empty? if x509_request
+        raise unless replay_allowed
 
-        super(
-          request,
-          redirect_count: redirect_count,
-          retry_count: retry_count + 1,
-          send_retry_header: send_retry_header
-        )
+        if x509_request
+          replay_state << true
+          replay_state.freeze
+          context = {deadline: deadline, replay_state: replay_state, token: nil}
+          request = request.merge(x509_request_context: context)
+        else
+          @workload_identity_auth.invalidate_token
+        end
+
+        begin
+          super(
+            request,
+            redirect_count: redirect_count,
+            retry_count: retry_count + 1,
+            send_retry_header: send_retry_header
+          )
+        rescue OpenAI::Errors::AuthenticationError
+          @workload_identity_auth.invalidate_token(context.fetch(:token)) if x509_request
+          raise
+        end
       end
     end
 
@@ -234,9 +309,14 @@ module OpenAI
     private def prepare_workload_identity_request(request)
       deadline = request[:workload_identity_deadline]
       token = @workload_identity_auth.get_token(deadline: deadline)
+      if (context = request[:x509_request_context])
+        context[:token] = token.dup.freeze
+        context.freeze
+      end
+
       updated_headers = request[:headers].merge("authorization" => "Bearer #{token}")
       request_with_remaining_timeout(
-        request.except(:workload_identity_deadline).merge(headers: updated_headers),
+        request.except(:workload_identity_deadline, :x509_request_context).merge(headers: updated_headers),
         deadline
       )
     rescue Timeout::Error => e

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -352,6 +352,13 @@ module OpenAI
           request
         end
 
+        # Validate the effective request after all per-attempt preparation hooks.
+        #
+        # @api private
+        private def validate_prepared_request(request, **_context)
+          request
+        end
+
         # @api private
         #
         # @return [String]
@@ -588,10 +595,13 @@ module OpenAI
               headers: encoded_headers.transform_values(&:dup),
               body: encoded_body
             )
-            prepared_request = prepare_request(
-              attempt_request,
-              redirect_count: redirect_count,
-              retry_count: retry_count
+            prepared_request = validate_prepared_request(
+              prepare_request(
+                attempt_request,
+                redirect_count: redirect_count,
+                retry_count: retry_count
+              ),
+              original_request: request
             )
 
             prepared_url = prepared_request.fetch(:url)

--- a/rbi/openai/auth.rbi
+++ b/rbi/openai/auth.rbi
@@ -58,8 +58,12 @@ module OpenAI
       def get_token(deadline: nil)
       end
 
-      sig { void }
-      def invalidate_token
+      sig { params(rejected_token: T.nilable(String)).void }
+      def invalidate_token(rejected_token = nil)
+      end
+
+      sig { returns(String) }
+      def inspect
       end
     end
   end

--- a/rbi/openai/client.rbi
+++ b/rbi/openai/client.rbi
@@ -148,6 +148,18 @@ module OpenAI
     private def prepare_request(request, redirect_count:, retry_count:)
     end
 
+    # @api private
+    sig do
+      override
+        .params(
+          request: OpenAI::Internal::Transport::BaseClient::RequestInput,
+          original_request: OpenAI::Internal::Transport::BaseClient::RequestInput
+        )
+        .returns(OpenAI::Internal::Transport::BaseClient::RequestInput)
+    end
+    private def validate_prepared_request(request, original_request:)
+    end
+
     # Returns a new client with the supplied options overridden.
     sig do
       params(

--- a/rbi/openai/internal/transport/base_client.rbi
+++ b/rbi/openai/internal/transport/base_client.rbi
@@ -222,6 +222,18 @@ module OpenAI
         end
 
         # @api private
+        sig do
+          overridable
+            .params(
+              request: OpenAI::Internal::Transport::BaseClient::RequestInput,
+              original_request: OpenAI::Internal::Transport::BaseClient::RequestInput
+            )
+            .returns(OpenAI::Internal::Transport::BaseClient::RequestInput)
+        end
+        private def validate_prepared_request(request, original_request:)
+        end
+
+        # @api private
         sig { returns(String) }
         private def user_agent
         end

--- a/sig/openai/auth.rbs
+++ b/sig/openai/auth.rbs
@@ -3,7 +3,9 @@ module OpenAI
     class WorkloadIdentityAuth
       def get_token: (?deadline: Float?) -> String
 
-      def invalidate_token: -> void
+      def invalidate_token: (?String? rejected_token) -> void
+
+      def inspect: -> String
     end
   end
 end

--- a/sig/openai/client.rbs
+++ b/sig/openai/client.rbs
@@ -82,6 +82,11 @@ module OpenAI
       retry_count: Integer
     ) -> OpenAI::Internal::Transport::BaseClient::request_input
 
+    private def validate_prepared_request: (
+      OpenAI::Internal::Transport::BaseClient::request_input request,
+      original_request: OpenAI::Internal::Transport::BaseClient::request_input
+    ) -> OpenAI::Internal::Transport::BaseClient::request_input
+
     def with_options: (
       ?api_key: String?,
       ?admin_api_key: String?,

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -108,6 +108,11 @@ module OpenAI
           retry_count: Integer
         ) -> OpenAI::Internal::Transport::BaseClient::request_input
 
+        private def validate_prepared_request: (
+          OpenAI::Internal::Transport::BaseClient::request_input request,
+          original_request: OpenAI::Internal::Transport::BaseClient::request_input
+        ) -> OpenAI::Internal::Transport::BaseClient::request_input
+
         private def user_agent: -> String
 
         private def generate_idempotency_key: -> String

--- a/test/openai/auth/x509_client_test.rb
+++ b/test/openai/auth/x509_client_test.rb
@@ -287,6 +287,64 @@ class OpenAI::Test::X509ClientTest < Minitest::Test
     end
   end
 
+  def test_prepared_x509_requests_dispatch_the_immutable_validated_header_snapshot
+    mutable_header = Class.new(String) do
+      attr_reader(:comparisons)
+
+      def to_s = self
+
+      def ==(other)
+        @comparisons = (@comparisons || 0) + 1
+        matches = super
+        replace("Bearer fake-mutated-after-validation") if matches
+        matches
+      end
+    end
+
+    retained_headers = []
+    client_class = Class.new(OpenAI::Client) do
+      define_method(:prepare_request) do |request, redirect_count:, retry_count:|
+        prepared = super(request, redirect_count: redirect_count, retry_count: retry_count)
+        retained = mutable_header.new(prepared.fetch(:headers).fetch("authorization"))
+        retained_headers << retained
+        prepared.merge(headers: prepared.fetch(:headers).merge("authorization" => retained))
+      end
+
+      private(:prepare_request)
+    end
+
+    client = client_class.new(api_key: nil, workload_identity: @identity, http_client: @transport)
+    observed = nil
+    dispatch = lambda do |request|
+      payload = if request.url.host == "mtls.auth.openai.com"
+        {
+          access_token: "fake-issued-token",
+          issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+          token_type: "Bearer",
+          expires_in: 120
+        }
+      else
+        observed = request
+        {id: "fake-model", created: 1, object: "model", owned_by: "openai"}
+      end
+
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: [JSON.generate(payload)]
+      )
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", client.models.retrieve("fake-model").id)
+    end
+
+    assert_equal("Bearer fake-issued-token", observed.headers.fetch("authorization"))
+    assert_instance_of(String, observed.headers.fetch("authorization"))
+    assert_predicate(observed.headers, :frozen?)
+    assert_nil(retained_headers.fetch(0).comparisons)
+  end
+
   def test_realtime_is_rejected_before_any_x509_exchange
     client = OpenAI::Client.new(api_key: nil, workload_identity: @identity, http_client: @transport)
 

--- a/test/openai/auth/x509_lifecycle_test.rb
+++ b/test/openai/auth/x509_lifecycle_test.rb
@@ -1,0 +1,705 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::X509LifecycleTest < Minitest::Test
+  def setup
+    super
+    @native = OpenAI::NetHTTPClient.new
+    @transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+    @identity = OpenAI::Auth::X509WorkloadIdentity.new(
+      identity_provider_id: "idp_fake",
+      service_account_id: "svc_acct_fake"
+    )
+    @client = OpenAI::Client.new(
+      api_key: nil,
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+  end
+
+  def teardown
+    @native.close
+    super
+  end
+
+  def test_successful_requests_share_one_cached_exchange
+    exchanges = 0
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        exchanges += 1
+        token_response("fake-token-#{exchanges}")
+      else
+        model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", @client.models.retrieve("first").id)
+      assert_equal("fake-model", @client.models.retrieve("second").id)
+    end
+
+    assert_equal(1, exchanges)
+  end
+
+  def test_401_invalidates_the_actual_bearer_and_replays_only_once
+    exchanges = 0
+    api_headers = []
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        exchanges += 1
+        token_response("fake-token-#{exchanges}")
+      else
+        api_headers << request.headers.fetch("authorization")
+        api_headers.one? ? unauthorized_response : model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", @client.models.retrieve("fake-model").id)
+    end
+
+    assert_equal(["Bearer fake-token-1", "Bearer fake-token-2"], api_headers)
+    assert_equal(2, exchanges)
+  end
+
+  def test_failed_replay_invalidates_the_second_rejected_bearer
+    exchanges = 0
+    api_headers = []
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        exchanges += 1
+        token_response("fake-token-#{exchanges}")
+      else
+        api_headers << request.headers.fetch("authorization")
+        api_headers.length <= 2 ? unauthorized_response : model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_raises(OpenAI::Errors::AuthenticationError) { @client.models.retrieve("first") }
+      assert_equal("fake-model", @client.models.retrieve("second").id)
+    end
+
+    assert_equal(["Bearer fake-token-1", "Bearer fake-token-2", "Bearer fake-token-3"], api_headers)
+    assert_equal(3, exchanges)
+  end
+
+  def test_nonreplayable_request_invalidates_without_resending_its_body
+    exchanges = 0
+    requests = []
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        exchanges += 1
+        token_response("fake-token-#{exchanges}")
+      else
+        requests << request
+        requests.one? ? unauthorized_response : model_response
+      end
+    end
+
+    io = StringIO.new("fake-file")
+    body = Class
+      .new do
+        def initialize(source) = @source = source
+        def read(*) = @source.read(*)
+      end
+      .new(io)
+
+    @native.stub(:execute, dispatch) do
+      assert_raises(OpenAI::Errors::AuthenticationError) do
+        @client.request(method: :post, path: "/v1/upload", body: body)
+      end
+
+      assert_equal("fake-model", @client.models.retrieve("next").id)
+    end
+
+    assert_equal(2, requests.length)
+    assert_equal(["Bearer fake-token-1", "Bearer fake-token-2"], requests.map { _1.headers["authorization"] })
+  end
+
+  def test_stale_invalidation_does_not_remove_a_newer_cached_generation
+    exchanges = 0
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        exchanges += 1
+        token_response("fake-token-#{exchanges}")
+      else
+        model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      auth = @client.workload_identity_auth
+      assert_equal("fake-token-1", auth.get_token)
+      auth.invalidate_token("fake-token-1")
+      assert_equal("fake-token-2", auth.get_token)
+      auth.invalidate_token("fake-token-1")
+      assert_equal("fake-token-2", auth.get_token)
+    end
+
+    assert_equal(2, exchanges)
+  end
+
+  def test_concurrent_waiters_receive_the_real_exchange_failure
+    auth = @client.workload_identity_auth
+    refresh_started = Queue.new
+    release_refresh = Queue.new
+    leader = nil
+    waiter = nil
+    failure = OpenAI::Errors::APIError.new(
+      url: URI("https://mtls.auth.openai.com/oauth/token"),
+      status: 503,
+      message: "identity service unavailable"
+    )
+    fetch = lambda do |deadline:|
+      refresh_started << deadline
+      release_refresh.pop
+      raise failure
+    end
+
+    auth.stub(:fetch_token_from_exchange, fetch) do
+      leader = Thread.new { auth.get_token }
+      leader.report_on_exception = false
+      Timeout.timeout(1) { refresh_started.pop }
+      waiter = Thread.new { auth.get_token }
+      waiter.report_on_exception = false
+      Timeout.timeout(1) { Thread.pass until waiter.status == "sleep" }
+      release_refresh << true
+
+      assert_same(failure, assert_raises(OpenAI::Errors::APIError) { leader.value })
+      assert_same(failure, assert_raises(OpenAI::Errors::APIError) { waiter.value })
+    end
+
+  ensure
+    release_refresh&.push(true) if leader&.alive?
+    leader&.kill&.join if leader&.alive?
+    waiter&.kill&.join if waiter&.alive?
+  end
+
+  def test_waiter_observes_its_joined_refresh_when_a_new_generation_starts
+    auth = @client.workload_identity_auth
+    condition = auth.instance_variable_get(:@cond_var)
+    original_wait = condition.method(:wait)
+    first_started = Queue.new
+    release_first = Queue.new
+    waiter_awakened = Queue.new
+    release_waiter = Queue.new
+    second_started = Queue.new
+    release_second = Queue.new
+    failure = OpenAI::Errors::APIError.new(
+      url: URI("https://mtls.auth.openai.com/oauth/token"),
+      status: 503,
+      message: "first refresh failed"
+    )
+    leader = nil
+    waiter = nil
+    successor = nil
+    attempts = 0
+    fetch = lambda do |deadline:|
+      attempts += 1
+      if attempts == 1
+        first_started << deadline
+        release_first.pop
+        raise failure
+      end
+
+      second_started << deadline
+      release_second.pop
+      {id: "fake-second-generation-token", expires_in: 120}
+    end
+
+    wait = lambda do |mutex, *arguments|
+      result = original_wait.call(mutex, *arguments)
+      if Thread.current == waiter
+        mutex.unlock
+        begin
+          waiter_awakened << true
+          release_waiter.pop
+        ensure
+          mutex.lock
+        end
+      end
+
+      result
+    end
+
+    auth.stub(:fetch_token_from_exchange, fetch) do
+      condition.stub(:wait, wait) do
+        leader = Thread.new { auth.get_token }
+        leader.report_on_exception = false
+        Timeout.timeout(2) { first_started.pop }
+
+        waiter = Thread.new { auth.get_token }
+        waiter.report_on_exception = false
+        Timeout.timeout(2) { Thread.pass until waiter.status == "sleep" }
+        release_first << true
+        Timeout.timeout(2) { waiter_awakened.pop }
+        assert_same(failure, assert_raises(OpenAI::Errors::APIError) { leader.value })
+
+        successor = Thread.new { auth.get_token }
+        successor.report_on_exception = false
+        Timeout.timeout(2) { second_started.pop }
+        release_waiter << true
+
+        joined_failure = nil
+        Timeout.timeout(2) do
+          joined_failure = assert_raises(OpenAI::Errors::APIError) { waiter.value }
+        end
+
+        assert_same(failure, joined_failure)
+        assert(successor.alive?, "the joined waiter must not wait for the next refresh")
+
+        release_second << true
+        assert_equal("fake-second-generation-token", Timeout.timeout(2) { successor.value })
+      end
+    end
+
+  ensure
+    release_first&.push(true) if leader&.alive?
+    release_waiter&.push(true) if waiter&.alive?
+    release_second&.push(true) if successor&.alive?
+    [leader, waiter, successor].compact.each { _1.kill.join if _1.alive? }
+  end
+
+  def test_waiter_never_returns_an_expired_joined_generation_token
+    auth = @client.workload_identity_auth
+    condition = auth.instance_variable_get(:@cond_var)
+    original_broadcast = condition.method(:broadcast)
+    refresh_started = Queue.new
+    release_refresh = Queue.new
+    leader = nil
+    waiter = nil
+    fetch = lambda do |deadline:|
+      refresh_started << deadline
+      release_refresh.pop
+      {id: "fake-expired-generation-token", expires_in: 0.01}
+    end
+
+    broadcast = lambda do
+      result = original_broadcast.call
+      sleep(0.05)
+      result
+    end
+
+    auth.stub(:fetch_token_from_exchange, fetch) do
+      condition.stub(:broadcast, broadcast) do
+        leader = Thread.new { auth.get_token }
+        leader.report_on_exception = false
+        Timeout.timeout(2) { refresh_started.pop }
+
+        waiter = Thread.new { auth.get_token }
+        waiter.report_on_exception = false
+        Timeout.timeout(2) { Thread.pass until waiter.status == "sleep" }
+        release_refresh << true
+
+        leader_error = assert_raises(OpenAI::Errors::AuthenticationError) { leader.value }
+        waiter_error = assert_raises(OpenAI::Errors::AuthenticationError) { waiter.value }
+        assert_equal(401, leader_error.status)
+        assert_equal(401, waiter_error.status)
+        assert_equal("https://mtls.auth.openai.com/oauth/token", waiter_error.url.to_s)
+      end
+    end
+
+  ensure
+    release_refresh&.push(true) if leader&.alive?
+    leader&.kill&.join if leader&.alive?
+    waiter&.kill&.join if waiter&.alive?
+  end
+
+  def test_waiter_never_returns_a_rejected_and_replaced_generation_token
+    auth = @client.workload_identity_auth
+    condition = auth.instance_variable_get(:@cond_var)
+    original_wait = condition.method(:wait)
+    first_started = Queue.new
+    release_first = Queue.new
+    waiter_awakened = Queue.new
+    release_waiter = Queue.new
+    leader = nil
+    waiter = nil
+    attempts = 0
+    fetch = lambda do |deadline:|
+      attempts += 1
+      if attempts == 1
+        first_started << deadline
+        release_first.pop
+      end
+
+      {id: "fake-generation-#{attempts}", expires_in: 120}
+    end
+
+    wait = lambda do |mutex, *arguments|
+      result = original_wait.call(mutex, *arguments)
+      if Thread.current == waiter
+        mutex.unlock
+        begin
+          waiter_awakened << true
+          release_waiter.pop
+        ensure
+          mutex.lock
+        end
+      end
+
+      result
+    end
+
+    auth.stub(:fetch_token_from_exchange, fetch) do
+      condition.stub(:wait, wait) do
+        leader = Thread.new { auth.get_token }
+        leader.report_on_exception = false
+        Timeout.timeout(2) { first_started.pop }
+
+        waiter = Thread.new { auth.get_token }
+        waiter.report_on_exception = false
+        Timeout.timeout(2) { Thread.pass until waiter.status == "sleep" }
+        release_first << true
+        Timeout.timeout(2) { waiter_awakened.pop }
+
+        rejected = Timeout.timeout(2) { leader.value }
+        assert_equal("fake-generation-1", rejected)
+        auth.invalidate_token(rejected)
+        replacement = auth.get_token
+        assert_equal("fake-generation-2", replacement)
+
+        release_waiter << true
+        assert_equal(replacement, Timeout.timeout(2) { waiter.value })
+      end
+    end
+
+  ensure
+    release_first&.push(true) if leader&.alive?
+    release_waiter&.push(true) if waiter&.alive?
+    leader&.kill&.join if leader&.alive?
+    waiter&.kill&.join if waiter&.alive?
+  end
+
+  def test_aborted_refresh_attributes_waiter_authentication_failure_to_mtls_issuer
+    auth = @client.workload_identity_auth
+    refresh_started = Queue.new
+    release_refresh = Queue.new
+    leader = nil
+    waiter = nil
+    fatal_error = Interrupt
+    fetch = lambda do |deadline:|
+      refresh_started << deadline
+      release_refresh.pop
+      raise fatal_error, "fake interrupted refresh"
+    end
+
+    auth.stub(:fetch_token_from_exchange, fetch) do
+      leader = Thread.new { auth.get_token }
+      leader.report_on_exception = false
+      Timeout.timeout(2) { refresh_started.pop }
+
+      waiter = Thread.new { auth.get_token }
+      waiter.report_on_exception = false
+      Timeout.timeout(2) { Thread.pass until waiter.status == "sleep" }
+      release_refresh << true
+
+      assert_raises(fatal_error) { leader.value }
+      error = assert_raises(OpenAI::Errors::AuthenticationError) { waiter.value }
+      assert_equal("https://mtls.auth.openai.com/oauth/token", error.url.to_s)
+      assert_equal(401, error.status)
+    end
+
+  ensure
+    release_refresh&.push(true) if leader&.alive?
+    leader&.kill&.join if leader&.alive?
+    waiter&.kill&.join if waiter&.alive?
+  end
+
+  def test_request_credential_overrides_are_rejected_before_any_exchange
+    hostile_headers = [
+      {"authorization" => "Bearer attacker-token"},
+      {"x_api_key" => "fake-provider-key"},
+      {"proxy_authorization" => "Basic fake-proxy"},
+      {"host" => "attacker.invalid"}
+    ]
+
+    @native.stub(:execute, -> (_request) { flunk("hostile headers must fail before token exchange") }) do
+      hostile_headers.each do |headers|
+        assert_raises(OpenAI::Errors::Error, ArgumentError) do
+          @client.models.retrieve("fake-model", request_options: {extra_headers: headers})
+        end
+      end
+    end
+  end
+
+  def test_post_preparation_hooks_cannot_replace_the_exchanged_bearer
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(headers: prepared.fetch(:headers).merge("authorization" => "Bearer fake-replacement"))
+      end
+    end
+
+    client = client_class.new(
+      api_key: nil,
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+    destinations = []
+    dispatch = lambda do |request|
+      destinations << request.url.host
+      token_response("fake-issued-token")
+    end
+
+    @native.stub(:execute, dispatch) do
+      error = assert_raises(OpenAI::Errors::Error) { client.models.retrieve("fake-model") }
+      assert_match(/cannot override the selected authorization credential/, error.message)
+    end
+
+    assert_equal(["mtls.auth.openai.com"], destinations)
+  end
+
+  def test_safe_post_preparation_hooks_remain_supported
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        prepared.merge(headers: prepared.fetch(:headers).merge("x-fake-trace" => "fake-value"))
+      end
+    end
+
+    client = client_class.new(
+      api_key: nil,
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+    api_request = nil
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        token_response("fake-issued-token")
+      else
+        api_request = request
+        model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", client.models.retrieve("fake-model").id)
+    end
+
+    assert_equal("Bearer fake-issued-token", api_request.headers.fetch("authorization"))
+    assert_equal("fake-value", api_request.headers.fetch("x-fake-trace"))
+  end
+
+  def test_post_preparation_hooks_cannot_mutate_the_trusted_original_credential
+    client_class = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        replacement = "Bearer fake-mutated-original"
+        request.delete(:x509_request_context)
+        request.fetch(:headers)["authorization"] = replacement
+        prepared.merge(headers: prepared.fetch(:headers).merge("authorization" => replacement))
+      end
+    end
+
+    client = client_class.new(
+      api_key: nil,
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+    destinations = []
+    dispatch = lambda do |request|
+      destinations << request.url.host
+      token_response("fake-issued-token")
+    end
+
+    @native.stub(:execute, dispatch) do
+      error = assert_raises(OpenAI::Errors::Error) { client.models.retrieve("fake-model") }
+      assert_match(/cannot override the selected authorization credential/, error.message)
+    end
+
+    assert_equal(["mtls.auth.openai.com"], destinations)
+  end
+
+  def test_cached_bearer_is_redacted_from_authenticator_inspection
+    dispatch = lambda do |request|
+      request.url.host == "mtls.auth.openai.com" ? token_response("fake-sensitive-token") : model_response
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", @client.models.retrieve("fake-model").id)
+    end
+
+    inspected = @client.workload_identity_auth.inspect
+    refute_includes(inspected, "fake-sensitive-token")
+    refute_includes(inspected, "idp_fake")
+    refute_includes(inspected, "svc_acct_fake")
+  end
+
+  def test_disabled_security_schemes_dispatch_without_exchanging_or_sending_credentials
+    client = OpenAI::Client.new(
+      api_key: nil,
+      admin_api_key: "fake-admin-key",
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+    observed = []
+    response = model_response
+    dispatch = lambda do |request|
+      observed << request
+      response
+    end
+
+    @native.stub(:execute, dispatch) do
+      client.request(
+        method: :get,
+        path: "/v1/models/fake-model",
+        security: {bearer_auth: false, admin_api_key_auth: false}
+      )
+    end
+
+    assert_equal(1, observed.length)
+    request = observed.fetch(0)
+    assert_equal("mtls.api.openai.com", request.url.host)
+    refute_includes(request.headers, "authorization")
+  end
+
+  def test_disabled_security_schemes_cannot_inject_an_authorization_override
+    client = OpenAI::Client.new(
+      api_key: nil,
+      admin_api_key: "fake-admin-key",
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+
+    @native.stub(:execute, -> (_request) { flunk("unauthenticated requests cannot inject credentials") }) do
+      error = assert_raises(OpenAI::Errors::Error) do
+        client.request(
+          method: :get,
+          path: "/v1/models/fake-model",
+          headers: {"authorization" => "Bearer fake-injected-token"},
+          security: {bearer_auth: false, admin_api_key_auth: false}
+        )
+      end
+
+      assert_match(/cannot override the selected authorization credential/, error.message)
+    end
+  end
+
+  def test_selected_security_schemes_cannot_be_replaced_by_another_configured_credential
+    client = OpenAI::Client.new(
+      api_key: nil,
+      admin_api_key: "fake-admin-key",
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+    disabled = {bearer_auth: false, admin_api_key_auth: false}
+    bearer_only = {bearer_auth: true, admin_api_key_auth: false}
+    admin_only = {bearer_auth: false, admin_api_key_auth: true}
+    both = {bearer_auth: true, admin_api_key_auth: true}
+    overrides = [
+      [disabled, "Bearer fake-admin-key"],
+      [disabled, "Bearer workload-identity-auth"],
+      [bearer_only, "Bearer fake-admin-key"],
+      [admin_only, "Bearer workload-identity-auth"],
+      [both, "Bearer fake-admin-key"],
+      [nil, "Bearer fake-admin-key"]
+    ]
+
+    @native.stub(:execute, -> (_request) { flunk("incorrect security scheme must fail before token exchange") }) do
+      overrides.each do |security, authorization|
+        error = assert_raises(OpenAI::Errors::Error) do
+          options = {
+            method: :get,
+            path: "/v1/models/fake-model",
+            headers: {"authorization" => authorization}
+          }
+          options[:security] = security unless security.nil?
+          client.request(**options)
+        end
+
+        assert_match(/cannot override the selected authorization credential/, error.message)
+      end
+    end
+  end
+
+  def test_explicit_bearer_security_uses_x509_instead_of_an_available_admin_credential
+    client = OpenAI::Client.new(
+      api_key: nil,
+      admin_api_key: "fake-admin-key",
+      workload_identity: @identity,
+      http_client: @transport,
+      max_retries: 0
+    )
+    destinations = []
+    dispatch = lambda do |request|
+      destinations << request
+      request.url.host == "mtls.auth.openai.com" ? token_response("fake-issued-token") : model_response
+    end
+
+    @native.stub(:execute, dispatch) do
+      client.request(
+        method: :get,
+        path: "/v1/models/fake-model",
+        security: {bearer_auth: true, admin_api_key_auth: false}
+      )
+    end
+
+    assert_equal(["mtls.auth.openai.com", "mtls.api.openai.com"], destinations.map { _1.url.host })
+    assert_equal("Bearer fake-issued-token", destinations.fetch(1).headers.fetch("authorization"))
+  end
+
+  def test_separate_admin_bearer_is_preserved_without_token_exchange
+    client = OpenAI::Client.new(
+      api_key: nil,
+      admin_api_key: "fake-admin-key",
+      workload_identity: @identity,
+      http_client: @transport
+    )
+    observed = nil
+    response = model_response
+    dispatch = lambda do |request|
+      observed = request
+      response
+    end
+
+    @native.stub(:execute, dispatch) do
+      client.request(
+        method: :get,
+        path: "/v1/models/fake-model",
+        security: {admin_api_key_auth: true}
+      )
+    end
+
+    assert_equal("mtls.api.openai.com", observed.url.host)
+    assert_equal("Bearer fake-admin-key", observed.headers.fetch("authorization"))
+  end
+
+  private def token_response(token)
+    OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {},
+      body: JSON.generate(
+        access_token: token,
+        issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        token_type: "Bearer",
+        expires_in: 120
+      )
+    )
+  end
+
+  private def unauthorized_response
+    OpenAI::HTTPClient::Response.new(
+      status: 401,
+      headers: {"content-type" => "application/json"},
+      body: JSON.generate(error: {message: "invalid authentication"})
+    )
+  end
+
+  private def model_response
+    OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: JSON.generate(id: "fake-model", created: 1, object: "model", owned_by: "openai")
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Fourth PR in the stacked X.509 workload-identity series; hardens the integrated flow while preserving existing JWT/ID workload-identity contracts.

- Compare-and-invalidate only the actual rejected bearer; invalidate non-replayable requests and failed replays without replaying request bodies more than once.
- Propagate the real shared-refresh failure to concurrent waiters and share one X.509 request deadline across refresh/replay without changing the existing per-retry JWT timeout behavior.
- Validate the final destination and exact issued bearer **after** all request-preparation hooks, using the independent outer request as the trusted reference; preserve safe application hooks and separate admin credentials.
- Reject hostile credential/header mutations before disclosure and redact cached bearer tokens and identity configuration from authenticator inspection.
- Add deterministic lifecycle, concurrency, stale-generation, hostile-hook, mutable-original-request, safe-hook, and token-redaction regression tests.
- Introduce a small general final-request validation seam in the existing base client, with matching Sorbet/RBS declarations.

## Verification

- `bundle exec ruby test/openai/auth/x509_lifecycle_test.rb`
- `bundle exec ruby test/openai/auth/workload_identity_test.rb`
- `bundle exec ruby test/openai/resources/polling_helpers_test.rb --name test_workload_identity_timeout_uses_the_sdk_error_and_retry_contract`
- `bundle exec rake test`
- `bundle exec rake lint`
- An independent security review reproduced the hostile-hook and mutable-original-request attacks before the fixes and confirmed both now fail before API dispatch.

## Stack

1. Attested transport and real-wire security boundary.
2. X.509 identity and pinned token-exchange protocol.
3. Public-client integration and two-leg mTLS end-to-end coverage.
4. **This PR:** lifecycle, retry, concurrency, and final-credential hardening.
5. Customer documentation, enrolled-credential live smoke, and installed-gem end-to-end coverage.

Review requested from `@openai/sdks-team` because this change affects authentication, bearer handling, and request preparation.
