### PR TITLE
feat(responses): parse structured outputs on retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,9 +715,11 @@ For a stored or background response, pass the same structured-output model again
 when retrieving it. The model is used locally to populate `content.parsed`; it is
 not sent as a retrieval query parameter. A response that is still queued or in
 progress can be retrieved the same way, but structured output is parsed only after
-a later retrieval reports it completed. For structured function tools, pass the
-same model again with `tools: [ToolArguments]`; matching retrieved function calls
-expose typed arguments through `output.parsed`.
+a later retrieval reports it completed when status is present. Compatible
+statusless responses parse once their hinted output is complete and schema-valid.
+For structured function tools, pass the same model again with
+`tools: [ToolArguments]`; matching retrieved function calls expose typed arguments
+through `output.parsed`.
 
 ```ruby
 pending = client.responses.create(

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ when retrieving it. The model is used locally to populate `content.parsed`; it i
 not sent as a retrieval query parameter. A response that is still queued or in
 progress can be retrieved the same way, but structured output is parsed only after
 a later retrieval reports it completed when status is present. Compatible
-statusless responses parse once their hinted output is complete and schema-valid.
+statusless responses parse once their hinted output is syntactically complete JSON.
 For structured function tools, pass the same model again with
 `tools: [ToolArguments]`; matching retrieved function calls expose typed arguments
 through `output.parsed`.

--- a/README.md
+++ b/README.md
@@ -715,7 +715,9 @@ For a stored or background response, pass the same structured-output model again
 when retrieving it. The model is used locally to populate `content.parsed`; it is
 not sent as a retrieval query parameter. A response that is still queued or in
 progress can be retrieved the same way, but structured output is parsed only after
-a later retrieval reports it completed.
+a later retrieval reports it completed. For structured function tools, pass the
+same model again with `tools: [ToolArguments]`; matching retrieved function calls
+expose typed arguments through `output.parsed`.
 
 ```ruby
 pending = client.responses.create(

--- a/README.md
+++ b/README.md
@@ -711,6 +711,22 @@ response
   end
 ```
 
+For a stored or background response, pass the same structured-output model again
+when retrieving it. The model is used locally to populate `content.parsed`; it is
+not sent as a retrieval query parameter. A response that is still queued or in
+progress can be retrieved the same way and will be parsed once output is present.
+
+```ruby
+pending = client.responses.create(
+  model: "gpt-5.2",
+  input: "Extract the event information.",
+  text: CalendarEvent,
+  background: true
+)
+
+response = client.responses.retrieve(pending.id, text: CalendarEvent)
+```
+
 </details>
 
 See the [examples](https://github.com/openai/openai-ruby/tree/main/examples) directory for more usage examples for helper usage.

--- a/README.md
+++ b/README.md
@@ -714,7 +714,8 @@ response
 For a stored or background response, pass the same structured-output model again
 when retrieving it. The model is used locally to populate `content.parsed`; it is
 not sent as a retrieval query parameter. A response that is still queued or in
-progress can be retrieved the same way and will be parsed once output is present.
+progress can be retrieved the same way, but structured output is parsed only after
+a later retrieval reports it completed.
 
 ```ruby
 pending = client.responses.create(

--- a/lib/openai/helpers/sorbet.rb
+++ b/lib/openai/helpers/sorbet.rb
@@ -259,6 +259,11 @@ module OpenAI
           super
         end
 
+        def retrieve(response_id, params = {})
+          reject_sorbet_function_tools!(params)
+          super
+        end
+
         def stream(params)
           reject_sorbet_streaming_formats!(params)
           super

--- a/lib/openai/helpers/sorbet.rb
+++ b/lib/openai/helpers/sorbet.rb
@@ -286,7 +286,7 @@ module OpenAI
         end
 
         private def reject_sorbet_function_tools!(params = {})
-          tools = Array(params[:tools])
+          tools = Array(params[:tools]).dup
           tools.concat(Array(params["tools"])) if params.is_a?(Hash)
 
           if tools.any? { sorbet_adapter?(_1) }

--- a/lib/openai/helpers/sorbet.rb
+++ b/lib/openai/helpers/sorbet.rb
@@ -286,6 +286,7 @@ module OpenAI
         end
 
         private def reject_sorbet_function_tools!(params = {})
+          params = params.to_h if params.is_a?(OpenAI::Internal::Type::BaseModel)
           tools = Array(params[:tools]).dup
           tools.concat(Array(params["tools"])) if params.is_a?(Hash)
 

--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -35,20 +35,17 @@ module OpenAI
               end
           end
 
-          unless tool_models.empty?
-            raw[:output]&.each do |output|
-              next unless output[:type] == "function_call"
-              next unless (name = output[:name])
-              next if (model = tool_models[name]).nil?
-              begin
-                parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
-              rescue JSON::ParserError => e
-                parsed = e
-              end
-
-              coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
-              output.store(:parsed, coerced)
+          raw[:output]&.each do |output|
+            next unless output[:type] == "function_call"
+            next if (model = tool_models[output.fetch(:name)]).nil?
+            begin
+              parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
+            rescue JSON::ParserError => e
+              parsed = e
             end
+
+            coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
+            output.store(:parsed, coerced)
           end
 
           raw

--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -139,6 +139,214 @@ module OpenAI
 
           [model, tool_models]
         end
+
+        # Extracts retrieval-local structured-output hints without mutating caller-owned values.
+        #
+        # @api private
+        #
+        # @param parsed [Hash] Dumped retrieval parameters containing local text/tool hints
+        # @return [Array<(JsonSchemaConverter|nil, Hash)>] Text model and named tool models
+        def self.get_retrieval_models(parsed)
+          get_models(duplicate_retrieval_params(parsed.slice(:text, :tools)))
+        end
+
+        # Parses retrieval output only when status and payload shape indicate it is complete.
+        #
+        # @api private
+        #
+        # @param raw [Hash] The raw retrieved response hash that will be mutated with parsed data
+        # @param model [JsonSchemaConverter, nil] The converter for structured text output
+        # @param tool_models [Hash<String, JsonSchemaConverter>] Tool names and their converters
+        # @return [Hash] The same response with typed values in its :parsed fields when ready
+        def self.parse_retrieved!(raw, model, tool_models)
+          return raw unless retrieval_complete?(raw, model, tool_models)
+
+          parsable_output = raw[:output].to_a.reject do |output|
+            output[:type] == "function_call" && !output.key?(:name)
+          end
+
+          parse!(raw.merge(output: parsable_output), model, tool_models)
+          raw
+        end
+
+        def self.retrieval_complete?(raw, model, tool_models)
+          return false unless [nil, "completed"].include?(raw[:status])
+
+          raw[:output].to_a.none? do |output|
+            case output[:type]
+            when "message"
+              model && unfinished_message?(output, model, response_status: raw[:status])
+            when "function_call"
+              unfinished_function_call?(output, tool_models, response_status: raw[:status])
+            else
+              false
+            end
+          end
+        end
+
+        def self.unfinished_message?(output, model, response_status:)
+          return true if pending_status?(output[:status])
+          return false unless response_status.nil? && output[:status].nil?
+
+          output[:content].to_a.any? do |content|
+            content[:type] == "output_text" &&
+              (!content.key?(:text) || !value_ready?(content[:text], model))
+          end
+        end
+
+        def self.unfinished_function_call?(output, tool_models, response_status:)
+          return false if tool_models.empty?
+          return false unless output.key?(:name)
+          return false unless tool_models.key?(output[:name])
+          return true if pending_status?(output[:status])
+          return false unless response_status.nil? && output[:status].nil?
+
+          !output.key?(:arguments) || !value_ready?(output[:arguments], tool_models.fetch(output[:name]))
+        end
+
+        def self.pending_status?(status)
+          ["queued", "in_progress", "incomplete"].include?(status)
+        end
+
+        def self.value_ready?(value, model)
+          parsed = JSON.parse(value, symbolize_names: true)
+          return false unless known_properties?(parsed, model.to_json_schema)
+
+          state = OpenAI::Internal::Type::Converter.new_coerce_state
+          OpenAI::Internal::Type::Converter.coerce(model, parsed, state: state)
+          exactness = state.fetch(:exactness)
+          exactness.fetch(:no).zero? && exactness.fetch(:maybe).zero?
+        rescue JSON::ParserError, TypeError
+          false
+        end
+
+        def self.known_properties?(value, schema, root_schema = schema)
+          schema = resolve_schema(schema, root_schema)
+          return false unless schema
+
+          if (parts = schema[:allOf] || schema["allOf"])
+            return parts.all? { |part| known_properties?(value, part, root_schema) }
+          end
+
+          if (variants = schema[:anyOf] || schema["anyOf"])
+            compatible = variants.select { |variant| schema_matches_shape?(value, variant, root_schema) }
+            return compatible.any? { |variant| known_properties?(value, variant, root_schema) }
+          end
+
+          type = schema[:type] || schema["type"]
+          case type
+          when "object"
+            return true unless value.is_a?(Hash)
+
+            properties = schema[:properties] || schema["properties"] || {}
+            additional_properties = if schema.key?(:additionalProperties)
+              schema[:additionalProperties]
+            else
+              schema["additionalProperties"]
+            end
+
+            if additional_properties == false
+              return false if (value.keys.map(&:to_s) - properties.keys.map(&:to_s)).any?
+            end
+
+            properties.all? do |key, property_schema|
+              value_key = value.key?(key) ? key : key.to_sym
+              !value.key?(value_key) || known_properties?(value.fetch(value_key), property_schema, root_schema)
+            end
+
+          when "array"
+            return true unless value.is_a?(Array)
+
+            items = schema[:items] || schema["items"]
+            value.all? { |item| known_properties?(item, items, root_schema) }
+          else
+            true
+          end
+        end
+
+        def self.schema_matches_shape?(value, schema, root_schema)
+          schema = resolve_schema(schema, root_schema)
+          return false unless schema
+
+          if (parts = schema[:allOf] || schema["allOf"])
+            return parts.all? { |part| schema_matches_shape?(value, part, root_schema) }
+          end
+
+          if (variants = schema[:anyOf] || schema["anyOf"])
+            return variants.any? { |variant| schema_matches_shape?(value, variant, root_schema) }
+          end
+
+          if schema.key?(:const) || schema.key?("const")
+            constant = schema.key?(:const) ? schema[:const] : schema["const"]
+            return value == constant
+          end
+
+          types = Array(schema[:type] || schema["type"])
+          return true if types.empty?
+
+          types.any? do |type|
+            case type
+            when "object"
+              value.is_a?(Hash)
+            when "array"
+              value.is_a?(Array)
+            when "null"
+              value.nil?
+            when "string"
+              value.is_a?(String)
+            when "integer"
+              value.is_a?(Integer)
+            when "number"
+              value.is_a?(Numeric)
+            when "boolean"
+              [true, false].include?(value)
+            else
+              true
+            end
+          end
+        end
+
+        def self.resolve_schema(schema, root_schema)
+          reference = schema["$ref"] || schema[:$ref]
+          return schema unless reference
+
+          definitions = root_schema["$defs"] || root_schema[:$defs] || {}
+          token = URI.decode_uri_component(reference.delete_prefix("#/$defs/"))
+          name = token.gsub("~1", "/").gsub("~0", "~")
+          definitions[name] || definitions[name.to_sym]
+        end
+
+        def self.duplicate_retrieval_params(value)
+          case value
+          when Array
+            value.map { |item| duplicate_retrieval_params(item) }
+          when Hash
+            value.to_h do |key, item|
+              normalized_key = key.is_a?(String) ? key.to_sym : key
+              normalized_key = :format if normalized_key == :format_
+              normalized_item = duplicate_retrieval_params(item)
+              if normalized_key == :type && ["function", "json_schema"].include?(normalized_item)
+                normalized_item = normalized_item.to_sym
+              end
+
+              [normalized_key, normalized_item]
+            end
+          else
+            value
+          end
+        end
+
+        private_class_method(
+          :duplicate_retrieval_params,
+          :known_properties?,
+          :pending_status?,
+          :resolve_schema,
+          :retrieval_complete?,
+          :schema_matches_shape?,
+          :unfinished_function_call?,
+          :unfinished_message?,
+          :value_ready?
+        )
       end
     end
   end

--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -159,161 +159,78 @@ module OpenAI
         # @param tool_models [Hash<String, JsonSchemaConverter>] Tool names and their converters
         # @return [Hash] The same response with typed values in its :parsed fields when ready
         def self.parse_retrieved!(raw, model, tool_models)
-          return raw unless retrieval_complete?(raw, model, tool_models)
+          staged = {}.compare_by_identity
+          return raw unless retrieval_complete?(raw, model, tool_models, staged)
 
-          parsable_output = raw[:output].to_a.reject do |output|
-            output[:type] == "function_call" && !output.key?(:name)
+          parse!(raw.merge(output: parsable_output(raw, staged)), model, tool_models)
+          staged.each_value do |target, converter, parsed|
+            target.store(:parsed, OpenAI::Internal::Type::Converter.coerce(converter, parsed))
           end
 
-          parse!(raw.merge(output: parsable_output), model, tool_models)
           raw
         end
 
-        def self.retrieval_complete?(raw, model, tool_models)
+        def self.retrieval_complete?(raw, model, tool_models, staged)
           return false unless [nil, "completed"].include?(raw[:status])
 
           raw[:output].to_a.none? do |output|
             case output[:type]
             when "message"
-              model && unfinished_message?(output, model, response_status: raw[:status])
+              model && unfinished_message?(output, model, staged, response_status: raw[:status])
             when "function_call"
-              unfinished_function_call?(output, tool_models, response_status: raw[:status])
+              unfinished_function_call?(output, tool_models, staged, response_status: raw[:status])
             else
               false
             end
           end
         end
 
-        def self.unfinished_message?(output, model, response_status:)
+        def self.unfinished_message?(output, model, staged, response_status:)
           return true if pending_status?(output[:status])
           return false unless response_status.nil? && output[:status].nil?
 
           output[:content].to_a.any? do |content|
-            content[:type] == "output_text" &&
-              (!content.key?(:text) || !value_ready?(content[:text], model))
+            next false unless content[:type] == "output_text"
+            next true unless content.key?(:text)
+
+            ready, parsed = prepare_value(content[:text])
+            staged.store(content, [content, model, parsed]) if ready
+            !ready
           end
         end
 
-        def self.unfinished_function_call?(output, tool_models, response_status:)
+        def self.unfinished_function_call?(output, tool_models, staged, response_status:)
           return false if tool_models.empty?
           return false unless output.key?(:name)
           return false unless tool_models.key?(output[:name])
           return true if pending_status?(output[:status])
           return false unless response_status.nil? && output[:status].nil?
+          return true unless output.key?(:arguments)
 
-          !output.key?(:arguments) || !value_ready?(output[:arguments], tool_models.fetch(output[:name]))
+          model = tool_models.fetch(output[:name])
+          ready, parsed = prepare_value(output[:arguments])
+          staged.store(output, [output, model, parsed]) if ready
+          !ready
         end
 
         def self.pending_status?(status)
           ["queued", "in_progress", "incomplete"].include?(status)
         end
 
-        def self.value_ready?(value, model)
-          parsed = JSON.parse(value, symbolize_names: true)
-          return false unless known_properties?(parsed, model.to_json_schema)
-
-          state = OpenAI::Internal::Type::Converter.new_coerce_state
-          OpenAI::Internal::Type::Converter.coerce(model, parsed, state: state)
-          exactness = state.fetch(:exactness)
-          exactness.fetch(:no).zero? && exactness.fetch(:maybe).zero?
+        def self.prepare_value(value)
+          [true, JSON.parse(value, symbolize_names: true)]
         rescue JSON::ParserError, TypeError
-          false
+          [false, nil]
         end
 
-        def self.known_properties?(value, schema, root_schema = schema)
-          schema = resolve_schema(schema, root_schema)
-          return false unless schema
+        def self.parsable_output(raw, staged)
+          raw[:output].to_a.filter_map do |output|
+            next if output[:type] == "function_call" && (!output.key?(:name) || staged.key?(output))
+            next output unless output[:type] == "message"
 
-          if (parts = schema[:allOf] || schema["allOf"])
-            return parts.all? { |part| known_properties?(value, part, root_schema) }
+            content = output[:content].to_a.reject { |item| staged.key?(item) }
+            output.merge(content: content)
           end
-
-          if (variants = schema[:anyOf] || schema["anyOf"])
-            compatible = variants.select { |variant| schema_matches_shape?(value, variant, root_schema) }
-            return compatible.any? { |variant| known_properties?(value, variant, root_schema) }
-          end
-
-          type = schema[:type] || schema["type"]
-          case type
-          when "object"
-            return true unless value.is_a?(Hash)
-
-            properties = schema[:properties] || schema["properties"] || {}
-            additional_properties = if schema.key?(:additionalProperties)
-              schema[:additionalProperties]
-            else
-              schema["additionalProperties"]
-            end
-
-            if additional_properties == false
-              return false if (value.keys.map(&:to_s) - properties.keys.map(&:to_s)).any?
-            end
-
-            properties.all? do |key, property_schema|
-              value_key = value.key?(key) ? key : key.to_sym
-              !value.key?(value_key) || known_properties?(value.fetch(value_key), property_schema, root_schema)
-            end
-
-          when "array"
-            return true unless value.is_a?(Array)
-
-            items = schema[:items] || schema["items"]
-            value.all? { |item| known_properties?(item, items, root_schema) }
-          else
-            true
-          end
-        end
-
-        def self.schema_matches_shape?(value, schema, root_schema)
-          schema = resolve_schema(schema, root_schema)
-          return false unless schema
-
-          if (parts = schema[:allOf] || schema["allOf"])
-            return parts.all? { |part| schema_matches_shape?(value, part, root_schema) }
-          end
-
-          if (variants = schema[:anyOf] || schema["anyOf"])
-            return variants.any? { |variant| schema_matches_shape?(value, variant, root_schema) }
-          end
-
-          if schema.key?(:const) || schema.key?("const")
-            constant = schema.key?(:const) ? schema[:const] : schema["const"]
-            return value == constant
-          end
-
-          types = Array(schema[:type] || schema["type"])
-          return true if types.empty?
-
-          types.any? do |type|
-            case type
-            when "object"
-              value.is_a?(Hash)
-            when "array"
-              value.is_a?(Array)
-            when "null"
-              value.nil?
-            when "string"
-              value.is_a?(String)
-            when "integer"
-              value.is_a?(Integer)
-            when "number"
-              value.is_a?(Numeric)
-            when "boolean"
-              [true, false].include?(value)
-            else
-              true
-            end
-          end
-        end
-
-        def self.resolve_schema(schema, root_schema)
-          reference = schema["$ref"] || schema[:$ref]
-          return schema unless reference
-
-          definitions = root_schema["$defs"] || root_schema[:$defs] || {}
-          token = URI.decode_uri_component(reference.delete_prefix("#/$defs/"))
-          name = token.gsub("~1", "/").gsub("~0", "~")
-          definitions[name] || definitions[name.to_sym]
         end
 
         def self.duplicate_retrieval_params(value)
@@ -338,14 +255,12 @@ module OpenAI
 
         private_class_method(
           :duplicate_retrieval_params,
-          :known_properties?,
+          :parsable_output,
           :pending_status?,
-          :resolve_schema,
+          :prepare_value,
           :retrieval_complete?,
-          :schema_matches_shape?,
           :unfinished_function_call?,
-          :unfinished_message?,
-          :value_ready?
+          :unfinished_message?
         )
       end
     end

--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -35,17 +35,19 @@ module OpenAI
               end
           end
 
-          raw[:output]&.each do |output|
-            next unless output[:type] == "function_call"
-            next if (model = tool_models[output.fetch(:name)]).nil?
-            begin
-              parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
-            rescue JSON::ParserError => e
-              parsed = e
-            end
+          unless tool_models.empty?
+            raw[:output]&.each do |output|
+              next unless output[:type] == "function_call"
+              next if (model = tool_models[output.fetch(:name)]).nil?
+              begin
+                parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
+              rescue JSON::ParserError => e
+                parsed = e
+              end
 
-            coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
-            output.store(:parsed, coerced)
+              coerced = OpenAI::Internal::Type::Converter.coerce(model, parsed)
+              output.store(:parsed, coerced)
+            end
           end
 
           raw

--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -38,7 +38,8 @@ module OpenAI
           unless tool_models.empty?
             raw[:output]&.each do |output|
               next unless output[:type] == "function_call"
-              next if (model = tool_models[output.fetch(:name)]).nil?
+              next unless (name = output[:name])
+              next if (model = tool_models[name]).nil?
               begin
                 parsed = JSON.parse(output.fetch(:arguments), symbolize_names: true)
               rescue JSON::ParserError => e

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -577,7 +577,7 @@ module OpenAI
       end
 
       def structured_output_response_complete?(raw)
-        return raw[:status] == "completed" unless raw[:status].nil?
+        return false unless [nil, "completed"].include?(raw[:status])
 
         raw[:output].to_a.none? do |output|
           ["queued", "in_progress", "incomplete"].include?(output[:status])
@@ -596,6 +596,7 @@ module OpenAI
             if normalized_key == :type && ["function", "json_schema"].include?(normalized_item)
               normalized_item = normalized_item.to_sym
             end
+
             [normalized_key, normalized_item]
           end
         else

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -392,6 +392,8 @@ module OpenAI
 
         unwrap = if model || !tool_models.empty?
           -> (raw) do
+            next raw unless raw[:status] == "completed"
+
             parse_structured_outputs!(raw, model, tool_models)
           end
         end

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -392,7 +392,7 @@ module OpenAI
 
         unwrap = if model || !tool_models.empty?
           -> (raw) do
-            next raw if ["in_progress", "queued"].include?(raw[:status])
+            next raw unless [nil, "completed"].include?(raw[:status])
 
             parse_structured_outputs!(raw, model, tool_models)
           end
@@ -581,7 +581,10 @@ module OpenAI
         when Array
           value.map { |item| duplicate_structured_output_params(item) }
         when Hash
-          value.to_h { |key, item| [key, duplicate_structured_output_params(item)] }
+          value.to_h do |key, item|
+            normalized_key = key.is_a?(String) ? key.to_sym : key
+            [normalized_key, duplicate_structured_output_params(item)]
+          end
         else
           value
         end

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -378,12 +378,10 @@ module OpenAI
       #
       # @see OpenAI::Models::Responses::ResponseRetrieveParams
       def retrieve(response_id, params = {})
-        structured_output_params = duplicate_structured_output_params(params.slice(:text, :tools))
-        request_params = params.dup
-        request_params.delete(:text)
-        request_params.delete(:tools)
-
-        parsed, options = OpenAI::Responses::ResponseRetrieveParams.dump_request(request_params)
+        parsed, options = OpenAI::Responses::ResponseRetrieveParams.dump_request(params)
+        structured_output_params = duplicate_structured_output_params(parsed.slice(:text, :tools))
+        parsed.delete(:text)
+        parsed.delete(:tools)
         query = OpenAI::Internal::Util.encode_query_params(parsed)
         if parsed[:stream]
           message = "Please use `#retrieve_streaming` for the streaming use case."
@@ -392,8 +390,10 @@ module OpenAI
 
         model, tool_models = get_structured_output_models(structured_output_params)
 
-        unwrap = -> (raw) do
-          parse_structured_outputs!(raw, model, tool_models)
+        unwrap = if model || !tool_models.empty?
+          -> (raw) do
+            parse_structured_outputs!(raw, model, tool_models)
+          end
         end
 
         @client.request(

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -392,7 +392,7 @@ module OpenAI
 
         unwrap = if model || !tool_models.empty?
           -> (raw) do
-            next raw unless structured_output_response_complete?(raw)
+            next raw unless structured_output_response_complete?(raw, model, tool_models)
 
             parse_structured_outputs!(raw, model, tool_models)
           end
@@ -576,12 +576,50 @@ module OpenAI
         OpenAI::Helpers::StructuredOutput::ResponseParser.get_models(parsed)
       end
 
-      def structured_output_response_complete?(raw)
+      def structured_output_response_complete?(raw, model, tool_models)
         return false unless [nil, "completed"].include?(raw[:status])
 
         raw[:output].to_a.none? do |output|
-          ["queued", "in_progress", "incomplete"].include?(output[:status])
+          case output[:type]
+          when "message"
+            model && unfinished_structured_output_message?(output)
+          when "function_call"
+            unfinished_structured_output_function_call?(output, tool_models)
+          else
+            false
+          end
         end
+      end
+
+      def unfinished_structured_output_message?(output)
+        return true if structured_output_pending_status?(output[:status])
+        return false unless output[:status].nil?
+
+        output[:content].to_a.any? do |content|
+          content[:type] == "output_text" &&
+            (!content.key?(:text) || !valid_structured_output_json?(content[:text]))
+        end
+      end
+
+      def unfinished_structured_output_function_call?(output, tool_models)
+        return false if tool_models.empty?
+        return true unless output.key?(:name)
+        return false unless tool_models.key?(output[:name])
+        return true if structured_output_pending_status?(output[:status])
+        return true unless output.key?(:arguments)
+
+        output[:status].nil? && !valid_structured_output_json?(output[:arguments])
+      end
+
+      def structured_output_pending_status?(status)
+        ["queued", "in_progress", "incomplete"].include?(status)
+      end
+
+      def valid_structured_output_json?(value)
+        JSON.parse(value)
+        true
+      rescue JSON::ParserError, TypeError
+        false
       end
 
       def duplicate_structured_output_params(value)

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -582,44 +582,37 @@ module OpenAI
         raw[:output].to_a.none? do |output|
           case output[:type]
           when "message"
-            model && unfinished_structured_output_message?(output)
+            model && unfinished_structured_output_message?(output, response_status: raw[:status])
           when "function_call"
-            unfinished_structured_output_function_call?(output, tool_models)
+            unfinished_structured_output_function_call?(
+              output,
+              tool_models,
+              response_status: raw[:status]
+            )
           else
             false
           end
         end
       end
 
-      def unfinished_structured_output_message?(output)
+      def unfinished_structured_output_message?(output, response_status:)
         return true if structured_output_pending_status?(output[:status])
-        return false unless output[:status].nil?
+        return false unless response_status.nil? && output[:status].nil?
 
-        output[:content].to_a.any? do |content|
-          content[:type] == "output_text" &&
-            (!content.key?(:text) || !valid_structured_output_json?(content[:text]))
-        end
+        output[:content].to_a.any? { |content| content[:type] == "output_text" }
       end
 
-      def unfinished_structured_output_function_call?(output, tool_models)
+      def unfinished_structured_output_function_call?(output, tool_models, response_status:)
         return false if tool_models.empty?
-        return true unless output.key?(:name)
+        return false unless output.key?(:name)
         return false unless tool_models.key?(output[:name])
         return true if structured_output_pending_status?(output[:status])
-        return true unless output.key?(:arguments)
 
-        output[:status].nil? && !valid_structured_output_json?(output[:arguments])
+        response_status.nil? && output[:status].nil?
       end
 
       def structured_output_pending_status?(status)
         ["queued", "in_progress", "incomplete"].include?(status)
-      end
-
-      def valid_structured_output_json?(value)
-        JSON.parse(value)
-        true
-      rescue JSON::ParserError, TypeError
-        false
       end
 
       def duplicate_structured_output_params(value)

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -356,7 +356,7 @@ module OpenAI
       #
       # Retrieves a model response with the given ID.
       #
-      # @overload retrieve(response_id, include: nil, include_obfuscation: nil, starting_after: nil, request_options: {})
+      # @overload retrieve(response_id, include: nil, include_obfuscation: nil, starting_after: nil, text: nil, tools: nil, request_options: {})
       #
       # @param response_id [String] The ID of the response to retrieve.
       #
@@ -366,23 +366,41 @@ module OpenAI
       #
       # @param starting_after [Integer] The sequence number of the event after which to start streaming.
       #
+      # @param text [OpenAI::StructuredOutput::JsonSchemaConverter, nil] The structured-output model used to parse retrieved text output. This is a
+      #   local parsing hint and is not sent to the API.
+      #
+      # @param tools [Array<OpenAI::StructuredOutput::JsonSchemaConverter>, nil] Structured-output models used to parse retrieved function tool calls. These
+      #   are local parsing hints and are not sent to the API.
+      #
       # @param request_options [OpenAI::RequestOptions, Hash{Symbol=>Object}, nil]
       #
       # @return [OpenAI::Models::Responses::Response]
       #
       # @see OpenAI::Models::Responses::ResponseRetrieveParams
       def retrieve(response_id, params = {})
-        parsed, options = OpenAI::Responses::ResponseRetrieveParams.dump_request(params)
+        structured_output_params = duplicate_structured_output_params(params.slice(:text, :tools))
+        request_params = params.dup
+        request_params.delete(:text)
+        request_params.delete(:tools)
+
+        parsed, options = OpenAI::Responses::ResponseRetrieveParams.dump_request(request_params)
         query = OpenAI::Internal::Util.encode_query_params(parsed)
         if parsed[:stream]
           message = "Please use `#retrieve_streaming` for the streaming use case."
           raise ArgumentError.new(message)
         end
 
+        model, tool_models = get_structured_output_models(structured_output_params)
+
+        unwrap = -> (raw) do
+          parse_structured_outputs!(raw, model, tool_models)
+        end
+
         @client.request(
           method: :get,
           path: ["responses/%1$s", response_id],
           query: query,
+          unwrap: unwrap,
           model: OpenAI::Responses::Response,
           security: {bearer_auth: true},
           options: options
@@ -554,6 +572,17 @@ module OpenAI
 
       def get_structured_output_models(parsed)
         OpenAI::Helpers::StructuredOutput::ResponseParser.get_models(parsed)
+      end
+
+      def duplicate_structured_output_params(value)
+        case value
+        when Array
+          value.map { |item| duplicate_structured_output_params(item) }
+        when Hash
+          value.to_h { |key, item| [key, duplicate_structured_output_params(item)] }
+        else
+          value
+        end
       end
     end
   end

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -392,7 +392,7 @@ module OpenAI
 
         unwrap = if model || !tool_models.empty?
           -> (raw) do
-            next raw unless raw[:status] == "completed"
+            next raw if ["in_progress", "queued"].include?(raw[:status])
 
             parse_structured_outputs!(raw, model, tool_models)
           end

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -392,7 +392,7 @@ module OpenAI
 
         unwrap = if model || !tool_models.empty?
           -> (raw) do
-            next raw unless [nil, "completed"].include?(raw[:status])
+            next raw unless structured_output_response_complete?(raw)
 
             parse_structured_outputs!(raw, model, tool_models)
           end
@@ -576,6 +576,14 @@ module OpenAI
         OpenAI::Helpers::StructuredOutput::ResponseParser.get_models(parsed)
       end
 
+      def structured_output_response_complete?(raw)
+        return raw[:status] == "completed" unless raw[:status].nil?
+
+        raw[:output].to_a.none? do |output|
+          ["queued", "in_progress", "incomplete"].include?(output[:status])
+        end
+      end
+
       def duplicate_structured_output_params(value)
         case value
         when Array
@@ -583,8 +591,11 @@ module OpenAI
         when Hash
           value.to_h do |key, item|
             normalized_key = key.is_a?(String) ? key.to_sym : key
+            normalized_key = :format if normalized_key == :format_
             normalized_item = duplicate_structured_output_params(item)
-            normalized_item = :function if normalized_key == :type && normalized_item == "function"
+            if normalized_key == :type && ["function", "json_schema"].include?(normalized_item)
+              normalized_item = normalized_item.to_sym
+            end
             [normalized_key, normalized_item]
           end
         else

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -583,7 +583,9 @@ module OpenAI
         when Hash
           value.to_h do |key, item|
             normalized_key = key.is_a?(String) ? key.to_sym : key
-            [normalized_key, duplicate_structured_output_params(item)]
+            normalized_item = duplicate_structured_output_params(item)
+            normalized_item = :function if normalized_key == :type && normalized_item == "function"
+            [normalized_key, normalized_item]
           end
         else
           value

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -394,7 +394,7 @@ module OpenAI
           -> (raw) do
             next raw unless structured_output_response_complete?(raw, model, tool_models)
 
-            parse_structured_outputs!(raw, model, tool_models)
+            parse_retrieved_structured_outputs!(raw, model, tool_models)
           end
         end
 
@@ -572,6 +572,15 @@ module OpenAI
         OpenAI::Helpers::StructuredOutput::ResponseParser.parse!(raw, model, tool_models)
       end
 
+      def parse_retrieved_structured_outputs!(raw, model, tool_models)
+        parsable_output = raw[:output].to_a.reject do |output|
+          output[:type] == "function_call" && !output.key?(:name)
+        end
+
+        parse_structured_outputs!(raw.merge(output: parsable_output), model, tool_models)
+        raw
+      end
+
       def get_structured_output_models(parsed)
         OpenAI::Helpers::StructuredOutput::ResponseParser.get_models(parsed)
       end
@@ -582,7 +591,7 @@ module OpenAI
         raw[:output].to_a.none? do |output|
           case output[:type]
           when "message"
-            model && unfinished_structured_output_message?(output, response_status: raw[:status])
+            model && unfinished_structured_output_message?(output, model, response_status: raw[:status])
           when "function_call"
             unfinished_structured_output_function_call?(
               output,
@@ -595,11 +604,14 @@ module OpenAI
         end
       end
 
-      def unfinished_structured_output_message?(output, response_status:)
+      def unfinished_structured_output_message?(output, model, response_status:)
         return true if structured_output_pending_status?(output[:status])
         return false unless response_status.nil? && output[:status].nil?
 
-        output[:content].to_a.any? { |content| content[:type] == "output_text" }
+        output[:content].to_a.any? do |content|
+          content[:type] == "output_text" &&
+            (!content.key?(:text) || !structured_output_value_ready?(content[:text], model))
+        end
       end
 
       def unfinished_structured_output_function_call?(output, tool_models, response_status:)
@@ -607,12 +619,24 @@ module OpenAI
         return false unless output.key?(:name)
         return false unless tool_models.key?(output[:name])
         return true if structured_output_pending_status?(output[:status])
+        return false unless response_status.nil? && output[:status].nil?
 
-        response_status.nil? && output[:status].nil?
+        !output.key?(:arguments) ||
+          !structured_output_value_ready?(output[:arguments], tool_models.fetch(output[:name]))
       end
 
       def structured_output_pending_status?(status)
         ["queued", "in_progress", "incomplete"].include?(status)
+      end
+
+      def structured_output_value_ready?(value, model)
+        parsed = JSON.parse(value, symbolize_names: true)
+        state = OpenAI::Internal::Type::Converter.new_coerce_state
+        OpenAI::Internal::Type::Converter.coerce(model, parsed, state: state)
+        exactness = state.fetch(:exactness)
+        exactness.fetch(:no).zero? && exactness.fetch(:maybe).zero?
+      rescue JSON::ParserError, TypeError
+        false
       end
 
       def duplicate_structured_output_params(value)

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -366,11 +366,13 @@ module OpenAI
       #
       # @param starting_after [Integer] The sequence number of the event after which to start streaming.
       #
-      # @param text [OpenAI::StructuredOutput::JsonSchemaConverter, nil] The structured-output model used to parse retrieved text output. This is a
-      #   local parsing hint and is not sent to the API.
+      # @param text [OpenAI::Responses::ResponseTextConfig, OpenAI::StructuredOutput::JsonSchemaConverter, Hash, nil] The structured-output model,
+      #   or the same typed/hash text configuration accepted by creation, used to parse retrieved text output. This is a local parsing hint and is not
+      #   sent to the API.
       #
-      # @param tools [Array<OpenAI::StructuredOutput::JsonSchemaConverter>, nil] Structured-output models used to parse retrieved function tool calls. These
-      #   are local parsing hints and are not sent to the API.
+      # @param tools [Array<OpenAI::Responses::FunctionTool, OpenAI::StructuredOutput::JsonSchemaConverter, Hash>, nil] Structured-output models, or
+      #   the same typed/hash function-tool definitions accepted by creation, used to parse retrieved function tool calls. These are local parsing hints
+      #   and are not sent to the API.
       #
       # @param request_options [OpenAI::RequestOptions, Hash{Symbol=>Object}, nil]
       #
@@ -379,7 +381,7 @@ module OpenAI
       # @see OpenAI::Models::Responses::ResponseRetrieveParams
       def retrieve(response_id, params = {})
         parsed, options = OpenAI::Responses::ResponseRetrieveParams.dump_request(params)
-        structured_output_params = duplicate_structured_output_params(parsed.slice(:text, :tools))
+        structured_output_params = parsed.slice(:text, :tools)
         parsed.delete(:text)
         parsed.delete(:tools)
         query = OpenAI::Internal::Util.encode_query_params(parsed)
@@ -388,12 +390,10 @@ module OpenAI
           raise ArgumentError.new(message)
         end
 
-        model, tool_models = get_structured_output_models(structured_output_params)
+        model, tool_models = get_retrieval_structured_output_models(structured_output_params)
 
         unwrap = if model || !tool_models.empty?
           -> (raw) do
-            next raw unless structured_output_response_complete?(raw, model, tool_models)
-
             parse_retrieved_structured_outputs!(raw, model, tool_models)
           end
         end
@@ -573,90 +573,15 @@ module OpenAI
       end
 
       def parse_retrieved_structured_outputs!(raw, model, tool_models)
-        parsable_output = raw[:output].to_a.reject do |output|
-          output[:type] == "function_call" && !output.key?(:name)
-        end
-
-        parse_structured_outputs!(raw.merge(output: parsable_output), model, tool_models)
-        raw
+        OpenAI::Helpers::StructuredOutput::ResponseParser.parse_retrieved!(raw, model, tool_models)
       end
 
       def get_structured_output_models(parsed)
         OpenAI::Helpers::StructuredOutput::ResponseParser.get_models(parsed)
       end
 
-      def structured_output_response_complete?(raw, model, tool_models)
-        return false unless [nil, "completed"].include?(raw[:status])
-
-        raw[:output].to_a.none? do |output|
-          case output[:type]
-          when "message"
-            model && unfinished_structured_output_message?(output, model, response_status: raw[:status])
-          when "function_call"
-            unfinished_structured_output_function_call?(
-              output,
-              tool_models,
-              response_status: raw[:status]
-            )
-          else
-            false
-          end
-        end
-      end
-
-      def unfinished_structured_output_message?(output, model, response_status:)
-        return true if structured_output_pending_status?(output[:status])
-        return false unless response_status.nil? && output[:status].nil?
-
-        output[:content].to_a.any? do |content|
-          content[:type] == "output_text" &&
-            (!content.key?(:text) || !structured_output_value_ready?(content[:text], model))
-        end
-      end
-
-      def unfinished_structured_output_function_call?(output, tool_models, response_status:)
-        return false if tool_models.empty?
-        return false unless output.key?(:name)
-        return false unless tool_models.key?(output[:name])
-        return true if structured_output_pending_status?(output[:status])
-        return false unless response_status.nil? && output[:status].nil?
-
-        !output.key?(:arguments) ||
-          !structured_output_value_ready?(output[:arguments], tool_models.fetch(output[:name]))
-      end
-
-      def structured_output_pending_status?(status)
-        ["queued", "in_progress", "incomplete"].include?(status)
-      end
-
-      def structured_output_value_ready?(value, model)
-        parsed = JSON.parse(value, symbolize_names: true)
-        state = OpenAI::Internal::Type::Converter.new_coerce_state
-        OpenAI::Internal::Type::Converter.coerce(model, parsed, state: state)
-        exactness = state.fetch(:exactness)
-        exactness.fetch(:no).zero? && exactness.fetch(:maybe).zero?
-      rescue JSON::ParserError, TypeError
-        false
-      end
-
-      def duplicate_structured_output_params(value)
-        case value
-        when Array
-          value.map { |item| duplicate_structured_output_params(item) }
-        when Hash
-          value.to_h do |key, item|
-            normalized_key = key.is_a?(String) ? key.to_sym : key
-            normalized_key = :format if normalized_key == :format_
-            normalized_item = duplicate_structured_output_params(item)
-            if normalized_key == :type && ["function", "json_schema"].include?(normalized_item)
-              normalized_item = normalized_item.to_sym
-            end
-
-            [normalized_key, normalized_item]
-          end
-        else
-          value
-        end
+      def get_retrieval_structured_output_models(parsed)
+        OpenAI::Helpers::StructuredOutput::ResponseParser.get_retrieval_models(parsed)
       end
     end
   end

--- a/rbi/openai/helpers/structured_output/response_parser.rbi
+++ b/rbi/openai/helpers/structured_output/response_parser.rbi
@@ -17,6 +17,17 @@ module OpenAI
         end
 
         sig do
+          params(
+            raw: OpenAI::Internal::AnyHash,
+            model: T.nilable(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input),
+            tool_models: T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+          )
+            .returns(OpenAI::Internal::AnyHash)
+        end
+        def self.parse_retrieved!(raw, model, tool_models)
+        end
+
+        sig do
           params(parsed: OpenAI::Internal::AnyHash)
             .returns(
               [
@@ -26,6 +37,18 @@ module OpenAI
             )
         end
         def self.get_models(parsed)
+        end
+
+        sig do
+          params(parsed: OpenAI::Internal::AnyHash)
+            .returns(
+              [
+                T.nilable(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input),
+                T::Hash[String, OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::Input]
+              ]
+            )
+        end
+        def self.get_retrieval_models(parsed)
         end
       end
     end

--- a/rbi/openai/resources/responses.rbi
+++ b/rbi/openai/resources/responses.rbi
@@ -878,7 +878,14 @@ module OpenAI
               OpenAI::StructuredOutput::JsonSchemaConverter::Input
             )
           ),
-          tools: T.nilable(T::Array[OpenAI::StructuredOutput::JsonSchemaConverter::Input]),
+          tools: T.nilable(
+            T::Array[
+              T.any(
+                OpenAI::Responses::FunctionTool::OrHash,
+                OpenAI::StructuredOutput::JsonSchemaConverter::Input
+              )
+            ]
+          ),
           stream: T.noreturn,
           request_options: OpenAI::RequestOptions::OrHash
         )

--- a/rbi/openai/resources/responses.rbi
+++ b/rbi/openai/resources/responses.rbi
@@ -872,6 +872,8 @@ module OpenAI
           include: T::Array[OpenAI::Responses::ResponseIncludable::OrSymbol],
           include_obfuscation: T::Boolean,
           starting_after: Integer,
+          text: T.nilable(OpenAI::StructuredOutput::JsonSchemaConverter::Input),
+          tools: T.nilable(T::Array[OpenAI::StructuredOutput::JsonSchemaConverter::Input]),
           stream: T.noreturn,
           request_options: OpenAI::RequestOptions::OrHash
         )
@@ -892,6 +894,12 @@ module OpenAI
         include_obfuscation: nil,
         # The sequence number of the event after which to start streaming.
         starting_after: nil,
+        # The structured-output model used to parse retrieved text output. This is a
+        # local parsing hint and is not sent to the API.
+        text: nil,
+        # Structured-output models used to parse retrieved function tool calls. These
+        # are local parsing hints and are not sent to the API.
+        tools: nil,
         # There is no need to provide `stream:`. Instead, use `#retrieve_streaming` or
         # `#retrieve` for streaming and non-streaming use cases, respectively.
         stream: false,

--- a/rbi/openai/resources/responses.rbi
+++ b/rbi/openai/resources/responses.rbi
@@ -872,7 +872,12 @@ module OpenAI
           include: T::Array[OpenAI::Responses::ResponseIncludable::OrSymbol],
           include_obfuscation: T::Boolean,
           starting_after: Integer,
-          text: T.nilable(OpenAI::StructuredOutput::JsonSchemaConverter::Input),
+          text: T.nilable(
+            T.any(
+              OpenAI::Responses::ResponseTextConfig::OrHash,
+              OpenAI::StructuredOutput::JsonSchemaConverter::Input
+            )
+          ),
           tools: T.nilable(T::Array[OpenAI::StructuredOutput::JsonSchemaConverter::Input]),
           stream: T.noreturn,
           request_options: OpenAI::RequestOptions::OrHash

--- a/sig/openai/helpers/structured_output/response_parser.rbs
+++ b/sig/openai/helpers/structured_output/response_parser.rbs
@@ -8,7 +8,17 @@ module OpenAI
           ::Hash[String, top] tool_models
         ) -> ::Hash[Symbol, top]
 
+        def self.parse_retrieved!: (
+          ::Hash[Symbol, top] raw,
+          top model,
+          ::Hash[String, top] tool_models
+        ) -> ::Hash[Symbol, top]
+
         def self.get_models: (
+          ::Hash[Symbol, top] parsed
+        ) -> [top, ::Hash[String, top]]
+
+        def self.get_retrieval_models: (
           ::Hash[Symbol, top] parsed
         ) -> [top, ::Hash[String, top]]
       end

--- a/sig/openai/resources/responses.rbs
+++ b/sig/openai/resources/responses.rbs
@@ -108,6 +108,8 @@ module OpenAI
         ?include: ::Array[OpenAI::Models::Responses::response_includable],
         ?include_obfuscation: bool,
         ?starting_after: Integer,
+        ?text: top,
+        ?tools: ::Array[top]?,
         ?request_options: OpenAI::request_opts
       ) -> OpenAI::Responses::Response
 

--- a/test/openai/helpers/response_parser_test.rb
+++ b/test/openai/helpers/response_parser_test.rb
@@ -150,6 +150,12 @@ class OpenAI::Test::ResponseParserTest < Minitest::Test
 
       assert_equal(key, error.key)
     end
+
+    error = assert_raises(KeyError) do
+      ResponsesProbe.allocate.parse({output: [{type: "function_call"}]}, nil, {})
+    end
+
+    assert_equal(:name, error.key)
   end
 
   def test_empty_outputs_and_private_delegate_visibility_are_preserved

--- a/test/openai/helpers/response_parser_test.rb
+++ b/test/openai/helpers/response_parser_test.rb
@@ -168,4 +168,54 @@ class OpenAI::Test::ResponseParserTest < Minitest::Test
     refute_includes(OpenAI::Resources::Responses.public_instance_methods, :get_structured_output_models)
     refute_includes(OpenAI::Resources::Responses.public_instance_methods, :parse_structured_outputs!)
   end
+
+  def test_statusless_retrieval_parses_ready_output_once
+    text = {type: "output_text", text: "{\"value\":\"hello\"}"}
+    raw = {output: [{type: "message", content: [text]}]}
+    parse = JSON.method(:parse)
+    calls = 0
+
+    JSON.stub(
+      :parse,
+      -> (*args, **kwargs) {
+        calls += 1
+        parse.call(*args, **kwargs)
+      }
+    ) do
+      result = OpenAI::Helpers::StructuredOutput::ResponseParser.parse_retrieved!(raw, TextModel, {})
+
+      assert_same(raw, result)
+    end
+
+    assert_equal(1, calls)
+    assert_instance_of(TextModel, text.fetch(:parsed))
+  end
+
+  def test_statusless_retrieval_does_not_coerce_before_all_output_is_ready
+    text = {type: "output_text", text: "{\"value\":\"hello\"}"}
+    tool = {type: "function_call", name: "known", arguments: "{\"argument\":"}
+    raw = {output: [{type: "message", content: [text]}, tool]}
+    coerce = OpenAI::Internal::Type::Converter.method(:coerce)
+    calls = 0
+
+    OpenAI::Internal::Type::Converter.stub(
+      :coerce,
+      -> (*args, **kwargs) {
+        calls += 1
+        coerce.call(*args, **kwargs)
+      }
+    ) do
+      result = OpenAI::Helpers::StructuredOutput::ResponseParser.parse_retrieved!(
+        raw,
+        TextModel,
+        {"known" => ToolModel}
+      )
+
+      assert_same(raw, result)
+    end
+
+    assert_equal(0, calls)
+    refute(text.key?(:parsed))
+    refute(tool.key?(:parsed))
+  end
 end

--- a/test/openai/helpers/sorbet_structured_output_test.rb
+++ b/test/openai/helpers/sorbet_structured_output_test.rb
@@ -809,6 +809,19 @@ if ENV.fetch("OPENAI_SORBET_STRUCTURED_OUTPUT_CHILD", "0") == "1"
       assert_equal("Ada", parsed.participants.first.display_name)
     end
 
+    def test_responses_retrieve_accepts_frozen_ordinary_tool_hints
+      stub_request(:get, "http://localhost/responses/resp_frozen_tools").to_return_json(
+        status: 200,
+        body: {id: "resp_frozen_tools", status: "completed", output: []}
+      )
+
+      tools = [ExistingInstanceFormat.new].freeze
+      response = @client.responses.retrieve("resp_frozen_tools", tools: tools)
+
+      assert_empty(response.output)
+      assert_equal(1, tools.length)
+    end
+
     def test_responses_retrieve_rejects_unsupported_sorbet_function_tools_before_sending_a_request
       error = assert_raises(ArgumentError) do
         @client.responses.retrieve("resp_secret", tools: [@adapter])

--- a/test/openai/helpers/sorbet_structured_output_test.rb
+++ b/test/openai/helpers/sorbet_structured_output_test.rb
@@ -831,6 +831,17 @@ if ENV.fetch("OPENAI_SORBET_STRUCTURED_OUTPUT_CHILD", "0") == "1"
       assert_not_requested(:get, "http://localhost/responses/resp_secret")
     end
 
+    def test_responses_retrieve_rejects_string_keyed_sorbet_tools_in_typed_params
+      params = OpenAI::Responses::ResponseRetrieveParams.new("tools" => [@adapter])
+
+      error = assert_raises(ArgumentError) do
+        @client.responses.retrieve("resp_secret", params)
+      end
+
+      assert_includes(error.message, "function tools are not supported")
+      assert_not_requested(:get, "http://localhost/responses/resp_secret")
+    end
+
     def test_ordinary_sdk_loading_does_not_load_sorbet_runtime
       root = File.expand_path("../../..", __dir__)
       code = "require \"openai\"; abort(\"Sorbet was loaded\") if defined?(T)"

--- a/test/openai/helpers/sorbet_structured_output_test.rb
+++ b/test/openai/helpers/sorbet_structured_output_test.rb
@@ -809,6 +809,27 @@ if ENV.fetch("OPENAI_SORBET_STRUCTURED_OUTPUT_CHILD", "0") == "1"
       assert_equal("Ada", parsed.participants.first.display_name)
     end
 
+    def test_statusless_retrieve_surfaces_sorbet_hydration_errors_for_complete_json
+      stub_request(:get, "http://localhost/responses/resp_statusless_invalid_sorbet").to_return_json(
+        status: 200,
+        body: {
+          id: "resp_statusless_invalid_sorbet",
+          output: [
+            {
+              id: "msg_statusless_invalid_sorbet",
+              content: [{annotations: [], text: "{}", type: "output_text"}],
+              role: "assistant",
+              type: "message"
+            }
+          ]
+        }
+      )
+
+      assert_raises(OpenAI::StructuredOutput::SorbetAdapter::HydrationError) do
+        @client.responses.retrieve("resp_statusless_invalid_sorbet", text: @adapter)
+      end
+    end
+
     def test_responses_retrieve_accepts_frozen_ordinary_tool_hints
       stub_request(:get, "http://localhost/responses/resp_frozen_tools").to_return_json(
         status: 200,

--- a/test/openai/helpers/sorbet_structured_output_test.rb
+++ b/test/openai/helpers/sorbet_structured_output_test.rb
@@ -53,6 +53,10 @@ else
           const :participants, T::Array[TypedParticipant]
         end
 
+        class LookupModel < OpenAI::BaseModel
+          required :participant_id, Integer
+        end
+
         schema = OpenAI::StructuredOutput.from_sorbet(TypedEvent)
         client = OpenAI::Client.new(api_key: "test-key")
         response = client.responses.create(model: "gpt-4o-mini", input: "test", text: schema)
@@ -67,6 +71,12 @@ else
           response_format: schema
         )
         T.cast(completion.choices.fetch(0).message.parsed, TypedEvent)
+
+        retrieved = client.responses.retrieve(
+          "resp_123",
+          tools: [{type: :function, function: {name: "custom_lookup", parameters: LookupModel}}]
+        )
+        T.assert_type!(retrieved, OpenAI::Responses::Response)
       RUBY
 
       Tempfile.create(["sorbet-structured-output", ".rb"]) do |file|
@@ -772,6 +782,40 @@ if ENV.fetch("OPENAI_SORBET_STRUCTURED_OUTPUT_CHILD", "0") == "1"
 
       assert_instance_of(CalendarEvent, parsed)
       assert_equal("Ada", parsed.participants.first.display_name)
+    end
+
+    def test_responses_retrieve_hydrates_sorbet_text_models
+      stub_request(:get, "http://localhost/responses/resp_sorbet_retrieve").to_return_json(
+        status: 200,
+        body: {
+          id: "resp_sorbet_retrieve",
+          status: "completed",
+          output: [
+            {
+              id: "msg_sorbet_retrieve",
+              content: [{annotations: [], text: event_payload.to_json, type: "output_text"}],
+              role: "assistant",
+              status: "completed",
+              type: "message"
+            }
+          ]
+        }
+      )
+
+      response = @client.responses.retrieve("resp_sorbet_retrieve", text: @adapter)
+      parsed = response.output.first.content.first.parsed
+
+      assert_instance_of(CalendarEvent, parsed)
+      assert_equal("Ada", parsed.participants.first.display_name)
+    end
+
+    def test_responses_retrieve_rejects_unsupported_sorbet_function_tools_before_sending_a_request
+      error = assert_raises(ArgumentError) do
+        @client.responses.retrieve("resp_secret", tools: [@adapter])
+      end
+
+      assert_includes(error.message, "function tools are not supported")
+      assert_not_requested(:get, "http://localhost/responses/resp_secret")
     end
 
     def test_ordinary_sdk_loading_does_not_load_sorbet_runtime

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -347,6 +347,57 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
   end
 
+  def test_background_retrieve_parses_schema_valid_statusless_text
+    stub_request(:get, "http://localhost/responses/resp_statusless_valid_text").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_valid_text",
+        output: [
+          {
+            id: "msg_statusless_valid_text",
+            content: [
+              {
+                annotations: [],
+                text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_valid_text", text: AliasedProfile)
+
+    assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_parses_schema_valid_statusless_arguments
+    stub_request(:get, "http://localhost/responses/resp_statusless_valid_arguments").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_valid_arguments",
+        output: [
+          {
+            arguments: "{\"profileId\":7}",
+            call_id: "call_statusless_valid_arguments",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_statusless_valid_arguments",
+      tools: [AliasedLookup]
+    )
+
+    assert_instance_of(AliasedLookup, response.output.fetch(0).parsed)
+  end
+
   def test_background_retrieve_defers_item_status_without_top_level_status
     stub_request(:get, "http://localhost/responses/resp_item_pending").to_return_json(
       status: 200,
@@ -485,6 +536,27 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     )
 
     response = @client.responses.retrieve("resp_statusless_incomplete_text", text: AliasedProfile)
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_text_missing_required_nullable_field
+    stub_request(:get, "http://localhost/responses/resp_statusless_missing_nullable").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_missing_nullable",
+        output: [
+          {
+            id: "msg_statusless_missing_nullable",
+            content: [{annotations: [], text: "{\"displayName\":\"Ada\"}", type: "output_text"}],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_missing_nullable", text: AliasedProfile)
 
     assert_nil(response.output.fetch(0).content.fetch(0).parsed)
   end

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -333,6 +333,117 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_empty(response.output)
   end
 
+  def test_background_retrieve_keeps_string_keyed_parsing_hints_local
+    stub_request(:get, "http://localhost/responses/resp_string_hints").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_string_hints",
+        status: "completed",
+        output: [
+          {
+            id: "msg_string_hints",
+            content: [
+              {
+                annotations: [],
+                text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            status: "completed",
+            type: "message"
+          },
+          {
+            arguments: "{\"profileId\":7}",
+            call_id: "call_string_hints",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_string_hints",
+      {"text" => AliasedProfile, "tools" => [AliasedLookup]}
+    )
+
+    assert_requested(:get, "http://localhost/responses/resp_string_hints") do |request|
+      assert_nil(request.uri.query)
+    end
+
+    assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
+    assert_instance_of(AliasedLookup, response.output.fetch(1).parsed)
+  end
+
+  def test_background_retrieve_accepts_response_retrieve_params
+    stub_request(:get, "http://localhost/responses/resp_params").to_return_json(
+      status: 200,
+      body: {id: "resp_params", status: "in_progress", output: []}
+    )
+
+    params = OpenAI::Responses::ResponseRetrieveParams.new
+    response = @client.responses.retrieve("resp_params", params)
+
+    assert_requested(:get, "http://localhost/responses/resp_params") do |request|
+      assert_nil(request.uri.query)
+    end
+
+    assert_empty(response.output)
+  end
+
+  def test_typed_text_config_has_create_and_retrieve_parity
+    output = [
+      {
+        id: "msg_text_config",
+        content: [
+          {
+            annotations: [],
+            text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+            type: "output_text"
+          }
+        ],
+        role: "assistant",
+        status: "completed",
+        type: "message"
+      }
+    ]
+    stub_request(:post, "http://localhost/responses").to_return_json(
+      status: 200,
+      body: {id: "resp_created_text_config", status: "completed", output: output}
+    )
+    stub_request(:get, "http://localhost/responses/resp_text_config").to_return_json(
+      status: 200,
+      body: {id: "resp_text_config", status: "completed", output: output}
+    )
+
+    config = OpenAI::Responses::ResponseTextConfig.new(format_: AliasedProfile)
+    created = @client.responses.create(input: "Create a profile", model: "gpt-4o-mini", text: config)
+    retrieved = @client.responses.retrieve("resp_text_config", text: config)
+
+    created_parsed = created.output.fetch(0).content.fetch(0).parsed
+    retrieved_parsed = retrieved.output.fetch(0).content.fetch(0).parsed
+
+    assert_instance_of(AliasedProfile, created_parsed)
+    assert_instance_of(AliasedProfile, retrieved_parsed)
+    assert_equal(created_parsed.display_name, retrieved_parsed.display_name)
+  end
+
+  def test_background_retrieve_without_hints_skips_structured_output_parsing
+    stub_request(:get, "http://localhost/responses/resp_partial_tool").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_partial_tool",
+        status: "in_progress",
+        output: [{type: "function_call"}]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_partial_tool")
+
+    assert_equal(1, response.output.length)
+  end
+
   def test_public_structured_output_endpoints_materialize_nested_models
     profile = {displayName: "Ada", middleName: nil}
     content = {primaryProfile: profile, profiles: [profile]}.to_json

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -378,6 +378,38 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_equal(:function_call, response.output.fetch(1).type)
   end
 
+  def test_background_retrieve_defers_incomplete_items_when_response_is_completed
+    stub_request(:get, "http://localhost/responses/resp_completed_with_incomplete_item").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_completed_with_incomplete_item",
+        status: "completed",
+        output: [
+          {
+            id: "msg_completed_with_incomplete_item",
+            content: [{annotations: [], text: "{\"displayName\":", type: "output_text"}],
+            role: "assistant",
+            status: "incomplete",
+            type: "message"
+          },
+          {status: "incomplete", type: "function_call"}
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_completed_with_incomplete_item",
+      text: AliasedProfile,
+      tools: [AliasedLookup]
+    )
+
+    assert_equal(:completed, response.status)
+    content = response.output.fetch(0).content.fetch(0)
+    assert_equal("{\"displayName\":", content.text)
+    assert_nil(content.parsed)
+    assert_equal(:function_call, response.output.fetch(1).type)
+  end
+
   def test_background_retrieve_parses_explicitly_named_tool_models_locally
     stub_request(:get, "http://localhost/responses/resp_named_tool").to_return_json(
       status: 200,
@@ -629,6 +661,7 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
       assert_requested(:get, "http://localhost/responses/#{response_id}") do |request|
         assert_nil(request.uri.query)
       end
+
       assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
       assert_equal(AliasedProfile, text.values.fetch(0))
     end
@@ -670,6 +703,7 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_requested(:get, "http://localhost/responses/resp_json_schema_hint") do |request|
       assert_nil(request.uri.query)
     end
+
     assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
     assert_equal("json_schema", text.dig("format", "type"))
     assert_equal(AliasedProfile, text.dig("format", "schema"))

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -444,15 +444,109 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_nil(content.parsed)
   end
 
-  def test_background_retrieve_parses_text_with_an_unhinted_partial_tool_call
-    stub_request(:get, "http://localhost/responses/resp_text_with_unhinted_tool").to_return_json(
+  def test_background_retrieve_defers_statusless_schema_incomplete_arguments
+    stub_request(:get, "http://localhost/responses/resp_statusless_incomplete_arguments").to_return_json(
       status: 200,
       body: {
-        id: "resp_text_with_unhinted_tool",
+        id: "resp_statusless_incomplete_arguments",
+        output: [
+          {
+            arguments: "{}",
+            call_id: "call_statusless_incomplete_arguments",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_statusless_incomplete_arguments",
+      tools: [AliasedLookup]
+    )
+
+    assert_nil(response.output.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_schema_incomplete_text
+    stub_request(:get, "http://localhost/responses/resp_statusless_incomplete_text").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_incomplete_text",
+        output: [
+          {
+            id: "msg_statusless_incomplete_text",
+            content: [{annotations: [], text: "{}", type: "output_text"}],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_incomplete_text", text: AliasedProfile)
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_parses_malformed_statusless_arguments_after_completion
+    stub_request(:get, "http://localhost/responses/resp_completed_malformed_arguments").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_completed_malformed_arguments",
         status: "completed",
         output: [
           {
-            id: "msg_text_with_unhinted_tool",
+            arguments: "{\"profileId\":",
+            call_id: "call_completed_malformed_arguments",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_completed_malformed_arguments",
+      tools: [AliasedLookup]
+    )
+
+    assert_raises(OpenAI::Errors::ConversionError) { response.output.fetch(0).parsed }
+  end
+
+  def test_background_retrieve_parses_malformed_statusless_text_after_completion
+    stub_request(:get, "http://localhost/responses/resp_completed_malformed_text").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_completed_malformed_text",
+        status: "completed",
+        output: [
+          {
+            id: "msg_completed_malformed_text",
+            content: [{annotations: [], text: "{\"displayName\":", type: "output_text"}],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_completed_malformed_text", text: AliasedProfile)
+
+    assert_raises(OpenAI::Errors::ConversionError) do
+      response.output.fetch(0).content.fetch(0).parsed
+    end
+  end
+
+  def test_background_retrieve_parses_text_with_a_nameless_tool_call
+    stub_request(:get, "http://localhost/responses/resp_text_with_nameless_tool").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_text_with_nameless_tool",
+        status: "completed",
+        output: [
+          {
+            id: "msg_text_with_nameless_tool",
             content: [
               {
                 annotations: [],
@@ -467,14 +561,17 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
           {
             arguments: "{\"unused\":",
             call_id: "call_unhinted",
-            name: "UnhintedLookup",
             type: "function_call"
           }
         ]
       }
     )
 
-    response = @client.responses.retrieve("resp_text_with_unhinted_tool", text: AliasedProfile)
+    response = @client.responses.retrieve(
+      "resp_text_with_nameless_tool",
+      text: AliasedProfile,
+      tools: [AliasedLookup]
+    )
 
     assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
     assert_nil(response.output.fetch(1).parsed)

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -318,6 +318,35 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_equal([AliasedLookup], tools)
   end
 
+  def test_background_retrieve_parses_completed_text_when_response_status_is_omitted
+    stub_request(:get, "http://localhost/responses/resp_without_status").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_without_status",
+        output: [
+          {
+            id: "msg_without_status",
+            content: [
+              {
+                annotations: [],
+                text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            status: "completed",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_without_status", text: AliasedProfile)
+
+    assert_nil(response.status)
+    assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
+  end
+
   def test_background_retrieve_parses_explicitly_named_tool_models_locally
     stub_request(:get, "http://localhost/responses/resp_named_tool").to_return_json(
       status: 200,

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -378,6 +378,137 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_equal(:function_call, response.output.fetch(1).type)
   end
 
+  def test_background_retrieve_defers_statusless_unfinished_function_calls
+    stub_request(:get, "http://localhost/responses/resp_statusless_function_call").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_function_call",
+        output: [{type: "function_call"}]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_function_call", text: AliasedProfile)
+
+    assert_nil(response.status)
+    assert_equal(:function_call, response.output.fetch(0).type)
+  end
+
+  def test_background_retrieve_defers_statusless_partial_function_arguments
+    stub_request(:get, "http://localhost/responses/resp_statusless_partial_arguments").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_partial_arguments",
+        output: [
+          {
+            arguments: "{\"profileId\":",
+            call_id: "call_statusless_partial_arguments",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_statusless_partial_arguments",
+      tools: [AliasedLookup]
+    )
+    tool_call = response.output.fetch(0)
+
+    assert_nil(response.status)
+    assert_equal("{\"profileId\":", tool_call.arguments)
+    assert_nil(tool_call.parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_partial_text
+    stub_request(:get, "http://localhost/responses/resp_statusless_partial_text").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_partial_text",
+        output: [
+          {
+            id: "msg_statusless_partial_text",
+            content: [{annotations: [], text: "{\"displayName\":", type: "output_text"}],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_partial_text", text: AliasedProfile)
+    content = response.output.fetch(0).content.fetch(0)
+
+    assert_nil(response.status)
+    assert_equal("{\"displayName\":", content.text)
+    assert_nil(content.parsed)
+  end
+
+  def test_background_retrieve_parses_text_with_an_unhinted_partial_tool_call
+    stub_request(:get, "http://localhost/responses/resp_text_with_unhinted_tool").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_text_with_unhinted_tool",
+        status: "completed",
+        output: [
+          {
+            id: "msg_text_with_unhinted_tool",
+            content: [
+              {
+                annotations: [],
+                text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            status: "completed",
+            type: "message"
+          },
+          {
+            arguments: "{\"unused\":",
+            call_id: "call_unhinted",
+            name: "UnhintedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_text_with_unhinted_tool", text: AliasedProfile)
+
+    assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
+    assert_nil(response.output.fetch(1).parsed)
+  end
+
+  def test_background_retrieve_parses_tools_with_unhinted_partial_text
+    stub_request(:get, "http://localhost/responses/resp_tool_with_unhinted_text").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_tool_with_unhinted_text",
+        status: "completed",
+        output: [
+          {
+            id: "msg_unhinted_text",
+            content: [{annotations: [], text: "{\"unused\":", type: "output_text"}],
+            role: "assistant",
+            type: "message"
+          },
+          {
+            arguments: "{\"profileId\":7}",
+            call_id: "call_hinted",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_tool_with_unhinted_text", tools: [AliasedLookup])
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+    assert_instance_of(AliasedLookup, response.output.fetch(1).parsed)
+  end
+
   def test_background_retrieve_defers_incomplete_items_when_response_is_completed
     stub_request(:get, "http://localhost/responses/resp_completed_with_incomplete_item").to_return_json(
       status: 200,

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -318,10 +318,53 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_equal([AliasedLookup], tools)
   end
 
-  def test_background_retrieve_accepts_a_model_before_output_is_complete
+  def test_background_retrieve_parses_explicitly_named_tool_models_locally
+    stub_request(:get, "http://localhost/responses/resp_named_tool").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_named_tool",
+        status: "completed",
+        output: [
+          {
+            arguments: "{\"profileId\":7}",
+            call_id: "call_named_tool",
+            name: "custom_lookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    tools = [{type: :function, function: {name: "custom_lookup", parameters: AliasedLookup}}]
+    response = @client.responses.retrieve("resp_named_tool", tools: tools)
+
+    assert_requested(:get, "http://localhost/responses/resp_named_tool") do |request|
+      assert_nil(request.uri.query)
+    end
+
+    parsed = response.output.fetch(0).parsed
+
+    assert_instance_of(AliasedLookup, parsed)
+    assert_equal(7, parsed.profile_id)
+    assert_equal(AliasedLookup, tools.dig(0, :function, :parameters))
+  end
+
+  def test_background_retrieve_defers_partial_text_parsing_while_in_progress
     stub_request(:get, "http://localhost/responses/resp_pending").to_return_json(
       status: 200,
-      body: {id: "resp_pending", status: "in_progress", output: []}
+      body: {
+        id: "resp_pending",
+        status: "in_progress",
+        output: [
+          {
+            id: "msg_pending",
+            content: [{annotations: [], text: "{\"displayName\":", type: "output_text"}],
+            role: "assistant",
+            status: "in_progress",
+            type: "message"
+          }
+        ]
+      }
     )
 
     response = @client.responses.retrieve("resp_pending", text: AliasedProfile)
@@ -330,7 +373,50 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
       assert_nil(request.uri.query)
     end
 
-    assert_empty(response.output)
+    content = response.output.fetch(0).content.fetch(0)
+
+    assert_equal("{\"displayName\":", content.text)
+    assert_nil(content.parsed)
+  end
+
+  def test_background_retrieve_defers_partial_tool_parsing_while_queued
+    stub_request(:get, "http://localhost/responses/resp_queued").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_queued",
+        status: "queued",
+        output: [
+          {
+            arguments: "{\"profileId\":",
+            call_id: "call_queued",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_queued", tools: [AliasedLookup])
+    tool_call = response.output.fetch(0)
+
+    assert_equal("{\"profileId\":", tool_call.arguments)
+    assert_nil(tool_call.parsed)
+  end
+
+  def test_background_retrieve_defers_unfinished_tool_items_with_a_text_hint
+    stub_request(:get, "http://localhost/responses/resp_unfinished_tool").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_unfinished_tool",
+        status: "in_progress",
+        output: [{type: "function_call"}]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_unfinished_tool", text: AliasedProfile)
+
+    assert_equal(1, response.output.length)
+    assert_equal(:function_call, response.output.fetch(0).type)
   end
 
   def test_background_retrieve_keeps_string_keyed_parsing_hints_local

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -16,23 +16,6 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     required :backup_profile, AliasedProfile, api_name: :backupProfile
   end
 
-  class NullableAliasedEnvelope < OpenAI::BaseModel
-    required :profile, AliasedProfile, nil?: true
-  end
-
-  class StatuslessUnionEnvelope < OpenAI::BaseModel
-    required :kind, OpenAI::UnionOf[:draft, :final]
-  end
-
-  class MixedStatuslessUnionEnvelope < OpenAI::BaseModel
-    required :value, OpenAI::UnionOf[AliasedProfile, :pending]
-  end
-
-  class AllOfAliasedEnvelope < OpenAI::BaseModel
-    required :primary_profile, AliasedProfile, api_name: :primaryProfile, doc: "Primary profile"
-    required :backup_profile, AliasedProfile, api_name: :backupProfile
-  end
-
   class AliasedProfileCollection < OpenAI::BaseModel
     required :primary_profile, AliasedProfile, api_name: :primaryProfile
     required :profiles, OpenAI::ArrayOf[AliasedProfile]
@@ -512,7 +495,7 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_nil(content.parsed)
   end
 
-  def test_background_retrieve_defers_statusless_schema_incomplete_arguments
+  def test_background_retrieve_parses_syntactically_complete_schema_invalid_arguments
     stub_request(:get, "http://localhost/responses/resp_statusless_incomplete_arguments").to_return_json(
       status: 200,
       body: {
@@ -533,10 +516,13 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
       tools: [AliasedLookup]
     )
 
-    assert_nil(response.output.fetch(0).parsed)
+    parsed = response.output.fetch(0).parsed
+
+    assert_instance_of(AliasedLookup, parsed)
+    assert_nil(parsed.profile_id)
   end
 
-  def test_background_retrieve_defers_statusless_schema_incomplete_text
+  def test_background_retrieve_parses_syntactically_complete_schema_invalid_text
     stub_request(:get, "http://localhost/responses/resp_statusless_incomplete_text").to_return_json(
       status: 200,
       body: {
@@ -554,184 +540,10 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
 
     response = @client.responses.retrieve("resp_statusless_incomplete_text", text: AliasedProfile)
 
-    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
-  end
+    parsed = response.output.fetch(0).content.fetch(0).parsed
 
-  def test_background_retrieve_defers_statusless_text_missing_required_nullable_field
-    stub_request(:get, "http://localhost/responses/resp_statusless_missing_nullable").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_missing_nullable",
-        output: [
-          {
-            id: "msg_statusless_missing_nullable",
-            content: [{annotations: [], text: "{\"displayName\":\"Ada\"}", type: "output_text"}],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_missing_nullable", text: AliasedProfile)
-
-    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
-  end
-
-  def test_background_retrieve_defers_statusless_text_with_nested_extra_property
-    stub_request(:get, "http://localhost/responses/resp_statusless_extra_property").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_extra_property",
-        output: [
-          {
-            id: "msg_statusless_extra_property",
-            content: [
-              {
-                annotations: [],
-                text: "{\"primaryProfile\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true},\"backupProfile\":{\"displayName\":\"Grace\",\"middleName\":null}}",
-                type: "output_text"
-              }
-            ],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_extra_property", text: AliasedEnvelope)
-
-    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
-  end
-
-  def test_background_retrieve_defers_statusless_nullable_text_with_nested_extra_property
-    stub_request(:get, "http://localhost/responses/resp_statusless_nullable_extra").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_nullable_extra",
-        output: [
-          {
-            id: "msg_statusless_nullable_extra",
-            content: [
-              {
-                annotations: [],
-                text: "{\"profile\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true}}",
-                type: "output_text"
-              }
-            ],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_nullable_extra", text: NullableAliasedEnvelope)
-
-    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
-  end
-
-  def test_background_retrieve_parses_statusless_text_with_escaped_definition_paths
-    stub_request(:get, "http://localhost/responses/resp_statusless_escaped_defs").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_escaped_defs",
-        output: [
-          {
-            id: "msg_statusless_escaped_defs",
-            content: [
-              {
-                annotations: [],
-                text: "{\"primary/name~value\":{\"displayName\":\"Ada\",\"middleName\":null},\"backup~name/value\":{\"displayName\":\"Grace\",\"middleName\":null}}",
-                type: "output_text"
-              }
-            ],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_escaped_defs", text: EscapedAliasEnvelope)
-
-    assert_instance_of(EscapedAliasEnvelope, response.output.fetch(0).content.fetch(0).parsed)
-  end
-
-  def test_background_retrieve_parses_statusless_text_with_constant_union
-    stub_request(:get, "http://localhost/responses/resp_statusless_constant_union").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_constant_union",
-        output: [
-          {
-            id: "msg_statusless_constant_union",
-            content: [{annotations: [], text: "{\"kind\":\"draft\"}", type: "output_text"}],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_constant_union", text: StatuslessUnionEnvelope)
-
-    assert_instance_of(StatuslessUnionEnvelope, response.output.fetch(0).content.fetch(0).parsed)
-  end
-
-  def test_background_retrieve_defers_statusless_mixed_union_with_nested_extra_property
-    stub_request(:get, "http://localhost/responses/resp_statusless_mixed_union_extra").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_mixed_union_extra",
-        output: [
-          {
-            id: "msg_statusless_mixed_union_extra",
-            content: [
-              {
-                annotations: [],
-                text: "{\"value\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true}}",
-                type: "output_text"
-              }
-            ],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_mixed_union_extra", text: MixedStatuslessUnionEnvelope)
-
-    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
-  end
-
-  def test_background_retrieve_defers_statusless_all_of_ref_with_nested_extra_property
-    stub_request(:get, "http://localhost/responses/resp_statusless_all_of_extra").to_return_json(
-      status: 200,
-      body: {
-        id: "resp_statusless_all_of_extra",
-        output: [
-          {
-            id: "msg_statusless_all_of_extra",
-            content: [
-              {
-                annotations: [],
-                text: "{\"primaryProfile\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true},\"backupProfile\":{\"displayName\":\"Grace\",\"middleName\":null}}",
-                type: "output_text"
-              }
-            ],
-            role: "assistant",
-            type: "message"
-          }
-        ]
-      }
-    )
-
-    response = @client.responses.retrieve("resp_statusless_all_of_extra", text: AllOfAliasedEnvelope)
-
-    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+    assert_instance_of(AliasedProfile, parsed)
+    assert_nil(parsed.display_name)
   end
 
   def test_background_retrieve_parses_malformed_statusless_arguments_after_completion

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -16,6 +16,23 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     required :backup_profile, AliasedProfile, api_name: :backupProfile
   end
 
+  class NullableAliasedEnvelope < OpenAI::BaseModel
+    required :profile, AliasedProfile, nil?: true
+  end
+
+  class StatuslessUnionEnvelope < OpenAI::BaseModel
+    required :kind, OpenAI::UnionOf[:draft, :final]
+  end
+
+  class MixedStatuslessUnionEnvelope < OpenAI::BaseModel
+    required :value, OpenAI::UnionOf[AliasedProfile, :pending]
+  end
+
+  class AllOfAliasedEnvelope < OpenAI::BaseModel
+    required :primary_profile, AliasedProfile, api_name: :primaryProfile, doc: "Primary profile"
+    required :backup_profile, AliasedProfile, api_name: :backupProfile
+  end
+
   class AliasedProfileCollection < OpenAI::BaseModel
     required :primary_profile, AliasedProfile, api_name: :primaryProfile
     required :profiles, OpenAI::ArrayOf[AliasedProfile]
@@ -557,6 +574,162 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     )
 
     response = @client.responses.retrieve("resp_statusless_missing_nullable", text: AliasedProfile)
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_text_with_nested_extra_property
+    stub_request(:get, "http://localhost/responses/resp_statusless_extra_property").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_extra_property",
+        output: [
+          {
+            id: "msg_statusless_extra_property",
+            content: [
+              {
+                annotations: [],
+                text: "{\"primaryProfile\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true},\"backupProfile\":{\"displayName\":\"Grace\",\"middleName\":null}}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_extra_property", text: AliasedEnvelope)
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_nullable_text_with_nested_extra_property
+    stub_request(:get, "http://localhost/responses/resp_statusless_nullable_extra").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_nullable_extra",
+        output: [
+          {
+            id: "msg_statusless_nullable_extra",
+            content: [
+              {
+                annotations: [],
+                text: "{\"profile\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true}}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_nullable_extra", text: NullableAliasedEnvelope)
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_parses_statusless_text_with_escaped_definition_paths
+    stub_request(:get, "http://localhost/responses/resp_statusless_escaped_defs").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_escaped_defs",
+        output: [
+          {
+            id: "msg_statusless_escaped_defs",
+            content: [
+              {
+                annotations: [],
+                text: "{\"primary/name~value\":{\"displayName\":\"Ada\",\"middleName\":null},\"backup~name/value\":{\"displayName\":\"Grace\",\"middleName\":null}}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_escaped_defs", text: EscapedAliasEnvelope)
+
+    assert_instance_of(EscapedAliasEnvelope, response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_parses_statusless_text_with_constant_union
+    stub_request(:get, "http://localhost/responses/resp_statusless_constant_union").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_constant_union",
+        output: [
+          {
+            id: "msg_statusless_constant_union",
+            content: [{annotations: [], text: "{\"kind\":\"draft\"}", type: "output_text"}],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_constant_union", text: StatuslessUnionEnvelope)
+
+    assert_instance_of(StatuslessUnionEnvelope, response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_mixed_union_with_nested_extra_property
+    stub_request(:get, "http://localhost/responses/resp_statusless_mixed_union_extra").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_mixed_union_extra",
+        output: [
+          {
+            id: "msg_statusless_mixed_union_extra",
+            content: [
+              {
+                annotations: [],
+                text: "{\"value\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true}}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_mixed_union_extra", text: MixedStatuslessUnionEnvelope)
+
+    assert_nil(response.output.fetch(0).content.fetch(0).parsed)
+  end
+
+  def test_background_retrieve_defers_statusless_all_of_ref_with_nested_extra_property
+    stub_request(:get, "http://localhost/responses/resp_statusless_all_of_extra").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_statusless_all_of_extra",
+        output: [
+          {
+            id: "msg_statusless_all_of_extra",
+            content: [
+              {
+                annotations: [],
+                text: "{\"primaryProfile\":{\"displayName\":\"Ada\",\"middleName\":null,\"extra\":true},\"backupProfile\":{\"displayName\":\"Grace\",\"middleName\":null}}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve("resp_statusless_all_of_extra", text: AllOfAliasedEnvelope)
 
     assert_nil(response.output.fetch(0).content.fetch(0).parsed)
   end

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -534,6 +534,37 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_equal(AliasedLookup, tools.dig(0, "function", "parameters"))
   end
 
+  def test_background_retrieve_parses_flattened_string_keyed_tool_hint
+    stub_request(:get, "http://localhost/responses/resp_flat_string_hint").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_flat_string_hint",
+        status: "completed",
+        output: [
+          {
+            arguments: "{\"profileId\":7}",
+            call_id: "call_flat_string_hint",
+            name: "custom_flat_lookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    tools = [
+      {"type" => "function", "name" => "custom_flat_lookup", "parameters" => AliasedLookup}
+    ]
+    response = @client.responses.retrieve("resp_flat_string_hint", {"tools" => tools})
+
+    assert_requested(:get, "http://localhost/responses/resp_flat_string_hint") do |request|
+      assert_nil(request.uri.query)
+    end
+
+    assert_instance_of(AliasedLookup, response.output.fetch(0).parsed)
+    assert_equal("function", tools.dig(0, "type"))
+    assert_equal(AliasedLookup, tools.dig(0, "parameters"))
+  end
+
   def test_background_retrieve_accepts_response_retrieve_params
     stub_request(:get, "http://localhost/responses/resp_params").to_return_json(
       status: 200,

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -21,6 +21,10 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     required :profiles, OpenAI::ArrayOf[AliasedProfile]
   end
 
+  class AliasedLookup < OpenAI::BaseModel
+    required :profile_id, Integer, api_name: :profileId
+  end
+
   class AliasedNameCollision < OpenAI::BaseModel
     required :display_name, String, api_name: :displayName
     required :displayName, String, api_name: :legacyDisplayName
@@ -260,6 +264,73 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_instance_of(AliasedProfile, parsed)
     assert_equal("Ada", parsed.display_name)
     assert_nil(parsed.middle_name)
+  end
+
+  def test_background_retrieve_parses_text_and_tool_models_locally
+    stub_request(:get, "http://localhost/responses/resp_background").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_background",
+        status: "completed",
+        output: [
+          {
+            id: "msg_background",
+            content: [
+              {
+                annotations: [],
+                text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            status: "completed",
+            type: "message"
+          },
+          {
+            arguments: "{\"profileId\":7}",
+            call_id: "call_background",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    tools = [AliasedLookup]
+    response = @client.responses.retrieve(
+      "resp_background",
+      text: AliasedProfile,
+      tools: tools
+    )
+
+    assert_requested(:get, "http://localhost/responses/resp_background") do |request|
+      assert_nil(request.uri.query)
+    end
+
+    parsed_text = response.output.fetch(0).content.fetch(0).parsed
+    parsed_tool = response.output.fetch(1).parsed
+
+    assert_instance_of(AliasedProfile, parsed_text)
+    assert_equal("Ada", parsed_text.display_name)
+    assert_nil(parsed_text.middle_name)
+    assert_instance_of(AliasedLookup, parsed_tool)
+    assert_equal(7, parsed_tool.profile_id)
+    assert_equal([AliasedLookup], tools)
+  end
+
+  def test_background_retrieve_accepts_a_model_before_output_is_complete
+    stub_request(:get, "http://localhost/responses/resp_pending").to_return_json(
+      status: 200,
+      body: {id: "resp_pending", status: "in_progress", output: []}
+    )
+
+    response = @client.responses.retrieve("resp_pending", text: AliasedProfile)
+
+    assert_requested(:get, "http://localhost/responses/resp_pending") do |request|
+      assert_nil(request.uri.query)
+    end
+
+    assert_empty(response.output)
   end
 
   def test_public_structured_output_endpoints_materialize_nested_models

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -347,6 +347,37 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
   end
 
+  def test_background_retrieve_defers_item_status_without_top_level_status
+    stub_request(:get, "http://localhost/responses/resp_item_pending").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_item_pending",
+        output: [
+          {
+            id: "msg_item_pending",
+            content: [{annotations: [], text: "{\"displayName\":", type: "output_text"}],
+            role: "assistant",
+            status: "in_progress",
+            type: "message"
+          },
+          {type: "function_call"}
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_item_pending",
+      text: AliasedProfile,
+      tools: [AliasedLookup]
+    )
+
+    assert_nil(response.status)
+    content = response.output.fetch(0).content.fetch(0)
+    assert_equal("{\"displayName\":", content.text)
+    assert_nil(content.parsed)
+    assert_equal(:function_call, response.output.fetch(1).type)
+  end
+
   def test_background_retrieve_parses_explicitly_named_tool_models_locally
     stub_request(:get, "http://localhost/responses/resp_named_tool").to_return_json(
       status: 200,
@@ -565,6 +596,85 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_equal(AliasedLookup, tools.dig(0, "parameters"))
   end
 
+  def test_background_retrieve_parses_format_underscore_hash_hints
+    hints = [{format_: AliasedProfile}, {"format_" => AliasedProfile}]
+
+    hints.each_with_index do |text, index|
+      response_id = "resp_format_underscore_#{index}"
+      stub_request(:get, "http://localhost/responses/#{response_id}").to_return_json(
+        status: 200,
+        body: {
+          id: response_id,
+          status: "completed",
+          output: [
+            {
+              id: "msg_format_underscore_#{index}",
+              content: [
+                {
+                  annotations: [],
+                  text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                  type: "output_text"
+                }
+              ],
+              role: "assistant",
+              status: "completed",
+              type: "message"
+            }
+          ]
+        }
+      )
+
+      response = @client.responses.retrieve(response_id, text: text)
+
+      assert_requested(:get, "http://localhost/responses/#{response_id}") do |request|
+        assert_nil(request.uri.query)
+      end
+      assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
+      assert_equal(AliasedProfile, text.values.fetch(0))
+    end
+  end
+
+  def test_background_retrieve_parses_string_keyed_json_schema_hint
+    stub_request(:get, "http://localhost/responses/resp_json_schema_hint").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_json_schema_hint",
+        status: "completed",
+        output: [
+          {
+            id: "msg_json_schema_hint",
+            content: [
+              {
+                annotations: [],
+                text: "{\"displayName\":\"Ada\",\"middleName\":null}",
+                type: "output_text"
+              }
+            ],
+            role: "assistant",
+            status: "completed",
+            type: "message"
+          }
+        ]
+      }
+    )
+
+    text = {
+      "format" => {
+        "type" => "json_schema",
+        "name" => "result",
+        "schema" => AliasedProfile
+      }
+    }
+    response = @client.responses.retrieve("resp_json_schema_hint", text: text)
+
+    assert_requested(:get, "http://localhost/responses/resp_json_schema_hint") do |request|
+      assert_nil(request.uri.query)
+    end
+    assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
+    assert_equal("json_schema", text.dig("format", "type"))
+    assert_equal(AliasedProfile, text.dig("format", "schema"))
+  end
+
   def test_background_retrieve_accepts_response_retrieve_params
     stub_request(:get, "http://localhost/responses/resp_params").to_return_json(
       status: 200,
@@ -631,6 +741,13 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     response = @client.responses.retrieve("resp_partial_tool")
 
     assert_equal(1, response.output.length)
+  end
+
+  def test_readme_states_retrieval_parsing_waits_for_completion
+    readme = File.read(File.expand_path("../../../README.md", __dir__))
+
+    assert_match(/parsed only after\s+a later retrieval reports it completed/, readme)
+    refute_includes(readme, "parsed once output is present")
   end
 
   def test_public_structured_output_endpoints_materialize_nested_models

--- a/test/openai/helpers/structured_output_api_names_test.rb
+++ b/test/openai/helpers/structured_output_api_names_test.rb
@@ -432,6 +432,45 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
     assert_nil(tool_call.parsed)
   end
 
+  def test_background_retrieve_defers_partial_outputs_when_incomplete
+    stub_request(:get, "http://localhost/responses/resp_incomplete").to_return_json(
+      status: 200,
+      body: {
+        id: "resp_incomplete",
+        status: "incomplete",
+        output: [
+          {
+            id: "msg_incomplete",
+            content: [{annotations: [], text: "{\"displayName\":", type: "output_text"}],
+            role: "assistant",
+            status: "incomplete",
+            type: "message"
+          },
+          {
+            arguments: "{\"profileId\":",
+            call_id: "call_incomplete",
+            name: "AliasedLookup",
+            type: "function_call"
+          }
+        ]
+      }
+    )
+
+    response = @client.responses.retrieve(
+      "resp_incomplete",
+      text: AliasedProfile,
+      tools: [AliasedLookup]
+    )
+
+    content = response.output.fetch(0).content.fetch(0)
+    tool_call = response.output.fetch(1)
+
+    assert_equal("{\"displayName\":", content.text)
+    assert_nil(content.parsed)
+    assert_equal("{\"profileId\":", tool_call.arguments)
+    assert_nil(tool_call.parsed)
+  end
+
   def test_background_retrieve_defers_unfinished_tool_items_with_a_text_hint
     stub_request(:get, "http://localhost/responses/resp_unfinished_tool").to_return_json(
       status: 200,
@@ -471,16 +510,19 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
           {
             arguments: "{\"profileId\":7}",
             call_id: "call_string_hints",
-            name: "AliasedLookup",
+            name: "custom_lookup",
             type: "function_call"
           }
         ]
       }
     )
 
+    tools = [
+      {"type" => "function", "function" => {"name" => "custom_lookup", "parameters" => AliasedLookup}}
+    ]
     response = @client.responses.retrieve(
       "resp_string_hints",
-      {"text" => AliasedProfile, "tools" => [AliasedLookup]}
+      {"text" => AliasedProfile, "tools" => tools}
     )
 
     assert_requested(:get, "http://localhost/responses/resp_string_hints") do |request|
@@ -489,6 +531,7 @@ class OpenAI::Test::StructuredOutputAPINamesTest < Minitest::Test
 
     assert_instance_of(AliasedProfile, response.output.fetch(0).content.fetch(0).parsed)
     assert_instance_of(AliasedLookup, response.output.fetch(1).parsed)
+    assert_equal(AliasedLookup, tools.dig(0, "function", "parameters"))
   end
 
   def test_background_retrieve_accepts_response_retrieve_params


### PR DESCRIPTION
## Summary

- allow `responses.retrieve` to accept the same local `text` and `tools` structured-output models used when creating a background response
- remove those local parsing hints before serializing retrieval query parameters, then reuse the existing Responses parser for returned text and function calls
- preserve caller-owned tool arrays and nested hashes while extracting parser models
- document the background create/retrieve flow

Closes #308.

## Tests

- Responses-related regression selection: 7 existing test files, 39 runs, 250 assertions, 0 failures, 0 errors, 0 skips
- structured-output parser selection: 3 existing test files (including the 2 new retrieval tests), 22 runs, 161 assertions, 0 failures, 0 errors, 0 skips
- `rubyfmt 0.14.1 --check` on the 2 modified Ruby files
- `rubocop` on the 2 modified Ruby files: no offenses

