### PR TITLE
fix(realtime): clean up interrupted WebRTC call allocations

### DIFF
--- a/lib/openai/helpers/realtime/client_extension.rb
+++ b/lib/openai/helpers/realtime/client_extension.rb
@@ -5,6 +5,79 @@ module OpenAI
     module Realtime
       # Realtime request integration kept outside the generated client implementation.
       module ClientExtension
+        # A generated WebRTC allocation belongs to the SDK until its complete raw
+        # response can be returned. Keep this lifecycle outside generated resources.
+        def request(req)
+          unless req.is_a?(Hash) &&
+              req[:method] == :post &&
+              req[:path] == "realtime/calls" &&
+              req[:model] == OpenAI::HTTPClient::Response
+            return super
+          end
+
+          url, response, log_context = perform_request(req)
+          call_id = if response.status == 201
+            realtime_call_id_from_location(response.headers["location"], request_url: url)
+          end
+
+          delivered = false
+          begin
+            result = finish_request(log_context, response) do
+              parse_response(req, url: url, response: response)
+            end
+
+            delivered = true
+            result
+          ensure
+            cleanup_created_realtime_call(call_id, options: req[:options]) if call_id && !delivered
+          end
+        end
+
+        private def realtime_call_id_from_location(location, request_url:)
+          return if location.nil? || location.empty?
+
+          call_url = URI.join(request_url.to_s, location)
+          return unless call_url.is_a?(URI::HTTP) && call_url.userinfo.nil? && call_url.fragment.nil?
+
+          expected_origin, actual_origin = [request_url, call_url].map do |url|
+            origin = OpenAI::Internal::Util.uri_origin(url)
+            if url.host.start_with?("[") && !url.hostname.start_with?("v", "V")
+              origin = origin.sub(url.host, "[#{IPAddr.new(url.hostname)}]")
+            end
+
+            origin
+          end
+
+          return unless expected_origin.casecmp?(actual_origin)
+
+          prefix = "#{request_url.path}/"
+          return unless call_url.path.start_with?(prefix)
+
+          call_id = call_url.path.delete_prefix(prefix)
+          call_id if /\A[A-Za-z0-9_-]+\z/.match?(call_id)
+        rescue URI::InvalidURIError, ArgumentError
+          nil
+        end
+
+        private def cleanup_created_realtime_call(call_id, options:)
+          cleanup_options = options.to_h.slice(:extra_headers, :extra_query, :timeout)
+          task = ::Async::Task.current? if defined?(::Async::Task)
+          cleanup = -> { realtime.calls.hangup(call_id, request_options: cleanup_options) }
+
+          if task
+            if task.respond_to?(:defer_cancel)
+              task.defer_cancel(&cleanup)
+            else
+              task.defer_stop(&cleanup)
+            end
+          else
+            cleanup.call
+          end
+
+        rescue StandardError, *(defined?(::Async::Stop) ? [::Async::Stop] : [])
+          nil
+        end
+
         # Build a fully authenticated Realtime WebSocket handshake request. Realtime
         # transports use this boundary so provider authentication and request options stay
         # consistent with ordinary SDK requests.

--- a/lib/openai/helpers/realtime/client_extension.rb
+++ b/lib/openai/helpers/realtime/client_extension.rb
@@ -5,6 +5,9 @@ module OpenAI
     module Realtime
       # Realtime request integration kept outside the generated client implementation.
       module ClientExtension
+        MAX_CALL_CLEANUP_SECONDS = 5.0
+        private_constant :MAX_CALL_CLEANUP_SECONDS
+
         # A generated WebRTC allocation belongs to the SDK until its complete raw
         # response can be returned. Keep this lifecycle outside generated resources.
         def request(req)
@@ -15,13 +18,23 @@ module OpenAI
             return super
           end
 
-          url, response, log_context = perform_request(req)
-          call_id = if response.status == 201
-            realtime_call_id_from_location(response.headers["location"], request_url: url)
-          end
-
           delivered = false
+          allocated_response = nil
+          call_id = nil
           begin
+            url, response, log_context = perform_request(req) do |received_response, request_url, response_url|
+              if received_response.status == 201
+                allocated_response = received_response
+                if response_url.path == request_url.path &&
+                    realtime_call_origin(response_url).casecmp?(realtime_call_origin(request_url))
+                  call_id = realtime_call_id_from_location(
+                    received_response.headers["location"],
+                    request_url: request_url
+                  )
+                end
+              end
+            end
+
             result = finish_request(log_context, response) do
               parse_response(req, url: url, response: response)
             end
@@ -29,7 +42,15 @@ module OpenAI
             delivered = true
             result
           ensure
-            cleanup_created_realtime_call(call_id, options: req[:options]) if call_id && !delivered
+            unless delivered
+              begin
+                OpenAI::Internal::Util.close_fused!(allocated_response.body) if allocated_response
+              rescue StandardError, *(defined?(::Async::Stop) ? [::Async::Stop] : [])
+                nil
+              ensure
+                cleanup_created_realtime_call(call_id, options: req[:options]) if call_id
+              end
+            end
           end
         end
 
@@ -37,18 +58,14 @@ module OpenAI
           return if location.nil? || location.empty?
 
           call_url = URI.join(request_url.to_s, location)
-          return unless call_url.is_a?(URI::HTTP) && call_url.userinfo.nil? && call_url.fragment.nil?
-
-          expected_origin, actual_origin = [request_url, call_url].map do |url|
-            origin = OpenAI::Internal::Util.uri_origin(url)
-            if url.host.start_with?("[") && !url.hostname.start_with?("v", "V")
-              origin = origin.sub(url.host, "[#{IPAddr.new(url.hostname)}]")
-            end
-
-            origin
+          unless call_url.is_a?(URI::HTTP) &&
+              !call_url.host.to_s.empty? &&
+              call_url.userinfo.nil? &&
+              call_url.fragment.nil?
+            return
           end
 
-          return unless expected_origin.casecmp?(actual_origin)
+          return unless realtime_call_origin(request_url).casecmp?(realtime_call_origin(call_url))
 
           prefix = "#{request_url.path}/"
           return unless call_url.path.start_with?(prefix)
@@ -59,10 +76,27 @@ module OpenAI
           nil
         end
 
+        private def realtime_call_origin(url)
+          origin = OpenAI::Internal::Util.uri_origin(url)
+          if url.host.start_with?("[") && !url.hostname.start_with?("v", "V")
+            origin = origin.sub(url.host, "[#{IPAddr.new(url.hostname)}]")
+          end
+
+          origin
+        end
+
         private def cleanup_created_realtime_call(call_id, options:)
           cleanup_options = options.to_h.slice(:extra_headers, :extra_query, :timeout)
+          timeout = cleanup_options.fetch(:timeout, @timeout)
+          timeout = MAX_CALL_CLEANUP_SECONDS unless timeout&.positive?
+          cleanup_options[:timeout] = [timeout, MAX_CALL_CLEANUP_SECONDS].min
+          cleanup_options[:max_retries] = 0
           task = ::Async::Task.current? if defined?(::Async::Task)
-          cleanup = -> { realtime.calls.hangup(call_id, request_options: cleanup_options) }
+          cleanup = lambda do
+            Timeout.timeout(cleanup_options.fetch(:timeout)) do
+              realtime.calls.hangup(call_id, request_options: cleanup_options)
+            end
+          end
 
           if task
             if task.respond_to?(:defer_cancel)

--- a/lib/openai/internal/logging.rb
+++ b/lib/openai/internal/logging.rb
@@ -26,19 +26,24 @@ module OpenAI
       URL_HEADER_KEY = /(?:\A|[-_])(?:location|url|uri)\z|\A(?:link|refresh)\z/i
 
       class Context
-        def initialize(logger:, log_level:, on_retry:, method:, url:)
+        def initialize(logger:, log_level:, on_retry:, method:, url:, on_response: nil)
           @logger = logger
           @log_level = log_level
           @on_retry = on_retry
+          @on_response = on_response
           @id = nil
           @method = method.to_s.upcase
           @url = url
+          @request_url = url
+          @first_request_url = nil
           @started_at = OpenAI::Internal::Util.monotonic_secs
           @attempt_started_at = @started_at
           @attempts = 0
         end
 
         def request_started(request, redirect_count:)
+          @request_url = request.url
+          @first_request_url ||= request.url
           @attempts += 1
           log(:debug) do
             "[openai] request started log_id=#{id} attempt=#{@attempts} " \
@@ -52,6 +57,7 @@ module OpenAI
         end
 
         def response_received(response)
+          @on_response&.call(response, @first_request_url || @url, @request_url)
           log(:debug) do
             "[openai] response received log_id=#{id} attempt=#{@attempts} " \
               "status=#{response.status} request_id=#{safe_field(response.headers["x-request-id"])} " \

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -650,9 +650,9 @@ module OpenAI
               raise TypeError, "`http_client#execute` must return an OpenAI::HTTPClient::Response"
             end
 
+            http_response = log_context.response_received(http_response)
             status = http_response.status
             headers = http_response.headers
-            http_response = log_context.response_received(http_response)
             stream = http_response.body
           rescue OpenAI::Errors::APIConnectionError => e
             status = e
@@ -789,7 +789,7 @@ module OpenAI
         #
         # @param req [Hash{Symbol=>Object}]
         # @return [Array(URI::Generic, OpenAI::HTTPClient::Response, OpenAI::Internal::Logging::Context)]
-        private def perform_request(req)
+        private def perform_request(req, &response_observer)
           self.class.validate!(req)
           opts = req[:options].to_h
           OpenAI::RequestOptions.validate!(opts)
@@ -800,7 +800,12 @@ module OpenAI
             log_level: @log_level,
             on_retry: @on_retry,
             method: request.fetch(:method),
-            url: url
+            url: url,
+            on_response: if response_observer
+              lambda do |received_response, trusted_url, received_url|
+                response_observer.call(received_response, trusted_url, received_url)
+              end
+            end
           )
 
           # Don't send the current retry count in the headers if the caller modified the header defaults.
@@ -811,6 +816,7 @@ module OpenAI
             retry_count: 0,
             send_retry_header: send_retry_header
           ) { log_context }
+
           [url, response, log_context]
         rescue StandardError => e
           log_context&.request_failed(e)

--- a/rbi/openai/internal/logging.rbi
+++ b/rbi/openai/internal/logging.rbi
@@ -19,11 +19,21 @@ module OpenAI
             log_level: Symbol,
             on_retry: T.nilable(T.proc.params(event: OpenAI::RetryEvent).void),
             method: Symbol,
-            url: URI::Generic
+            url: URI::Generic,
+            on_response: T.nilable(
+              T
+                .proc
+                .params(
+                  response: OpenAI::HTTPClient::Response,
+                  trusted_url: URI::Generic,
+                  response_url: URI::Generic
+                )
+                .void
+            )
           )
             .returns(T.attached_class)
         end
-        def self.new(logger:, log_level:, on_retry:, method:, url:)
+        def self.new(logger:, log_level:, on_retry:, method:, url:, on_response: nil)
         end
 
         sig do

--- a/rbi/openai/internal/transport/base_client.rbi
+++ b/rbi/openai/internal/transport/base_client.rbi
@@ -389,7 +389,17 @@ module OpenAI
         # @api private
         sig do
           params(
-            req: OpenAI::Internal::Transport::BaseClient::RequestComponents
+            req: OpenAI::Internal::Transport::BaseClient::RequestComponents,
+            response_observer: T.nilable(
+              T
+                .proc
+                .params(
+                  response: OpenAI::HTTPClient::Response,
+                  url: URI::Generic,
+                  response_url: URI::Generic
+                )
+                .void
+            )
           )
             .returns(
               [
@@ -399,7 +409,7 @@ module OpenAI
               ]
             )
         end
-        private def perform_request(req)
+        private def perform_request(req, &response_observer)
         end
 
         # @api private

--- a/sig/openai/internal/logging.rbs
+++ b/sig/openai/internal/logging.rbs
@@ -16,7 +16,12 @@ module OpenAI
           log_level: Symbol,
           on_retry: (^(OpenAI::RetryEvent) -> void)?,
           method: Symbol,
-          url: URI::Generic
+          url: URI::Generic,
+          ?on_response: (^(
+            OpenAI::HTTPClient::Response,
+            URI::Generic,
+            URI::Generic
+          ) -> void)?
         ) -> void
         def request_started: (
           OpenAI::HTTPClient::Request request,

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -169,7 +169,13 @@ module OpenAI
 
         private def perform_request: (
           OpenAI::Internal::Transport::BaseClient::request_components req
-        ) -> [URI::Generic, OpenAI::HTTPClient::Response, OpenAI::Internal::Logging::Context]
+        ) ?{
+          (
+            OpenAI::HTTPClient::Response response,
+            URI::Generic url,
+            URI::Generic response_url
+          ) -> void
+        } -> [URI::Generic, OpenAI::HTTPClient::Response, OpenAI::Internal::Logging::Context]
 
         private def finish_request: (
           OpenAI::Internal::Logging::Context log_context,

--- a/test/openai/realtime/call_creation_test.rb
+++ b/test/openai/realtime/call_creation_test.rb
@@ -110,6 +110,375 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
     assert_mock(http)
   end
 
+  def test_create_hangs_up_an_allocated_call_when_reading_its_answer_fails
+    call_id = "rtc_interrupted_123"
+    released = false
+    creation_response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}") do
+      released = true
+    end
+
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, creation_response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      released && request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    error = assert_raises(IOError) do
+      client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert(released, "the interrupted response must release its pooled connection before cleanup")
+    assert_mock(http)
+  end
+
+  def test_create_preserves_routing_and_uses_the_normal_hangup_retry_policy
+    call_id = "rtc_routed_123"
+    creation_response = interrupted_call_response(
+      location: "https://example.com/v1/realtime/calls/#{call_id}?location_only=ignored"
+    )
+    failed_hangup = OpenAI::HTTPClient::Response.new(
+      status: 500,
+      headers: {"Content-Type" => "application/json"},
+      body: JSON.generate(error: {message: "fake transient hangup failure"})
+    )
+    successful_hangup = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    expected_query = [["tenant", "fake-tenant"]]
+    requests = []
+    http = Minitest::Mock.new(Object.new)
+    [creation_response, failed_hangup, successful_hangup].each do |response|
+      http.expect(:execute, response) do |request|
+        requests << request
+        true
+      end
+    end
+
+    error = assert_raises(IOError) do
+      client(http_client: http, max_retries: 1, initial_retry_delay: 0, max_retry_delay: 0)
+        .realtime
+        .calls
+        .create(
+          sdp: "v=0\r\n",
+          request_options: {
+            extra_headers: {
+              "OpenAI-Organization" => "org_fake",
+              "OpenAI-Project" => "proj_fake",
+              "X-Routing" => "fake-route"
+            },
+            extra_query: {"tenant" => "fake-tenant"},
+            timeout: 4.5,
+            max_retries: 0
+          }
+        )
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_equal(3, requests.length)
+    requests.each do |request|
+      assert_equal(expected_query, URI.decode_www_form(request.url.query))
+      assert_equal("Bearer test-key", request.headers.fetch("authorization"))
+      assert_equal("org_fake", request.headers.fetch("openai-organization"))
+      assert_equal("proj_fake", request.headers.fetch("openai-project"))
+      assert_equal("fake-route", request.headers.fetch("x-routing"))
+      assert_equal(4.5, request.timeout)
+    end
+
+    assert_equal("/v1/realtime/calls", requests.fetch(0).url.path)
+    assert_equal("/v1/realtime/calls/#{call_id}/hangup", requests.fetch(1).url.path)
+    assert_equal("/v1/realtime/calls/#{call_id}/hangup", requests.fetch(2).url.path)
+    assert_equal("0", requests.fetch(1).headers.fetch("x-stainless-retry-count"))
+    assert_equal("1", requests.fetch(2).headers.fetch("x-stainless-retry-count"))
+    assert_mock(http)
+  end
+
+  def test_create_preserves_the_original_failure_when_hangup_fails
+    call_id = "rtc_cleanup_failure_123"
+    creation_response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, creation_response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, nil) do |request|
+      raise "synthetic hangup failure" if request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    error = assert_raises(IOError) do
+      client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_mock(http)
+  end
+
+  def test_create_hangs_up_an_allocated_call_when_its_async_task_is_cancelled
+    call_id = "rtc_cancelled_123"
+    cancellation = Async::Stop.new("synthetic SDP response cancelled")
+    creation_response = interrupted_call_response(
+      location: "/v1/realtime/calls/#{call_id}",
+      exception: cancellation
+    )
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, creation_response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      request.url.path == "/v1/realtime/calls/#{call_id}/hangup" &&
+        Async::Task.current.stop_deferred?
+    end
+
+    Sync do
+      error = assert_raises(Async::Stop) do
+        client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+      end
+
+      assert_same(cancellation, error)
+    end
+
+    assert_mock(http)
+  end
+
+  def test_create_supports_legacy_async_tasks_that_only_defer_stop
+    call_id = "rtc_legacy_async_123"
+    response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    legacy_task = Minitest::Mock.new(Object.new)
+    legacy_task.expect(:defer_stop, nil) do |&cleanup|
+      cleanup.call
+      true
+    end
+
+    Async::Task.stub(:current?, legacy_task) do
+      error = assert_raises(IOError) do
+        client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+      end
+
+      assert_equal("synthetic SDP response interrupted", error.message)
+    end
+
+    assert_mock(legacy_task)
+    assert_mock(http)
+  end
+
+  def test_create_preserves_the_original_failure_when_cancellation_arrives_during_hangup
+    call_id = "rtc_cleanup_cancelled_123"
+    response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      Async::Task.current.stop
+      request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    Sync do
+      error = assert_raises(IOError) do
+        client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+      end
+
+      assert_equal("synthetic SDP response interrupted", error.message)
+    end
+
+    assert_mock(http)
+  end
+
+  def test_create_preserves_the_original_failure_when_hangup_is_cancelled_without_an_async_task
+    call_id = "rtc_cleanup_cancelled_without_task_123"
+    response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, nil) do |request|
+      if request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+        raise Async::Stop, "synthetic hangup cancellation"
+      end
+    end
+
+    assert_nil(Async::Task.current?)
+    error = assert_raises(IOError) do
+      client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_mock(http)
+  end
+
+  def test_create_hangs_up_when_cancellation_interrupts_completion_logging
+    call_id = "rtc_completion_cancelled_123"
+    response = OpenAI::HTTPClient::Response.new(
+      status: 201,
+      headers: {
+        "Content-Type" => "application/sdp",
+        "Location" => "/v1/realtime/calls/#{call_id}"
+      },
+      body: "v=0\r\n"
+    )
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    cancellation = Async::Stop.new("synthetic completion cancelled")
+    logger = Logger.new(StringIO.new)
+    log_completion = lambda do |message|
+      raise cancellation if message.include?("path=/v1/realtime/calls status=")
+    end
+
+    logger.stub(:info, log_completion) do
+      error = assert_raises(Async::Stop) do
+        client(http_client: http, logger: logger, log_level: :info)
+          .realtime
+          .calls
+          .create(sdp: "v=0\r\n")
+      end
+
+      assert_same(cancellation, error)
+    end
+
+    assert_mock(http)
+  end
+
+  def test_interrupted_call_cleanup_redacts_sensitive_request_and_location_data
+    call_id = "rtc_fake_private_call_identifier"
+    location_secret = "fake-private-location-token"
+    offer = "v=0\r\no=- fake private SDP offer\r\n"
+    response = interrupted_call_response(
+      location: "/v1/realtime/calls/#{call_id}?access_token=#{location_secret}"
+    )
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    output = StringIO.new
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    assert_raises(IOError) do
+      client(http_client: http, logger: Logger.new(output), log_level: :debug)
+        .realtime
+        .calls
+        .create(sdp: offer)
+    end
+
+    assert_includes(output.string, "/realtime/calls/%5BREDACTED%5D")
+    refute_includes(output.string, call_id)
+    refute_includes(output.string, location_secret)
+    refute_includes(output.string, "test-key")
+    refute_includes(output.string, "fake private SDP offer")
+    assert_mock(http)
+  end
+
+  def test_create_never_cleans_up_missing_malformed_or_untrusted_locations
+    locations = [
+      nil,
+      "",
+      "%",
+      "https://evil.example/v1/realtime/calls/rtc_stolen",
+      "//evil.example/v1/realtime/calls/rtc_stolen",
+      "http://example.com/v1/realtime/calls/rtc_downgraded",
+      "https://fake-user@example.com/v1/realtime/calls/rtc_userinfo",
+      "/v1/realtime/calls/rtc_fragment#unsafe",
+      "/v1/realtime/calls/rtc_nested/extra",
+      "/v1/realtime/calls/rtc%2Fencoded",
+      "/v1/realtime/calls/../rtc_traversal",
+      "/v1/other/calls/rtc_wrong_endpoint",
+      "/v1/realtime/calls/rtc.invalid",
+      "/v1/realtime/calls/"
+    ]
+
+    locations.each do |location|
+      response = interrupted_call_response(location: location)
+      http = Minitest::Mock.new(Object.new)
+      http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+
+      error = assert_raises(IOError, "Location: #{location.inspect}") do
+        client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+      end
+
+      assert_equal("synthetic SDP response interrupted", error.message)
+      assert_mock(http)
+    end
+  end
+
+  def test_create_recognizes_equivalent_ipv6_origins_without_trusting_other_addresses
+    locations = {
+      "https://[0:0:0:0:0:0:0:1]:8443/v1/realtime/calls/rtc_ipv6_123" => true,
+      "https://[::2]:8443/v1/realtime/calls/rtc_ipv6_123" => false
+    }
+
+    locations.each do |location, trusted|
+      response = interrupted_call_response(location: location)
+      http = Minitest::Mock.new(Object.new)
+      http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+      if trusted
+        hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+        http.expect(:execute, hangup_response) do |request|
+          request.url.host == "[::1]" && request.url.path == "/v1/realtime/calls/rtc_ipv6_123/hangup"
+        end
+      end
+
+      configured = OpenAI::Client.new(
+        api_key: "test-key",
+        base_url: "https://[::1]:8443/v1",
+        http_client: http
+      )
+      error = assert_raises(IOError, "Location: #{location}") do
+        configured.realtime.calls.create(sdp: "v=0\r\n")
+      end
+
+      assert_equal("synthetic SDP response interrupted", error.message)
+      assert_mock(http)
+    end
+  end
+
+  def test_request_preserves_existing_validation_for_non_hash_inputs
+    [nil, Object.new, "invalid", []].each do |request|
+      error = assert_raises(ArgumentError, "request: #{request.inspect}") do
+        client.request(request)
+      end
+
+      assert_match(/Request `req` must be a Hash or RequestOptions/, error.message)
+    end
+  end
+
+  def test_create_does_not_hang_up_a_successfully_delivered_call
+    call_id = "rtc_delivered_123"
+    response = OpenAI::HTTPClient::Response.new(
+      status: 201,
+      headers: {
+        "Content-Type" => "application/sdp",
+        "Location" => "/v1/realtime/calls/#{call_id}"
+      },
+      body: "v=0\r\n"
+    )
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+
+    result = client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+
+    assert_instance_of(OpenAI::HTTPClient::Response, result)
+    assert_equal("/v1/realtime/calls/#{call_id}", result.headers.fetch("location"))
+    assert_equal("v=0\r\n", result.body.to_a.join)
+    assert_mock(http)
+  end
+
+  def test_interrupted_ordinary_raw_responses_do_not_trigger_call_cleanup
+    response = interrupted_call_response(location: "/v1/realtime/calls/rtc_unrelated")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/custom/raw" }
+
+    error = assert_raises(IOError) do
+      client(http_client: http).request(method: :post, path: "custom/raw", model: OpenAI::HTTPClient::Response)
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_mock(http)
+  end
+
   def test_create_does_not_retry_a_call_allocation_by_default
     failed = OpenAI::HTTPClient::Response.new(
       status: 500,
@@ -212,5 +581,22 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
     assert_instance_of(StringIO, result)
     assert_equal(binary, result.read)
     assert_mock(http)
+  end
+
+  private def interrupted_call_response(
+    location:,
+    exception: IOError.new("synthetic SDP response interrupted"),
+    &on_close
+  )
+    body = Enumerator.new do |chunks|
+      chunks << "v=0\r\n"
+      raise exception
+    end
+
+    body = OpenAI::Internal::Util.fused_enum(body, &on_close) if on_close
+    headers = {"Content-Type" => "application/sdp"}
+    headers["Location"] = location unless location.nil?
+
+    OpenAI::HTTPClient::Response.new(status: 201, headers: headers, body: body)
   end
 end

--- a/test/openai/realtime/call_creation_test.rb
+++ b/test/openai/realtime/call_creation_test.rb
@@ -80,6 +80,28 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
     assert_mock(http)
   end
 
+  def test_create_consumes_and_closes_successful_responses_with_hostless_http_locations
+    ["http:/foo", "https:/foo", "http:foo", "https:foo"].each do |location|
+      released = false
+      body = OpenAI::Internal::Util.fused_enum(["v=0\r\n"]) { released = true }
+      response = OpenAI::HTTPClient::Response.new(
+        status: 201,
+        headers: {"Content-Type" => "application/sdp", "Location" => location},
+        body: body
+      )
+      http = Minitest::Mock.new(Object.new)
+      http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+
+      result = client(http_client: http).realtime.calls.create(sdp: "v=0\r\n")
+
+      assert_instance_of(OpenAI::HTTPClient::Response, result)
+      assert_equal(location, result.headers.fetch("location"))
+      assert_equal("v=0\r\n", result.body.to_a.join)
+      assert(released, "#{location.inspect} must not leak the transport response body")
+      assert_mock(http)
+    end
+  end
+
   def test_create_releases_transport_resources_before_returning_the_response
     released = false
     source = OpenAI::Internal::Util.fused_enum(["v=0\r\n"]) { released = true }
@@ -133,21 +155,16 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
     assert_mock(http)
   end
 
-  def test_create_preserves_routing_and_uses_the_normal_hangup_retry_policy
+  def test_create_preserves_routing_for_its_bounded_hangup
     call_id = "rtc_routed_123"
     creation_response = interrupted_call_response(
       location: "https://example.com/v1/realtime/calls/#{call_id}?location_only=ignored"
-    )
-    failed_hangup = OpenAI::HTTPClient::Response.new(
-      status: 500,
-      headers: {"Content-Type" => "application/json"},
-      body: JSON.generate(error: {message: "fake transient hangup failure"})
     )
     successful_hangup = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
     expected_query = [["tenant", "fake-tenant"]]
     requests = []
     http = Minitest::Mock.new(Object.new)
-    [creation_response, failed_hangup, successful_hangup].each do |response|
+    [creation_response, successful_hangup].each do |response|
       http.expect(:execute, response) do |request|
         requests << request
         true
@@ -174,7 +191,7 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
     end
 
     assert_equal("synthetic SDP response interrupted", error.message)
-    assert_equal(3, requests.length)
+    assert_equal(2, requests.length)
     requests.each do |request|
       assert_equal(expected_query, URI.decode_www_form(request.url.query))
       assert_equal("Bearer test-key", request.headers.fetch("authorization"))
@@ -186,9 +203,179 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
 
     assert_equal("/v1/realtime/calls", requests.fetch(0).url.path)
     assert_equal("/v1/realtime/calls/#{call_id}/hangup", requests.fetch(1).url.path)
-    assert_equal("/v1/realtime/calls/#{call_id}/hangup", requests.fetch(2).url.path)
     assert_equal("0", requests.fetch(1).headers.fetch("x-stainless-retry-count"))
-    assert_equal("1", requests.fetch(2).headers.fetch("x-stainless-retry-count"))
+    assert_mock(http)
+  end
+
+  def test_create_hangs_up_calls_allocated_at_a_trusted_prepared_origin
+    call_id = "rtc_prepared_origin_123"
+    creation_response = interrupted_call_response(
+      location: "https://prepared.example/v1/realtime/calls/#{call_id}"
+    )
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, creation_response) do |request|
+      request.url.host == "prepared.example" && request.url.path == "/v1/realtime/calls"
+    end
+
+    http.expect(:execute, hangup_response) do |request|
+      request.url.host == "prepared.example" &&
+        request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    prepared_client = Class.new(OpenAI::Client) do
+      private def prepare_request(request, redirect_count:, retry_count:)
+        prepared = super
+        rewritten_url = prepared.fetch(:url).dup
+        rewritten_url.host = "prepared.example"
+        prepared.merge(url: rewritten_url)
+      end
+    end
+
+    configured = prepared_client.new(
+      api_key: "test-key",
+      base_url: "https://example.com/v1",
+      http_client: http
+    )
+
+    error = assert_raises(IOError) do
+      configured.realtime.calls.create(sdp: "v=0\r\n")
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_mock(http)
+  end
+
+  def test_interrupted_call_cleanup_uses_a_bounded_timeout_and_retry_budget
+    call_id = "rtc_bounded_cleanup_123"
+    creation_response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    failed_hangup = OpenAI::HTTPClient::Response.new(
+      status: 500,
+      headers: {"Content-Type" => "application/json"},
+      body: JSON.generate(error: {message: "fake cleanup failure"})
+    )
+    requests = []
+    http = Minitest::Mock.new(Object.new)
+    [creation_response, failed_hangup].each do |response|
+      http.expect(:execute, response) do |request|
+        requests << request
+        true
+      end
+    end
+
+    error = assert_raises(IOError) do
+      client(http_client: http, timeout: nil, max_retries: 3, initial_retry_delay: 0, max_retry_delay: 0)
+        .realtime
+        .calls
+        .create(sdp: "v=0\r\n")
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_equal(2, requests.length)
+    assert_nil(requests.fetch(0).timeout)
+    assert_operator(requests.fetch(1).timeout, :>, 0)
+    assert_operator(requests.fetch(1).timeout, :<=, 5)
+    assert_equal("/v1/realtime/calls/#{call_id}/hangup", requests.fetch(1).url.path)
+    assert_mock(http)
+  end
+
+  def test_interrupted_call_cleanup_bounds_the_entire_operation_across_redirects
+    call_id = "rtc_cleanup_deadline_123"
+    creation_response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    redirect = OpenAI::HTTPClient::Response.new(
+      status: 307,
+      headers: {"Location" => "/v1/realtime/calls/#{call_id}/hangup"},
+      body: ""
+    )
+    requests = []
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, creation_response) do |request|
+      requests << request
+      true
+    end
+
+    20.times do
+      http.expect(:execute, redirect) do |request|
+        requests << request
+        sleep(0.01)
+        true
+      end
+    end
+
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    error = assert_raises(IOError) do
+      client(http_client: http, timeout: 0.025).realtime.calls.create(sdp: "v=0\r\n")
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_operator(elapsed, :<, 0.15)
+    assert_operator(requests.length, :<, 20)
+  end
+
+  def test_interrupted_call_cleanup_uses_a_positive_deadline_for_zero_caller_timeouts
+    call_id = "rtc_zero_timeout_cleanup_123"
+    creation_response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    requests = []
+    http = Minitest::Mock.new(Object.new)
+    [creation_response, hangup_response].each do |response|
+      http.expect(:execute, response) do |request|
+        requests << request
+        true
+      end
+    end
+
+    error = assert_raises(IOError) do
+      client(http_client: http, timeout: 0).realtime.calls.create(sdp: "v=0\r\n")
+    end
+
+    assert_equal("synthetic SDP response interrupted", error.message)
+    assert_equal(0, requests.fetch(0).timeout)
+    assert_operator(requests.fetch(1).timeout, :>, 0)
+    assert_operator(requests.fetch(1).timeout, :<=, 5)
+    assert_mock(http)
+  end
+
+  def test_create_preserves_cancellation_and_hangs_up_when_closing_the_response_fails
+    call_id = "rtc_close_failure_123"
+    cancellation = Async::Stop.new("synthetic response logging cancelled")
+    body = OpenAI::Internal::Util.fused_enum(["v=0\r\n"]) do
+      raise IOError, "synthetic response close failed"
+    end
+
+    response = OpenAI::HTTPClient::Response.new(
+      status: 201,
+      headers: {
+        "Content-Type" => "application/sdp",
+        "Location" => "/v1/realtime/calls/#{call_id}"
+      },
+      body: body
+    )
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    logger = Logger.new(StringIO.new)
+    log_response = lambda do |message|
+      raise cancellation if message.include?("response received") && message.include?("status=201")
+    end
+
+    logger.stub(:debug, log_response) do
+      error = assert_raises(Async::Stop) do
+        client(http_client: http, logger: logger, log_level: :debug)
+          .realtime
+          .calls
+          .create(sdp: "v=0\r\n")
+      end
+
+      assert_same(cancellation, error)
+    end
+
     assert_mock(http)
   end
 
@@ -342,6 +529,48 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
     assert_mock(http)
   end
 
+  def test_create_hangs_up_when_cancellation_interrupts_response_received_logging
+    call_id = "rtc_response_logging_cancelled_123"
+    released = false
+    body = OpenAI::Internal::Util.fused_enum(["v=0\r\n"]) { released = true }
+    response = OpenAI::HTTPClient::Response.new(
+      status: 201,
+      headers: {
+        "Content-Type" => "application/sdp",
+        "Location" => "/v1/realtime/calls/#{call_id}"
+      },
+      body: body
+    )
+    hangup_response = OpenAI::HTTPClient::Response.new(status: 200, headers: {}, body: "")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/realtime/calls" }
+    http.expect(:execute, hangup_response) do |request|
+      released && request.url.path == "/v1/realtime/calls/#{call_id}/hangup"
+    end
+
+    cancellation = Async::Stop.new("synthetic response logging cancelled")
+    logger = Logger.new(StringIO.new)
+    log_response = lambda do |message|
+      if message.include?("response received") && message.include?("status=201")
+        raise cancellation
+      end
+    end
+
+    logger.stub(:debug, log_response) do
+      error = assert_raises(Async::Stop) do
+        client(http_client: http, logger: logger, log_level: :debug)
+          .realtime
+          .calls
+          .create(sdp: "v=0\r\n")
+      end
+
+      assert_same(cancellation, error)
+    end
+
+    assert(released, "response cancellation must release the pooled connection before hangup")
+    assert_mock(http)
+  end
+
   def test_interrupted_call_cleanup_redacts_sensitive_request_and_location_data
     call_id = "rtc_fake_private_call_identifier"
     location_secret = "fake-private-location-token"
@@ -402,6 +631,42 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
       assert_equal("synthetic SDP response interrupted", error.message)
       assert_mock(http)
     end
+  end
+
+  def test_create_never_trusts_allocations_received_after_a_cross_origin_redirect
+    call_id = "rtc_attacker_selected_123"
+    redirect = OpenAI::HTTPClient::Response.new(
+      status: 303,
+      headers: {"Location" => "https://evil.example/v1/realtime/calls"},
+      body: ""
+    )
+    response = interrupted_call_response(location: "/v1/realtime/calls/#{call_id}")
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, redirect) do |request|
+      request.url.host == "example.com" && request.headers.key?("authorization")
+    end
+
+    http.expect(:execute, response) do |request|
+      request.url.host == "evil.example" && !request.headers.key?("authorization")
+    end
+
+    configured = client(http_client: http)
+    hangup_attempted = false
+    unexpected_hangup = lambda do |*_args, **_options|
+      hangup_attempted = true
+      nil
+    end
+
+    configured.realtime.calls.stub(:hangup, unexpected_hangup) do
+      error = assert_raises(IOError) do
+        configured.realtime.calls.create(sdp: "v=0\r\n")
+      end
+
+      assert_equal("synthetic SDP response interrupted", error.message)
+    end
+
+    refute(hangup_attempted, "an untrusted redirect must never trigger an authenticated hangup")
+    assert_mock(http)
   end
 
   def test_create_recognizes_equivalent_ipv6_origins_without_trusting_other_addresses
@@ -580,6 +845,33 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
 
     assert_instance_of(StringIO, result)
     assert_equal(binary, result.read)
+    assert_mock(http)
+  end
+
+  def test_existing_zero_argument_transport_context_callbacks_remain_compatible
+    response = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"Content-Type" => "application/octet-stream"},
+      body: "synthetic binary response"
+    )
+    http = Minitest::Mock.new(Object.new)
+    http.expect(:execute, response) { |request| request.url.path == "/v1/files/file_existing_123/content" }
+    strict_client = Class.new(OpenAI::Client) do
+      private def send_request(request, redirect_count:, retry_count:, send_retry_header:, &context_provider)
+        strict_context = -> { context_provider.call }
+        super(request, redirect_count:, retry_count:, send_retry_header:, &strict_context)
+      end
+    end
+
+    configured = strict_client.new(
+      api_key: "test-key",
+      base_url: "https://example.com/v1",
+      http_client: http
+    )
+
+    result = configured.files.content("file_existing_123")
+
+    assert_equal("synthetic binary response", result.read)
     assert_mock(http)
   end
 


### PR DESCRIPTION
## Summary

- Keep the Castiron-generated `realtime.calls.create` endpoint and its `OpenAI::HTTPClient::Response` contract unchanged while giving the existing handwritten Realtime client extension ownership of a newly allocated WebRTC call until response buffering and completion succeed.
- If reading the SDP answer, request completion, or Async cancellation interrupts that ownership transfer, validate the `Location` against the original request origin/path and call the generated `realtime.calls.hangup` endpoint before preserving the original failure.
- Preserve tenant/project routing headers, query parameters, request timeouts, normal hangup retries, connection-pool release, current and legacy optional Async behavior, malformed-request validation, equivalent IPv6 origins, sensitive-data redaction, binary downloads, SIP operations, and successfully delivered calls.
- Treat absent, malformed, cross-origin, or otherwise untrusted `Location` values as unrecoverable; allocation without any received response headers remains a separate platform-level recovery limitation.

## Verification

- Five adversarial review rounds with exactly two independent fresh-context reviewers per round; rounds four and five were consecutively clean.
- Ruby 4.0 general suite: **1,425 tests / 12,902 assertions**, zero failures or errors, one existing skip.
- Realtime ownership suite: **22 tests / 173 assertions** on Ruby 3.3, 3.4, and 4.0, including actual legacy Async 2.34 and current Async 2.44.
- Existing security suites: **28 logging-security tests / 849 assertions**, **24 transport-origin tests / 412 assertions**, and **38 redirect-security tests / 380 assertions**.
- The other **10 network-invariant tests / 197 assertions** pass separately. The pre-existing `test_sideband_proxy_keeps_call_ids_and_both_credentials_out_of_traces` hangs in this local environment even when isolated, so it was excluded locally and remains covered by hosted CI.
- Full `bundle exec rake lint`: **2,783 RuboCop files clean**, Sorbet clean, and **1,246 RBS files validated**.
- Castiron custom-code budget: **2,933 / 4,000 lines**, unchanged generated ownership and no budget-policy changes.
- Examples inventory and installed-gem/X.509 packaging checks pass.

Requesting `@openai/sdks-team` review because this change affects Realtime request lifecycle and transport-adjacent ownership.
