### PR TITLE
chore: prevent intermittent RBS formatting failures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,8 @@ multitask(:"format:rbs") do
 end
 
 desc("Format everything")
-multitask(format: [:"format:rb", :"format:rbs"])
+# RuboCop temporarily changes cwd; RBS discovery must not run alongside it.
+task(format: [:"format:rb", :"format:rbs"])
 
 desc("Validate `*.rbs`")
 multitask(:"validate:rbs") do

--- a/test/scripts/formatting_policy_test.rb
+++ b/test/scripts/formatting_policy_test.rb
@@ -260,4 +260,28 @@ class FormattingPolicyTest < Minitest::Test
     assert_includes(prerequisites, "lint:rubyfmt")
     assert_includes(prerequisites, "lint:rbs_format")
   end
+
+  def test_format_runs_ruby_and_rbs_on_the_calling_thread
+    # RuboCop's process-wide chdir must not overlap RBS discovery or file I/O.
+    source = <<~RUBY
+      require "json"
+      require "rake"
+      load "Rakefile"
+      Rake.application.options.thread_pool_size = 2
+      calling_thread = Thread.current
+      calls = []
+      %w[format:rb format:rbs].each do |name|
+        task = Rake::Task[name]
+        task.clear
+        task.enhance do
+          calls << [name, Thread.current == calling_thread]
+        end
+      end
+      Rake::Task["format"].invoke
+      puts JSON.generate(calls)
+    RUBY
+    stdout, stderr, status = Open3.capture3("bundle", "exec", "ruby", "-e", source, chdir: ROOT)
+    assert(status.success?, "#{stdout}\n#{stderr}")
+    assert_equal([["format:rb", true], ["format:rbs", true]], JSON.parse(stdout))
+  end
 end


### PR DESCRIPTION
## Summary

`rake format` can report success while leaving RBS signatures untouched, causing later lint checks to fail unpredictably. Ruby source discovery loads RuboCop configuration, which temporarily changes the process-wide working directory while RBS is discovering files.

Run the Ruby and RBS formatter tasks sequentially so discovery and formatting use a stable working directory. Existing lint checks and CI job parallelism are unchanged.
