### PR TITLE
feat(auth): simplify and harden X.509 workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,37 +433,40 @@ native_http_client = OpenAI::NetHTTPClient.new do |connection|
   connection.key = client_private_key
 end
 
-transport = OpenAI::Auth::X509Transport.new(
-  http_client: native_http_client,
-  certificate_identity: :static,
-  proxy: :direct,
-  api_origin: api_origin
-)
-
 identity = OpenAI::Auth::X509WorkloadIdentity.new(
   identity_provider_id: ENV.fetch("IDENTITY_PROVIDER_ID"),
-  service_account_id: ENV.fetch("SERVICE_ACCOUNT_ID")
+  service_account_id: ENV.fetch("SERVICE_ACCOUNT_ID"),
+  http_client: native_http_client,
+  api_origin: api_origin
 )
 
 client = OpenAI::Client.new(
   api_key: nil,
-  workload_identity: identity,
-  http_client: transport,
-  base_url: "#{transport.api_origin}/v1"
+  workload_identity: identity
 )
 
 model = client.models.list.data.first
 ```
 
-The application owns its certificate, key, trust settings, and native HTTP
-client. Keep the selected certificate identity static, configure only the
-approved issuer and API destinations, and create a fresh native client and
-transport when rotating credentials. Direct mode rejects ambient proxies; use
-`proxy: :http_connect` only when an HTTP CONNECT proxy is configured. HTTPS
-proxies are rejected before proxy credentials can be transmitted. Arbitrary
-custom transports, Azure/Bedrock providers, and Realtime WebSockets are not
-supported. Preview access must be enabled for the organization, and mTLS can be
-configured for the enrolled organization or project.
+The identity creates its guarded transport internally and selects the matching
+mTLS API endpoint automatically. The application still owns its certificate,
+key, trust settings, and native HTTP client. Keep the selected certificate
+identity static, configure only the approved issuer and API destinations, and
+create a fresh native client and identity when rotating credentials. Clients
+derived with `with_options` share the original identity's cached token when
+their transport is unchanged.
+
+The supported X.509 API regions are global, US, and EU. Set `api_origin:` to
+`https://mtls.api.openai.com`, `https://mtls-us.api.openai.com`, or
+`https://mtls-eu.api.openai.com`; an optional `data_residency:` on the client
+must match. Direct mode rejects ambient proxies; pass `proxy: :http_connect` to
+the identity only when an HTTP CONNECT proxy is configured. HTTPS proxies are
+rejected before proxy credentials can be transmitted. Arbitrary custom
+transports, Azure/Bedrock providers, and Realtime WebSockets are not supported.
+The normal client or per-request timeout covers both token exchange and the API
+request; `timeout: nil` disables both deadlines. Preview access must be enabled
+for the organization, and mTLS can be configured for the enrolled organization
+or project.
 
 See the complete [X.509 workload identity live smoke
 example](examples/x509_workload_identity.rb). It performs a real token exchange

--- a/examples/x509_workload_identity.rb
+++ b/examples/x509_workload_identity.rb
@@ -46,21 +46,16 @@ begin
     connection.key = key
   end
 
-  transport = OpenAI::Auth::X509Transport.new(
-    http_client: native_http_client,
-    certificate_identity: :static,
-    proxy: ENV.fetch("OPENAI_X509_PROXY_MODE", "direct").to_sym,
-    api_origin: api_origin
-  )
   identity = OpenAI::Auth::X509WorkloadIdentity.new(
     identity_provider_id: ENV.fetch("IDENTITY_PROVIDER_ID"),
-    service_account_id: ENV.fetch("SERVICE_ACCOUNT_ID")
+    service_account_id: ENV.fetch("SERVICE_ACCOUNT_ID"),
+    http_client: native_http_client,
+    proxy: ENV.fetch("OPENAI_X509_PROXY_MODE", "direct").to_sym,
+    api_origin: api_origin
   )
   client = OpenAI::Client.new(
     api_key: nil,
     workload_identity: identity,
-    http_client: transport,
-    base_url: "#{transport.api_origin}/v1",
     log_level: :off
   )
 

--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -13,6 +13,8 @@ module OpenAI
       TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
       DEFAULT_TOKEN_EXCHANGE_URL = "https://auth.openai.com/oauth/token"
       DEFAULT_REFRESH_BUFFER_SECONDS = 1200
+      MAX_REJECTED_TOKEN_REFRESH_ATTEMPTS = 3
+      private_constant :MAX_REJECTED_TOKEN_REFRESH_ATTEMPTS
 
       def initialize(
         config,
@@ -28,6 +30,7 @@ module OpenAI
         @cached_token = nil
         @cached_token_expires_at_monotonic = nil
         @cached_token_refresh_at_monotonic = nil
+        @rejected_tokens = {}
         @refreshing = false
         @refresh_generation = nil
         @refresh_error = nil
@@ -125,6 +128,10 @@ module OpenAI
         @mutex.synchronize do
           return nil unless rejected_token.nil? || rejected_token == @cached_token
 
+          if @token_exchange && rejected_token
+            @rejected_tokens[rejected_token] = @cached_token_expires_at_monotonic || Float::INFINITY
+          end
+
           @cached_token = nil
           @cached_token_expires_at_monotonic = nil
           @cached_token_refresh_at_monotonic = nil
@@ -219,15 +226,43 @@ module OpenAI
       end
 
       private def perform_refresh(deadline:)
-        token_data = fetch_token_from_exchange(deadline: deadline)
-        now = OpenAI::Internal::Util.monotonic_secs
-        expires_in = token_data.fetch(:expires_in)
+        rejected_attempts = 0
 
-        @mutex.synchronize do
-          @refresh_error = nil
-          @cached_token = token_data.fetch(:id)
-          @cached_token_expires_at_monotonic = now + expires_in
-          @cached_token_refresh_at_monotonic = now + refresh_delay_seconds(expires_in)
+        loop do
+          token_data = fetch_token_from_exchange(deadline: deadline)
+          now = OpenAI::Internal::Util.monotonic_secs
+          expires_in = token_data.fetch(:expires_in)
+          token = token_data.fetch(:id)
+
+          published = @mutex.synchronize do
+            @rejected_tokens.delete_if { |_rejected, expires_at| expires_at <= now }
+            unless @token_exchange && @rejected_tokens.key?(token)
+              @refresh_error = nil
+              @cached_token = token
+              @cached_token_expires_at_monotonic = now + expires_in
+              @cached_token_refresh_at_monotonic = now + refresh_delay_seconds(expires_in)
+              true
+            end
+          end
+
+          return if published
+
+          rejected_attempts += 1
+          if rejected_attempts >= MAX_REJECTED_TOKEN_REFRESH_ATTEMPTS
+            raise(
+              OpenAI::Errors::AuthenticationError.new(
+                url: @token_exchange_url,
+                status: 401,
+                headers: nil,
+                body: nil,
+                request: nil,
+                response: nil,
+                message: "Token issuer repeatedly returned a rejected access token"
+              )
+            )
+          end
+
+          check_deadline!(deadline)
         end
       end
 

--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -131,6 +131,13 @@ module OpenAI
         end
       end
 
+      # @api private
+      def bound_to?(identity, transport:)
+        @config.equal?(identity) &&
+          X509Transport.exact_instance?(@token_exchange, X509TokenExchange) &&
+          @token_exchange.bound_to?(identity, transport: transport)
+      end
+
       # Avoid exposing cached access tokens or identity configuration in diagnostics.
       #
       # @return [String]

--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -30,6 +30,7 @@ module OpenAI
         @cached_token = nil
         @cached_token_expires_at_monotonic = nil
         @cached_token_refresh_at_monotonic = nil
+        @issued_token_expirations = {}
         @rejected_tokens = {}
         @refreshing = false
         @refresh_generation = nil
@@ -126,11 +127,12 @@ module OpenAI
       # @api private
       def invalidate_token(rejected_token = nil)
         @mutex.synchronize do
-          return nil unless rejected_token.nil? || rejected_token == @cached_token
-
           if @token_exchange && rejected_token
-            @rejected_tokens[rejected_token] = @cached_token_expires_at_monotonic || Float::INFINITY
+            expires_at = @issued_token_expirations[rejected_token]
+            @rejected_tokens[rejected_token] = expires_at unless expires_at.nil?
           end
+
+          return nil unless rejected_token.nil? || rejected_token == @cached_token
 
           @cached_token = nil
           @cached_token_expires_at_monotonic = nil
@@ -235,12 +237,15 @@ module OpenAI
           token = token_data.fetch(:id)
 
           published = @mutex.synchronize do
+            @issued_token_expirations.delete_if { |_issued, expires_at| expires_at <= now }
             @rejected_tokens.delete_if { |_rejected, expires_at| expires_at <= now }
             unless @token_exchange && @rejected_tokens.key?(token)
+              expires_at = now + expires_in
               @refresh_error = nil
               @cached_token = token
-              @cached_token_expires_at_monotonic = now + expires_in
+              @cached_token_expires_at_monotonic = expires_at
               @cached_token_refresh_at_monotonic = now + refresh_delay_seconds(expires_in)
+              @issued_token_expirations[token] = expires_at if @token_exchange
               true
             end
           end

--- a/lib/openai/auth/x509_token_exchange.rb
+++ b/lib/openai/auth/x509_token_exchange.rb
@@ -7,7 +7,6 @@ module OpenAI
     # @api private
     class X509TokenExchange
       MAX_TOKEN_LIFETIME = 3600
-      DEFAULT_TIMEOUT = 5.0
       TOKEN_URL = "#{X509Transport::ISSUER_ORIGIN}/oauth/token".freeze
       GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
       SUBJECT_TOKEN_TYPE = "urn:openai:params:oauth:token-type:x509"
@@ -16,7 +15,6 @@ module OpenAI
       OAUTH_ERROR_CODES = %w[invalid_grant invalid_subject_token token_exchange_server_error].freeze
       private_constant(
         :MAX_TOKEN_LIFETIME,
-        :DEFAULT_TIMEOUT,
         :TOKEN_URL,
         :GRANT_TYPE,
         :SUBJECT_TOKEN_TYPE,
@@ -75,14 +73,14 @@ module OpenAI
       end
 
       private def remaining_timeout(deadline)
-        return DEFAULT_TIMEOUT if deadline.nil?
+        return if deadline.nil?
 
         remaining = deadline - OpenAI::Internal::Util.monotonic_secs
         unless remaining.positive?
           raise Timeout::Error, "request timed out during workload identity authentication"
         end
 
-        [remaining, DEFAULT_TIMEOUT].min
+        remaining
       end
 
       private def parse_response(response, deadline:, strict:)

--- a/lib/openai/auth/x509_token_exchange.rb
+++ b/lib/openai/auth/x509_token_exchange.rb
@@ -24,11 +24,11 @@ module OpenAI
       )
 
       def initialize(config, transport:)
-        unless config.instance_of?(X509WorkloadIdentity)
+        unless X509Transport.exact_instance?(config, X509WorkloadIdentity)
           raise ArgumentError, "X.509 exchange requires an X509WorkloadIdentity"
         end
 
-        unless transport.instance_of?(X509Transport)
+        unless X509Transport.exact_instance?(transport, X509Transport)
           raise ArgumentError, "X.509 exchange requires an attested X509Transport"
         end
 
@@ -41,6 +41,11 @@ module OpenAI
       # @return [String]
       def inspect
         "#<#{self.class.name}:0x#{object_id.to_s(16)}>"
+      end
+
+      # @api private
+      def bound_to?(identity, transport:)
+        @config.equal?(identity) && @transport.equal?(transport)
       end
 
       # @param deadline [Float, nil] absolute monotonic request deadline

--- a/lib/openai/auth/x509_transport.rb
+++ b/lib/openai/auth/x509_transport.rb
@@ -13,7 +13,12 @@ module OpenAI
     class X509Transport
       ISSUER_ORIGIN = "https://mtls.auth.openai.com"
       ISSUER_PATH = "/oauth/token"
-      API_HOSTS = %w[mtls.api.openai.com mtls-us.api.openai.com mtls-eu.api.openai.com].freeze
+      REGIONAL_API_ORIGINS = {
+        "global" => "https://mtls.api.openai.com",
+        "us" => "https://mtls-us.api.openai.com",
+        "eu" => "https://mtls-eu.api.openai.com"
+      }.freeze
+      API_HOSTS = REGIONAL_API_ORIGINS.values.map { URI(_1).host }.freeze
       PROXY_MODES = [:direct, :http_connect].freeze
       FORBIDDEN_HEADERS = %w[api-key x-api-key proxy-authorization content-length transfer-encoding].freeze
       EXCHANGE_FORBIDDEN_HEADERS = %w[authorization cookie openai-organization openai-project].freeze
@@ -22,6 +27,7 @@ module OpenAI
       GuardedVerificationCallback = Class.new(Proc)
       private_constant(
         :ISSUER_PATH,
+        :REGIONAL_API_ORIGINS,
         :API_HOSTS,
         :PROXY_MODES,
         :FORBIDDEN_HEADERS,
@@ -132,6 +138,13 @@ module OpenAI
         end
 
         validated_headers(headers, url: destination, exchange: false)
+      end
+
+      # @param residency [Symbol, String]
+      # @return [Boolean]
+      # @api private
+      def supports_data_residency?(residency)
+        REGIONAL_API_ORIGINS[residency.to_s] == @api_origin
       end
 
       private def normalize_api_origin(value)

--- a/lib/openai/auth/x509_transport.rb
+++ b/lib/openai/auth/x509_transport.rb
@@ -47,6 +47,14 @@ module OpenAI
       # @return [Symbol]
       attr_reader :proxy_mode
 
+      # Checks an exact security-boundary class without dispatching through a
+      # potentially overridden predicate on the untrusted candidate.
+      #
+      # @api private
+      def self.exact_instance?(candidate, expected_class)
+        Object.instance_method(:instance_of?).bind_call(candidate, expected_class)
+      end
+
       # @param http_client [OpenAI::NetHTTPClient] caller-owned configured native transport
       # @param certificate_identity [Symbol] must explicitly be :static
       # @param proxy [Symbol] either :direct or :http_connect
@@ -57,7 +65,7 @@ module OpenAI
         proxy: :direct,
         api_origin: "https://mtls.api.openai.com"
       )
-        unless http_client.instance_of?(OpenAI::NetHTTPClient)
+        unless X509Transport.exact_instance?(http_client, OpenAI::NetHTTPClient)
           raise ArgumentError, "X.509 transport requires a caller-owned OpenAI::NetHTTPClient"
         end
 

--- a/lib/openai/auth/x509_workload_identity.rb
+++ b/lib/openai/auth/x509_workload_identity.rb
@@ -43,7 +43,7 @@ module OpenAI
           raise ArgumentError, "X.509 transport configuration requires http_client:"
         end
 
-        @transport = if http_client
+        @transport = unless http_client.nil?
           X509Transport.new(
             http_client: http_client,
             certificate_identity: :static,

--- a/lib/openai/auth/x509_workload_identity.rb
+++ b/lib/openai/auth/x509_workload_identity.rb
@@ -14,16 +14,42 @@ module OpenAI
       # @return [Integer]
       attr_reader :refresh_buffer_seconds
 
+      # The internally guarded transport derived from the caller-owned native client.
+      #
+      # @return [OpenAI::Auth::X509Transport, nil]
+      # @api private
+      attr_reader :transport
+
+      # @param http_client [OpenAI::NetHTTPClient, nil] application-owned native
+      #   client configured with one static client certificate and private key.
+      # @param proxy [Symbol] explicitly approved :direct or :http_connect policy.
+      # @param api_origin [String] approved global, US, or EU OpenAI mTLS origin.
       def initialize(
         identity_provider_id: ENV["IDENTITY_PROVIDER_ID"],
         service_account_id: ENV["SERVICE_ACCOUNT_ID"],
-        refresh_buffer_seconds: 1200
+        refresh_buffer_seconds: 1200,
+        http_client: nil,
+        proxy: :direct,
+        api_origin: "https://mtls.api.openai.com"
       )
         @identity_provider_id = validate_identifier(identity_provider_id, "identity_provider_id").freeze
         @service_account_id = validate_identifier(service_account_id, "service_account_id").freeze
         @refresh_buffer_seconds = Integer(refresh_buffer_seconds)
         if @refresh_buffer_seconds.negative?
           raise ArgumentError, "refresh_buffer_seconds must be greater than or equal to zero"
+        end
+
+        if http_client.nil? && (proxy != :direct || api_origin != "https://mtls.api.openai.com")
+          raise ArgumentError, "X.509 transport configuration requires http_client:"
+        end
+
+        @transport = if http_client
+          X509Transport.new(
+            http_client: http_client,
+            certificate_identity: :static,
+            proxy: proxy,
+            api_origin: api_origin
+          )
         end
 
         freeze

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -168,6 +168,16 @@ module OpenAI
       {"authorization" => "Bearer #{@admin_api_key}"}
     end
 
+    # @api private
+    private def x509_identity?(identity)
+      OpenAI::Auth::X509Transport.exact_instance?(identity, OpenAI::Auth::X509WorkloadIdentity)
+    end
+
+    # @api private
+    private def x509_transport?(transport)
+      OpenAI::Auth::X509Transport.exact_instance?(transport, OpenAI::Auth::X509Transport)
+    end
+
     # Creates and returns a new client for interacting with the API.
     #
     # @param api_key [String, nil] Defaults to `ENV["OPENAI_API_KEY"]`.
@@ -176,7 +186,7 @@ module OpenAI
 
     # @api private
     private def build_request(request, options)
-      unless @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
+      unless @workload_identity_auth && x509_transport?(@requester)
         return super
       end
 
@@ -217,7 +227,7 @@ module OpenAI
     # @api private
     private def validate_prepared_request(request, original_request:)
       prepared_request = super
-      return prepared_request unless @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
+      return prepared_request unless @workload_identity_auth && x509_transport?(@requester)
 
       canonical_headers = @requester.validate_api_request!(
         url: prepared_request.fetch(:url),
@@ -248,7 +258,7 @@ module OpenAI
 
     # @api private
     private def send_request(request, redirect_count:, retry_count:, send_retry_header:)
-      if @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
+      if @workload_identity_auth && x509_transport?(@requester)
         canonical_headers = @requester.validate_api_request!(
           url: request.fetch(:url),
           headers: request.fetch(:headers)
@@ -264,7 +274,7 @@ module OpenAI
 
       return super unless workload_identity_request?(request)
 
-      x509_request = @requester.instance_of?(OpenAI::Auth::X509Transport)
+      x509_request = x509_transport?(@requester)
       previous_context = request[:x509_request_context]
       deadline = if x509_request
         previous_context&.fetch(:deadline) ||
@@ -370,7 +380,7 @@ module OpenAI
           [408, 409, 429].include?(status) ||
           (status.is_a?(Integer) && (500..599).cover?(status))
         consumed_retries = attempts + previous_issuer_retries + retry_count
-        unless @requester.instance_of?(OpenAI::Auth::X509Transport) &&
+        unless x509_transport?(@requester) &&
             retryable_status &&
             consumed_retries < request.fetch(:x509_request_context).fetch(:auth_max_retries) &&
             (connection_failure || self.class.should_retry?(status, headers: error.headers || {}))
@@ -422,7 +432,7 @@ module OpenAI
         deadline
       )
     rescue Timeout::Error => e
-      raise if @requester.instance_of?(OpenAI::Auth::X509Transport)
+      raise if x509_transport?(@requester)
 
       raise OpenAI::Errors::APITimeoutError.new(url: request.fetch(:url), message: e.message)
     end
@@ -451,9 +461,16 @@ module OpenAI
     # @param overrides [Hash{Symbol=>Object}] Options accepted by {#initialize}.
     # @return [self]
     def with_options(**overrides)
+      if overrides.key?(:workload_identity) && !overrides.key?(:http_client)
+        selected_identity = overrides.fetch(:workload_identity)
+        if x509_identity?(selected_identity) && (configured_transport = selected_identity.transport)
+          overrides = overrides.merge(http_client: configured_transport)
+        end
+      end
+
       previous_transport = @copy_options.fetch(:http_client)
       transport = overrides.fetch(:http_client, previous_transport)
-      if overrides[:data_residency] && transport.instance_of?(OpenAI::Auth::X509Transport)
+      if overrides[:data_residency] && x509_transport?(transport)
         residency = overrides.fetch(:data_residency)
         options = OpenAI::Internal::ClientOptions.copy(@copy_options, overrides.except(:data_residency))
         options.delete(:base_url) unless overrides.key?(:base_url)
@@ -461,10 +478,10 @@ module OpenAI
       end
 
       options = OpenAI::Internal::ClientOptions.copy(@copy_options, overrides)
-      adopted_identity = options.fetch(:workload_identity).instance_of?(OpenAI::Auth::X509WorkloadIdentity) &&
-        !@copy_options.fetch(:workload_identity).instance_of?(OpenAI::Auth::X509WorkloadIdentity)
-      previous_origin = previous_transport.api_origin if previous_transport.instance_of?(OpenAI::Auth::X509Transport)
-      selected_origin = transport.api_origin if transport.instance_of?(OpenAI::Auth::X509Transport)
+      adopted_identity = x509_identity?(options.fetch(:workload_identity)) &&
+        !x509_identity?(@copy_options.fetch(:workload_identity))
+      previous_origin = previous_transport.api_origin if x509_transport?(previous_transport)
+      selected_origin = transport.api_origin if x509_transport?(transport)
       if adopted_identity && selected_origin
         inherited_origin = OpenAI::Internal::Util.uri_origin(URI(options.fetch(:base_url).to_s))
         adopted_identity = !inherited_origin.casecmp?(selected_origin)
@@ -483,7 +500,7 @@ module OpenAI
     private def copy_with_workload_identity_auth(options)
       copied = self.class.new(**options)
       identity = @copy_options.fetch(:workload_identity)
-      if identity.instance_of?(OpenAI::Auth::X509WorkloadIdentity) &&
+      if x509_identity?(identity) &&
           identity.equal?(options.fetch(:workload_identity)) &&
           copied.requester.equal?(@requester)
         copied.adopt_workload_identity_auth!(@workload_identity_auth)
@@ -494,6 +511,14 @@ module OpenAI
 
     # @api private
     def adopt_workload_identity_auth!(authenticator)
+      identity = @copy_options.fetch(:workload_identity)
+      unless x509_identity?(identity) &&
+          x509_transport?(@requester) &&
+          OpenAI::Auth::X509Transport.exact_instance?(authenticator, OpenAI::Auth::WorkloadIdentityAuth) &&
+          authenticator.bound_to?(identity, transport: @requester)
+        raise ArgumentError, "X.509 authenticator must match its workload identity and attested transport"
+      end
+
       @workload_identity_auth = authenticator
     end
 
@@ -565,12 +590,12 @@ module OpenAI
       log_level: nil,
       on_retry: nil
     )
-      if workload_identity.is_a?(OpenAI::Auth::X509WorkloadIdentity) &&
-          !workload_identity.instance_of?(OpenAI::Auth::X509WorkloadIdentity)
+      if Object.instance_method(:is_a?).bind_call(workload_identity, OpenAI::Auth::X509WorkloadIdentity) &&
+          !x509_identity?(workload_identity)
         raise ArgumentError, "X509WorkloadIdentity subclasses are not supported"
       end
 
-      x509_identity = workload_identity.instance_of?(OpenAI::Auth::X509WorkloadIdentity)
+      x509_identity = x509_identity?(workload_identity)
       if x509_identity && (configured_transport = workload_identity.transport)
         if !http_client.nil? && !http_client.equal?(configured_transport)
           raise ArgumentError, "X.509 workload identity must use its configured X.509 transport"
@@ -579,7 +604,7 @@ module OpenAI
         http_client = configured_transport
       end
 
-      if x509_identity && !http_client.instance_of?(OpenAI::Auth::X509Transport)
+      if x509_identity && !x509_transport?(http_client)
         raise ArgumentError, "X.509 workload identity requires an attested X509Transport"
       end
 
@@ -588,7 +613,7 @@ module OpenAI
         base_url: base_url,
         provider: provider
       )
-      if http_client.instance_of?(OpenAI::Auth::X509Transport) && !data_residency.nil?
+      if x509_transport?(http_client) && !data_residency.nil?
         unless http_client.supports_data_residency?(data_residency)
           raise ArgumentError, "X.509 data residency must match its attested OpenAI mTLS API origin"
         end
@@ -638,7 +663,7 @@ module OpenAI
       webhook_secret = nil if webhook_secret.equal?(OpenAI::Internal::OMIT)
       base_url = provider_runtime.base_url if provider_runtime
       base_url = nil if base_url.equal?(OpenAI::Internal::OMIT)
-      base_url ||= if http_client.instance_of?(OpenAI::Auth::X509Transport)
+      base_url ||= if x509_transport?(http_client)
         "#{http_client.api_origin}/v1"
       else
         "https://api.openai.com/v1"

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -311,7 +311,13 @@ module OpenAI
           send_retry_header: send_retry_header
         )
       rescue OpenAI::Errors::AuthenticationError
-        @workload_identity_auth.invalidate_token(context.fetch(:token)) if x509_request
+        if x509_request
+          rejected_token = context.fetch(:token)
+          raise if rejected_token.nil?
+
+          @workload_identity_auth.invalidate_token(rejected_token)
+        end
+
         replay_allowed = request_replayable?(request)
         replay_allowed &&= x509_request ? replay_state.empty? : retry_count.zero?
         raise unless replay_allowed
@@ -345,7 +351,10 @@ module OpenAI
             send_retry_header: send_retry_header
           )
         rescue OpenAI::Errors::AuthenticationError
-          @workload_identity_auth.invalidate_token(context.fetch(:token)) if x509_request
+          if x509_request && (rejected_token = context.fetch(:token))
+            @workload_identity_auth.invalidate_token(rejected_token)
+          end
+
           raise
         end
       end

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -312,7 +312,7 @@ module OpenAI
         )
       rescue OpenAI::Errors::AuthenticationError
         if x509_request
-          rejected_token = context.fetch(:token)
+          rejected_token = request.fetch(:x509_request_context).fetch(:token)
           raise if rejected_token.nil?
 
           @workload_identity_auth.invalidate_token(rejected_token)
@@ -351,7 +351,7 @@ module OpenAI
             send_retry_header: send_retry_header
           )
         rescue OpenAI::Errors::AuthenticationError
-          if x509_request && (rejected_token = context.fetch(:token))
+          if x509_request && (rejected_token = request.fetch(:x509_request_context).fetch(:token))
             @workload_identity_auth.invalidate_token(rejected_token)
           end
 

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -237,6 +237,16 @@ module OpenAI
     end
 
     # @api private
+    private def validate_retry_delay!(request, delay:)
+      deadline = request[:x509_request_context]&.fetch(:deadline)
+      if deadline && delay >= deadline - OpenAI::Internal::Util.monotonic_secs
+        raise Timeout::Error, "request timed out during workload identity authentication"
+      end
+
+      super
+    end
+
+    # @api private
     private def send_request(request, redirect_count:, retry_count:, send_retry_header:)
       if @workload_identity_auth && @requester.instance_of?(OpenAI::Auth::X509Transport)
         canonical_headers = @requester.validate_api_request!(
@@ -447,7 +457,7 @@ module OpenAI
         residency = overrides.fetch(:data_residency)
         options = OpenAI::Internal::ClientOptions.copy(@copy_options, overrides.except(:data_residency))
         options.delete(:base_url) unless overrides.key?(:base_url)
-        return self.class.new(**options, data_residency: residency)
+        return copy_with_workload_identity_auth(options.merge(data_residency: residency))
       end
 
       options = OpenAI::Internal::ClientOptions.copy(@copy_options, overrides)
@@ -466,7 +476,25 @@ module OpenAI
         options.delete(:base_url)
       end
 
-      self.class.new(**options)
+      copy_with_workload_identity_auth(options)
+    end
+
+    # @api private
+    private def copy_with_workload_identity_auth(options)
+      copied = self.class.new(**options)
+      identity = @copy_options.fetch(:workload_identity)
+      if identity.instance_of?(OpenAI::Auth::X509WorkloadIdentity) &&
+          identity.equal?(options.fetch(:workload_identity)) &&
+          copied.requester.equal?(@requester)
+        copied.adopt_workload_identity_auth!(@workload_identity_auth)
+      end
+
+      copied
+    end
+
+    # @api private
+    def adopt_workload_identity_auth!(authenticator)
+      @workload_identity_auth = authenticator
     end
 
     # Creates and returns a new client for interacting with the API.
@@ -537,7 +565,20 @@ module OpenAI
       log_level: nil,
       on_retry: nil
     )
+      if workload_identity.is_a?(OpenAI::Auth::X509WorkloadIdentity) &&
+          !workload_identity.instance_of?(OpenAI::Auth::X509WorkloadIdentity)
+        raise ArgumentError, "X509WorkloadIdentity subclasses are not supported"
+      end
+
       x509_identity = workload_identity.instance_of?(OpenAI::Auth::X509WorkloadIdentity)
+      if x509_identity && (configured_transport = workload_identity.transport)
+        if !http_client.nil? && !http_client.equal?(configured_transport)
+          raise ArgumentError, "X.509 workload identity must use its configured X.509 transport"
+        end
+
+        http_client = configured_transport
+      end
+
       if x509_identity && !http_client.instance_of?(OpenAI::Auth::X509Transport)
         raise ArgumentError, "X.509 workload identity requires an attested X509Transport"
       end
@@ -548,12 +589,7 @@ module OpenAI
         provider: provider
       )
       if http_client.instance_of?(OpenAI::Auth::X509Transport) && !data_residency.nil?
-        regional_origins = {
-          "global" => "https://mtls.api.openai.com",
-          "us" => "https://mtls-us.api.openai.com",
-          "eu" => "https://mtls-eu.api.openai.com"
-        }
-        unless regional_origins[data_residency.to_s] == http_client.api_origin
+        unless http_client.supports_data_residency?(data_residency)
           raise ArgumentError, "X.509 data residency must match its attested OpenAI mTLS API origin"
         end
 

--- a/lib/openai/helpers/realtime/client_extension.rb
+++ b/lib/openai/helpers/realtime/client_extension.rb
@@ -64,7 +64,7 @@ module OpenAI
           options:,
           deadline: nil
         )
-          if @copy_options.fetch(:workload_identity).instance_of?(OpenAI::Auth::X509WorkloadIdentity)
+          if x509_identity?(@copy_options.fetch(:workload_identity))
             raise OpenAI::Errors::Error, "X.509 workload identity does not support Realtime WebSocket connections"
           end
 

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -523,6 +523,14 @@ module OpenAI
           delay * jitter
         end
 
+        # Allow authentication strategies to enforce a shared request deadline
+        # before publishing or sleeping for an API retry.
+        #
+        # @api private
+        private def validate_retry_delay!(_request, **_context)
+          nil
+        end
+
         # @api private
         private def raise_status_error!(url:, status:, headers:, response:, stream:)
           decoded = Kernel.then do
@@ -718,6 +726,7 @@ module OpenAI
             self.class.reap_connection!(status, stream: stream)
 
             delay = retry_delay(headers, retry_count: retry_count)
+            validate_retry_delay!(request, delay: delay)
             log_context.retry_scheduled(
               status,
               delay: delay,

--- a/rbi/openai/auth.rbi
+++ b/rbi/openai/auth.rbi
@@ -62,6 +62,14 @@ module OpenAI
       def invalidate_token(rejected_token = nil)
       end
 
+      # @api private
+      sig do
+        params(identity: OpenAI::Auth::X509WorkloadIdentity, transport: OpenAI::Auth::X509Transport)
+          .returns(T::Boolean)
+      end
+      def bound_to?(identity, transport:)
+      end
+
       sig { returns(String) }
       def inspect
       end

--- a/rbi/openai/auth/x509_token_exchange.rbi
+++ b/rbi/openai/auth/x509_token_exchange.rbi
@@ -13,6 +13,14 @@ module OpenAI
       def inspect
       end
 
+      # @api private
+      sig do
+        params(identity: OpenAI::Auth::X509WorkloadIdentity, transport: OpenAI::Auth::X509Transport)
+          .returns(T::Boolean)
+      end
+      def bound_to?(identity, transport:)
+      end
+
       sig { params(deadline: T.nilable(Float)).returns(T::Hash[Symbol, T.any(String, Float)]) }
       def fetch(deadline: nil)
       end

--- a/rbi/openai/auth/x509_transport.rbi
+++ b/rbi/openai/auth/x509_transport.rbi
@@ -42,6 +42,11 @@ module OpenAI
       end
       def validate_api_request!(url:, headers:)
       end
+
+      # @api private
+      sig { params(residency: T.any(Symbol, String)).returns(T::Boolean) }
+      def supports_data_residency?(residency)
+      end
     end
   end
 end

--- a/rbi/openai/auth/x509_transport.rbi
+++ b/rbi/openai/auth/x509_transport.rbi
@@ -11,6 +11,11 @@ module OpenAI
       sig { returns(Symbol) }
       attr_reader :proxy_mode
 
+      # @api private
+      sig { params(candidate: T.untyped, expected_class: T.class_of(BasicObject)).returns(T::Boolean) }
+      def self.exact_instance?(candidate, expected_class)
+      end
+
       sig do
         params(
           http_client: OpenAI::NetHTTPClient,

--- a/rbi/openai/auth/x509_workload_identity.rbi
+++ b/rbi/openai/auth/x509_workload_identity.rbi
@@ -12,18 +12,28 @@ module OpenAI
       sig { returns(Integer) }
       attr_reader :refresh_buffer_seconds
 
+      # @api private
+      sig { returns(T.nilable(OpenAI::Auth::X509Transport)) }
+      attr_reader :transport
+
       sig do
         params(
           identity_provider_id: T.nilable(T.any(String, Symbol)),
           service_account_id: T.nilable(T.any(String, Symbol)),
-          refresh_buffer_seconds: Integer
+          refresh_buffer_seconds: Integer,
+          http_client: T.nilable(OpenAI::NetHTTPClient),
+          proxy: Symbol,
+          api_origin: String
         )
           .void
       end
       def initialize(
         identity_provider_id: ENV["IDENTITY_PROVIDER_ID"],
         service_account_id: ENV["SERVICE_ACCOUNT_ID"],
-        refresh_buffer_seconds: 1200
+        refresh_buffer_seconds: 1200,
+        http_client: nil,
+        proxy: :direct,
+        api_origin: "https://mtls.api.openai.com"
       )
       end
 

--- a/rbi/openai/client.rbi
+++ b/rbi/openai/client.rbi
@@ -16,6 +16,10 @@ module OpenAI
     sig { returns(T.nilable(String)) }
     attr_reader :admin_api_key
 
+    # @api private
+    sig { returns(T.nilable(OpenAI::Auth::WorkloadIdentityAuth)) }
+    attr_reader :workload_identity_auth
+
     sig { returns(T.nilable(String)) }
     attr_reader :organization
 
@@ -158,6 +162,28 @@ module OpenAI
         .returns(OpenAI::Internal::Transport::BaseClient::RequestInput)
     end
     private def validate_prepared_request(request, original_request:)
+    end
+
+    # @api private
+    sig do
+      override
+        .params(
+          request: OpenAI::Internal::Transport::BaseClient::RequestInput,
+          delay: Float
+        )
+        .void
+    end
+    private def validate_retry_delay!(request, delay:)
+    end
+
+    # @api private
+    sig { params(options: T::Hash[Symbol, T.untyped]).returns(T.self_type) }
+    private def copy_with_workload_identity_auth(options)
+    end
+
+    # @api private
+    sig { params(authenticator: OpenAI::Auth::WorkloadIdentityAuth).void }
+    def adopt_workload_identity_auth!(authenticator)
     end
 
     # Returns a new client with the supplied options overridden.

--- a/rbi/openai/client.rbi
+++ b/rbi/openai/client.rbi
@@ -177,6 +177,16 @@ module OpenAI
     end
 
     # @api private
+    sig { params(identity: T.untyped).returns(T::Boolean) }
+    private def x509_identity?(identity)
+    end
+
+    # @api private
+    sig { params(transport: T.untyped).returns(T::Boolean) }
+    private def x509_transport?(transport)
+    end
+
+    # @api private
     sig { params(options: T::Hash[Symbol, T.untyped]).returns(T.self_type) }
     private def copy_with_workload_identity_auth(options)
     end

--- a/rbi/openai/internal/transport/base_client.rbi
+++ b/rbi/openai/internal/transport/base_client.rbi
@@ -278,6 +278,18 @@ module OpenAI
 
         # @api private
         sig do
+          overridable
+            .params(
+              request: OpenAI::Internal::Transport::BaseClient::RequestInput,
+              delay: Float
+            )
+            .void
+        end
+        private def validate_retry_delay!(request, delay:)
+        end
+
+        # @api private
+        sig do
           params(
             url: URI::Generic,
             status: Integer,

--- a/realtime.md
+++ b/realtime.md
@@ -413,6 +413,10 @@ workload-identity token rejected with a definitive upgrade `401` is invalidated
 and retried exactly once before the connection is yielded. Exceptions from the
 application block never trigger a reconnect or block replay.
 
+X.509 workload identities are HTTP-only and cannot open Realtime WebSocket
+connections. The workload-identity behavior above applies to supported
+subject-token providers such as Kubernetes, Azure, and GCP.
+
 The WebSocket URL normally derives from `base_url`. A gateway that has a
 different WebSocket origin can set a separate, validated endpoint:
 

--- a/sig/openai/auth.rbs
+++ b/sig/openai/auth.rbs
@@ -31,6 +31,11 @@ module OpenAI
 
       def invalidate_token: (?String? rejected_token) -> void
 
+      def bound_to?: (
+        OpenAI::Auth::X509WorkloadIdentity identity,
+        transport: OpenAI::Auth::X509Transport
+      ) -> bool
+
       def inspect: -> String
     end
   end

--- a/sig/openai/auth.rbs
+++ b/sig/openai/auth.rbs
@@ -1,5 +1,31 @@
 module OpenAI
   module Auth
+    module SubjectTokenProvider
+      def token_type: -> Symbol
+
+      def get_token: -> String
+    end
+
+    class WorkloadIdentity
+      attr_reader client_id: String?
+
+      attr_reader identity_provider_id: String
+
+      attr_reader service_account_id: String
+
+      attr_reader provider: OpenAI::Auth::SubjectTokenProvider
+
+      attr_reader refresh_buffer_seconds: Integer
+
+      def initialize: (
+        provider: OpenAI::Auth::SubjectTokenProvider,
+        ?identity_provider_id: (String | Symbol)?,
+        ?service_account_id: (String | Symbol)?,
+        ?client_id: (String | Symbol)?,
+        ?refresh_buffer_seconds: Integer
+      ) -> void
+    end
+
     class WorkloadIdentityAuth
       def get_token: (?deadline: Float?) -> String
 

--- a/sig/openai/auth/x509_token_exchange.rbs
+++ b/sig/openai/auth/x509_token_exchange.rbs
@@ -8,6 +8,11 @@ module OpenAI
 
       def inspect: -> String
 
+      def bound_to?: (
+        OpenAI::Auth::X509WorkloadIdentity identity,
+        transport: OpenAI::Auth::X509Transport
+      ) -> bool
+
       def fetch: (?deadline: Float?) -> ::Hash[Symbol, (String | Float)]
     end
   end

--- a/sig/openai/auth/x509_transport.rbs
+++ b/sig/openai/auth/x509_transport.rbs
@@ -7,6 +7,11 @@ module OpenAI
 
       attr_reader proxy_mode: Symbol
 
+      def self.exact_instance?: (
+        untyped candidate,
+        Class expected_class
+      ) -> bool
+
       def initialize: (
         http_client: OpenAI::NetHTTPClient,
         certificate_identity: Symbol,

--- a/sig/openai/auth/x509_transport.rbs
+++ b/sig/openai/auth/x509_transport.rbs
@@ -22,6 +22,8 @@ module OpenAI
         url: URI::Generic,
         headers: ::Hash[String, String]
       ) -> ::Hash[String, String]
+
+      def supports_data_residency?: (Symbol | String residency) -> bool
     end
   end
 end

--- a/sig/openai/auth/x509_workload_identity.rbs
+++ b/sig/openai/auth/x509_workload_identity.rbs
@@ -7,10 +7,15 @@ module OpenAI
 
       attr_reader refresh_buffer_seconds: Integer
 
+      attr_reader transport: OpenAI::Auth::X509Transport?
+
       def initialize: (
         ?identity_provider_id: (String | Symbol)?,
         ?service_account_id: (String | Symbol)?,
-        ?refresh_buffer_seconds: Integer
+        ?refresh_buffer_seconds: Integer,
+        ?http_client: OpenAI::NetHTTPClient?,
+        ?proxy: Symbol,
+        ?api_origin: String
       ) -> void
 
       def inspect: -> String

--- a/sig/openai/client.rbs
+++ b/sig/openai/client.rbs
@@ -92,6 +92,10 @@ module OpenAI
       delay: Float
     ) -> void
 
+    private def x509_identity?: (untyped identity) -> bool
+
+    private def x509_transport?: (untyped transport) -> bool
+
     private def copy_with_workload_identity_auth: (
       ::Hash[Symbol, untyped] options
     ) -> self

--- a/sig/openai/client.rbs
+++ b/sig/openai/client.rbs
@@ -12,7 +12,7 @@ module OpenAI
 
     attr_reader admin_api_key: String?
 
-    attr_reader workload_identity_auth: untyped?
+    attr_reader workload_identity_auth: OpenAI::Auth::WorkloadIdentityAuth?
 
     attr_reader organization: String?
 
@@ -87,10 +87,24 @@ module OpenAI
       original_request: OpenAI::Internal::Transport::BaseClient::request_input
     ) -> OpenAI::Internal::Transport::BaseClient::request_input
 
+    private def validate_retry_delay!: (
+      OpenAI::Internal::Transport::BaseClient::request_input request,
+      delay: Float
+    ) -> void
+
+    private def copy_with_workload_identity_auth: (
+      ::Hash[Symbol, untyped] options
+    ) -> self
+
+    def adopt_workload_identity_auth!: (
+      OpenAI::Auth::WorkloadIdentityAuth authenticator
+    ) -> void
+
     def with_options: (
       ?api_key: String?,
       ?admin_api_key: String?,
-      ?workload_identity: untyped?,
+      ?workload_identity: (OpenAI::Auth::WorkloadIdentity
+      | OpenAI::Auth::X509WorkloadIdentity)?,
       ?organization: String?,
       ?project: String?,
       ?webhook_secret: String?,
@@ -111,7 +125,8 @@ module OpenAI
     def initialize: (
       ?api_key: String?,
       ?admin_api_key: String?,
-      ?workload_identity: untyped?,
+      ?workload_identity: (OpenAI::Auth::WorkloadIdentity
+      | OpenAI::Auth::X509WorkloadIdentity)?,
       ?organization: String?,
       ?project: String?,
       ?webhook_secret: String?,

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -131,6 +131,11 @@ module OpenAI
           retry_count: Integer
         ) -> Float
 
+        private def validate_retry_delay!: (
+          OpenAI::Internal::Transport::BaseClient::request_input request,
+          delay: Float
+        ) -> void
+
         private def raise_status_error!: (
           url: URI::Generic,
           status: Integer,

--- a/test/openai/auth/x509_contract_test.rb
+++ b/test/openai/auth/x509_contract_test.rb
@@ -50,7 +50,14 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
   end
 
   def test_identity_rejects_unapproved_native_clients_and_origins
-    invalid_clients = [Object.new, Class.new(OpenAI::NetHTTPClient).new]
+    spoofed_client = Class
+      .new(OpenAI::NetHTTPClient) do
+        def instance_of?(expected_class)
+          expected_class == OpenAI::NetHTTPClient || super
+        end
+      end
+      .new
+    invalid_clients = [Object.new, false, Class.new(OpenAI::NetHTTPClient).new, spoofed_client]
     invalid_clients.each do |http_client|
       error = assert_raises(ArgumentError) do
         OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: http_client)
@@ -92,14 +99,29 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
   end
 
   def test_identity_subclasses_fail_at_client_construction
-    identity = Class.new(OpenAI::Auth::X509WorkloadIdentity).new(**@identity_options)
     transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+    identities = [
+      Class.new(OpenAI::Auth::X509WorkloadIdentity).new(**@identity_options),
+      Class
+        .new(OpenAI::Auth::X509WorkloadIdentity) do
+          def instance_of?(expected_class)
+            expected_class == OpenAI::Auth::X509WorkloadIdentity || super
+          end
 
-    error = assert_raises(ArgumentError) do
-      OpenAI::Client.new(api_key: nil, workload_identity: identity, http_client: transport)
+          def is_a?(expected_class)
+            expected_class != OpenAI::Auth::X509WorkloadIdentity && super
+          end
+        end
+        .new(**@identity_options)
+    ]
+
+    identities.each do |identity|
+      error = assert_raises(ArgumentError) do
+        OpenAI::Client.new(api_key: nil, workload_identity: identity, http_client: transport)
+      end
+
+      assert_match(/X509WorkloadIdentity subclasses/, error.message)
     end
-
-    assert_match(/X509WorkloadIdentity subclasses/, error.message)
   end
 
   def test_scoped_copies_share_the_token_cache_and_refresh_coordinator
@@ -160,6 +182,70 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
       original.workload_identity_auth,
       original.with_options(http_client: other_transport).workload_identity_auth
     )
+  end
+
+  def test_authenticator_adoption_rejects_different_identity_and_transport
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity)
+    other_native = OpenAI::NetHTTPClient.new
+    other_identity = OpenAI::Auth::X509WorkloadIdentity.new(
+      identity_provider_id: "idp_other",
+      service_account_id: "svc_acct_other",
+      http_client: other_native
+    )
+    other = OpenAI::Client.new(api_key: nil, workload_identity: other_identity)
+    original_authenticator = original.workload_identity_auth
+
+    error = assert_raises(ArgumentError) do
+      original.adopt_workload_identity_auth!(other.workload_identity_auth)
+    end
+
+    assert_match(/identity and attested transport/, error.message)
+    assert_same(original_authenticator, original.workload_identity_auth)
+
+    same_identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options)
+    first_transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+    second_transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+    first = OpenAI::Client.new(api_key: nil, workload_identity: same_identity, http_client: first_transport)
+    second = OpenAI::Client.new(api_key: nil, workload_identity: same_identity, http_client: second_transport)
+
+    assert_raises(ArgumentError) { first.adopt_workload_identity_auth!(second.workload_identity_auth) }
+  ensure
+    other_native&.close
+  end
+
+  def test_with_options_adopts_a_configured_identity_and_its_transport
+    client = OpenAI::Client.new(api_key: nil, admin_api_key: "fake-admin-key")
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+
+    adopted = client.with_options(workload_identity: identity)
+
+    assert_same(identity.transport, adopted.requester)
+    assert_equal("https://mtls.api.openai.com/v1", adopted.base_url.to_s)
+    assert_raises(ArgumentError) do
+      client.with_options(workload_identity: identity, http_client: @native)
+    end
+  end
+
+  def test_with_options_rotates_configured_identity_and_regional_transport
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity)
+    other_native = OpenAI::NetHTTPClient.new
+    replacement = OpenAI::Auth::X509WorkloadIdentity.new(
+      identity_provider_id: "idp_rotated",
+      service_account_id: "svc_acct_rotated",
+      http_client: other_native,
+      api_origin: "https://mtls-eu.api.openai.com"
+    )
+
+    rotated = original.with_options(workload_identity: replacement)
+
+    assert_same(replacement.transport, rotated.requester)
+    assert_equal("https://mtls-eu.api.openai.com/v1", rotated.base_url.to_s)
+    refute_same(original.workload_identity_auth, rotated.workload_identity_auth)
+    assert_same(identity.transport, original.requester)
+  ensure
+    other_native&.close
   end
 
   def test_issuer_exchange_honors_configured_and_disabled_request_timeouts

--- a/test/openai/auth/x509_contract_test.rb
+++ b/test/openai/auth/x509_contract_test.rb
@@ -150,6 +150,149 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
     assert_equal(1, exchange_count)
   end
 
+  def test_scoped_clients_never_republish_a_rejected_bearer
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity, max_retries: 0)
+    scoped = original.with_options(timeout: 30.0)
+    issued = ["fake-rejected-token", "fake-rejected-token", "fake-fresh-token"]
+    api_headers = []
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        token_response(issued.shift)
+      else
+        authorization = request.headers.fetch("authorization")
+        api_headers << authorization
+        authorization == "Bearer fake-rejected-token" ? unauthorized_response : model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", original.models.retrieve("first").id)
+      assert_equal("fake-model", scoped.models.retrieve("second").id)
+    end
+
+    assert_equal(
+      ["Bearer fake-rejected-token", "Bearer fake-fresh-token", "Bearer fake-fresh-token"],
+      api_headers
+    )
+    assert_empty(issued)
+  end
+
+  def test_reissued_rejected_bearers_fail_closed_after_a_bounded_shared_refresh
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    client = OpenAI::Client.new(api_key: nil, workload_identity: identity, max_retries: 0)
+    issuer_attempts = 0
+    api_headers = []
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        issuer_attempts += 1
+        token_response("fake-rejected-token")
+      else
+        api_headers << request.headers.fetch("authorization")
+        unauthorized_response
+      end
+    end
+
+    error = @native.stub(:execute, dispatch) do
+      assert_raises(OpenAI::Errors::AuthenticationError) { client.models.retrieve("first") }
+    end
+
+    assert_equal(["Bearer fake-rejected-token"], api_headers)
+    assert_equal(4, issuer_attempts)
+    assert_equal("https://mtls.auth.openai.com/oauth/token", error.url.to_s)
+    refute_match(/fake-rejected-token/, error.message)
+  end
+
+  def test_scoped_waiters_share_one_bounded_rejected_token_refresh
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity)
+    scoped = original.with_options(timeout: 30.0)
+    auth = original.workload_identity_auth
+    issuer_attempts = 0
+    refresh_started = Queue.new
+    release_refresh = Queue.new
+    leader = nil
+    waiter = nil
+    dispatch = lambda do |_request|
+      issuer_attempts += 1
+      if issuer_attempts == 2
+        refresh_started << true
+        release_refresh.pop
+      end
+
+      token_response("fake-rejected-token")
+    end
+
+    @native.stub(:execute, dispatch) do
+      rejected = auth.get_token
+      auth.invalidate_token(rejected)
+      leader = Thread.new { auth.get_token }
+      leader.report_on_exception = false
+      Timeout.timeout(2) { refresh_started.pop }
+
+      waiter = Thread.new { scoped.workload_identity_auth.get_token }
+      waiter.report_on_exception = false
+      Timeout.timeout(2) { Thread.pass until waiter.status == "sleep" }
+      release_refresh << true
+
+      leader_error = assert_raises(OpenAI::Errors::AuthenticationError) { leader.value }
+      waiter_error = assert_raises(OpenAI::Errors::AuthenticationError) { waiter.value }
+      assert_same(leader_error, waiter_error)
+    end
+
+    assert_equal(4, issuer_attempts)
+
+  ensure
+    release_refresh&.push(true) if leader&.alive?
+    leader&.kill&.join if leader&.alive?
+    waiter&.kill&.join if waiter&.alive?
+  end
+
+  def test_late_scoped_client_rejections_cannot_invalidate_a_newer_bearer
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity, max_retries: 0)
+    scoped = original.with_options(timeout: 30.0)
+    issuer_attempts = 0
+    api_headers = []
+    late_started = Queue.new
+    release_late = Queue.new
+    late_request = nil
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        issuer_attempts += 1
+        token_response(issuer_attempts <= 2 ? "fake-rejected-token" : "fake-fresh-token")
+      else
+        authorization = request.headers.fetch("authorization")
+        api_headers << authorization
+        if request.url.path.end_with?("/late") && authorization == "Bearer fake-rejected-token"
+          late_started << true
+          release_late.pop
+        end
+
+        authorization == "Bearer fake-rejected-token" ? unauthorized_response : model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-rejected-token", original.workload_identity_auth.get_token)
+      late_request = Thread.new { scoped.models.retrieve("late") }
+      late_request.report_on_exception = false
+      Timeout.timeout(2) { late_started.pop }
+
+      assert_equal("fake-model", original.models.retrieve("first").id)
+      release_late << true
+      assert_equal("fake-model", Timeout.timeout(2) { late_request.value }.id)
+    end
+
+    assert_equal(3, issuer_attempts)
+    assert_equal(2, api_headers.count("Bearer fake-rejected-token"))
+    assert_equal(2, api_headers.count("Bearer fake-fresh-token"))
+
+  ensure
+    release_late&.push(true) if late_request&.alive?
+    late_request&.kill&.join if late_request&.alive?
+  end
+
   def test_scoped_regional_copies_preserve_the_same_token_cache
     identity = OpenAI::Auth::X509WorkloadIdentity.new(
       **@identity_options,
@@ -330,16 +473,24 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
     Thread.current.thread_variable_set(:mock_sleep, nil)
   end
 
-  private def token_response
+  private def token_response(token = "fake-issued-token")
     OpenAI::HTTPClient::Response.new(
       status: 200,
       headers: {},
       body: JSON.generate(
-        access_token: "fake-issued-token",
+        access_token: token,
         issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
         token_type: "Bearer",
         expires_in: 120
       )
+    )
+  end
+
+  private def unauthorized_response
+    OpenAI::HTTPClient::Response.new(
+      status: 401,
+      headers: {"content-type" => "application/json"},
+      body: JSON.generate(error: {message: "invalid authentication"})
     )
   end
 

--- a/test/openai/auth/x509_contract_test.rb
+++ b/test/openai/auth/x509_contract_test.rb
@@ -201,6 +201,13 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
     assert_equal(4, issuer_attempts)
     assert_equal("https://mtls.auth.openai.com/oauth/token", error.url.to_s)
     refute_match(/fake-rejected-token/, error.message)
+
+    @native.stub(:execute, dispatch) do
+      assert_raises(OpenAI::Errors::AuthenticationError) { client.models.retrieve("second") }
+    end
+
+    assert_equal(["Bearer fake-rejected-token"], api_headers)
+    assert_equal(7, issuer_attempts, "issuer authentication failures must not trigger API replay")
   end
 
   def test_scoped_waiters_share_one_bounded_rejected_token_refresh
@@ -291,6 +298,39 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
   ensure
     release_late&.push(true) if late_request&.alive?
     late_request&.kill&.join if late_request&.alive?
+  end
+
+  def test_first_late_rejection_after_proactive_rotation_stays_tombstoned
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    client = OpenAI::Client.new(api_key: nil, workload_identity: identity)
+    auth = client.workload_identity_auth
+    monotonic = 100.0
+    issued = [
+      {id: "fake-first-token", expires_in: 120},
+      {id: "fake-rotated-token", expires_in: 10},
+      {id: "fake-first-token", expires_in: 120},
+      {id: "fake-fresh-token", expires_in: 120}
+    ]
+    fetch = lambda do |deadline:|
+      assert_nil(deadline)
+      issued.shift
+    end
+
+    OpenAI::Internal::Util.stub(:monotonic_secs, -> { monotonic }) do
+      auth.stub(:fetch_token_from_exchange, fetch) do
+        assert_equal("fake-first-token", auth.get_token)
+        monotonic = 161.0
+        assert_equal("fake-rotated-token", auth.get_token)
+
+        auth.invalidate_token("fake-first-token")
+        assert_equal("fake-rotated-token", auth.get_token)
+
+        monotonic = 167.0
+        assert_equal("fake-fresh-token", auth.get_token)
+      end
+    end
+
+    assert_empty(issued)
   end
 
   def test_scoped_regional_copies_preserve_the_same_token_cache

--- a/test/openai/auth/x509_contract_test.rb
+++ b/test/openai/auth/x509_contract_test.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::X509ContractTest < Minitest::Test
+  def setup
+    super
+    @native = OpenAI::NetHTTPClient.new
+    @identity_options = {identity_provider_id: "idp_fake", service_account_id: "svc_acct_fake"}
+  end
+
+  def teardown
+    @native.close
+    super
+  end
+
+  def test_identity_builds_its_attested_transport_without_exposing_transport_assembly
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    client = OpenAI::Client.new(api_key: nil, workload_identity: identity)
+    requests = []
+    dispatch = lambda do |request|
+      requests << request
+      request.url.host == "mtls.auth.openai.com" ? token_response : model_response
+    end
+
+    @native.stub(:execute, dispatch) do
+      assert_equal("fake-model", client.models.retrieve("fake-model").id)
+    end
+
+    assert_instance_of(OpenAI::Auth::X509Transport, client.requester)
+    assert_equal("https://mtls.api.openai.com/v1", client.base_url.to_s)
+    assert_equal(%w[mtls.auth.openai.com mtls.api.openai.com], requests.map { _1.url.host })
+    assert_equal("Bearer fake-issued-token", requests.fetch(1).headers.fetch("authorization"))
+    assert_predicate(identity, :frozen?)
+  end
+
+  def test_identity_supports_approved_regions_and_explicit_proxy_policy
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(
+      **@identity_options,
+      http_client: @native,
+      api_origin: "https://mtls-eu.api.openai.com",
+      proxy: :http_connect
+    )
+    client = OpenAI::Client.new(api_key: nil, workload_identity: identity, data_residency: :eu)
+
+    assert_equal("https://mtls-eu.api.openai.com/v1", client.base_url.to_s)
+    assert_equal(:http_connect, client.requester.proxy_mode)
+    assert_raises(ArgumentError) { client.with_options(data_residency: :us) }
+    assert_raises(ArgumentError) { client.with_options(data_residency: :ae) }
+  end
+
+  def test_identity_rejects_unapproved_native_clients_and_origins
+    invalid_clients = [Object.new, Class.new(OpenAI::NetHTTPClient).new]
+    invalid_clients.each do |http_client|
+      error = assert_raises(ArgumentError) do
+        OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: http_client)
+      end
+
+      assert_match(/caller-owned OpenAI::NetHTTPClient/, error.message)
+      http_client.close if http_client.respond_to?(:close)
+    end
+
+    assert_raises(ArgumentError) do
+      OpenAI::Auth::X509WorkloadIdentity.new(
+        **@identity_options,
+        http_client: @native,
+        api_origin: "https://attacker.invalid"
+      )
+    end
+
+    [
+      {proxy: :http_connect},
+      {api_origin: "https://mtls-eu.api.openai.com"}
+    ].each do |options|
+      error = assert_raises(ArgumentError) do
+        OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, **options)
+      end
+
+      assert_match(/requires http_client:/, error.message)
+    end
+  end
+
+  def test_configured_identity_rejects_transport_substitution
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    substituted = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+
+    error = assert_raises(ArgumentError) do
+      OpenAI::Client.new(api_key: nil, workload_identity: identity, http_client: substituted)
+    end
+
+    assert_match(/configured X\.509 transport/, error.message)
+  end
+
+  def test_identity_subclasses_fail_at_client_construction
+    identity = Class.new(OpenAI::Auth::X509WorkloadIdentity).new(**@identity_options)
+    transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+
+    error = assert_raises(ArgumentError) do
+      OpenAI::Client.new(api_key: nil, workload_identity: identity, http_client: transport)
+    end
+
+    assert_match(/X509WorkloadIdentity subclasses/, error.message)
+  end
+
+  def test_scoped_copies_share_the_token_cache_and_refresh_coordinator
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity)
+    scoped = original.with_options(timeout: 30.0)
+    nested = scoped.with_options(default_headers: {"x-feature" => "scoped"})
+    exchange_count = 0
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        exchange_count += 1
+        token_response
+      else
+        model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      [original, scoped, nested].each do |client|
+        assert_equal("fake-model", client.models.retrieve("fake-model").id)
+      end
+    end
+
+    assert_same(original.workload_identity_auth, scoped.workload_identity_auth)
+    assert_same(original.workload_identity_auth, nested.workload_identity_auth)
+    assert_equal(1, exchange_count)
+  end
+
+  def test_scoped_regional_copies_preserve_the_same_token_cache
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(
+      **@identity_options,
+      http_client: @native,
+      api_origin: "https://mtls-eu.api.openai.com"
+    )
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity, data_residency: :eu)
+
+    copied = original.with_options(data_residency: :eu, timeout: 30.0)
+
+    assert_same(original.requester, copied.requester)
+    assert_same(original.workload_identity_auth, copied.workload_identity_auth)
+  end
+
+  def test_changing_identity_or_transport_never_shares_a_token_cache
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options)
+    transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+    original = OpenAI::Client.new(api_key: nil, workload_identity: identity, http_client: transport)
+    other_identity = OpenAI::Auth::X509WorkloadIdentity.new(
+      identity_provider_id: "idp_other",
+      service_account_id: "svc_acct_other"
+    )
+    other_transport = OpenAI::Auth::X509Transport.new(http_client: @native, certificate_identity: :static)
+
+    refute_same(
+      original.workload_identity_auth,
+      original.with_options(workload_identity: other_identity).workload_identity_auth
+    )
+    refute_same(
+      original.workload_identity_auth,
+      original.with_options(http_client: other_transport).workload_identity_auth
+    )
+  end
+
+  def test_issuer_exchange_honors_configured_and_disabled_request_timeouts
+    [nil, 30.0, 120.0].each do |timeout|
+      identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+      client = OpenAI::Client.new(api_key: nil, workload_identity: identity, timeout: timeout)
+      issuer_request = nil
+      dispatch = lambda do |request|
+        if request.url.host == "mtls.auth.openai.com"
+          issuer_request = request
+          token_response
+        else
+          model_response
+        end
+      end
+
+      @native.stub(:execute, dispatch) { client.models.retrieve("fake-model") }
+
+      if timeout.nil?
+        assert_nil(issuer_request.timeout)
+      else
+        assert_operator(issuer_request.timeout, :>, timeout - 1)
+        assert_operator(issuer_request.timeout, :<=, timeout)
+      end
+    end
+  end
+
+  def test_per_request_timeout_overrides_the_issuer_exchange_deadline
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    client = OpenAI::Client.new(api_key: nil, workload_identity: identity, timeout: 120.0)
+    issuer_request = nil
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        issuer_request = request
+        token_response
+      else
+        model_response
+      end
+    end
+
+    @native.stub(:execute, dispatch) do
+      client.models.retrieve("fake-model", request_options: {timeout: 30.0})
+    end
+
+    assert_operator(issuer_request.timeout, :>, 29.0)
+    assert_operator(issuer_request.timeout, :<=, 30.0)
+  end
+
+  def test_api_retry_backoff_never_sleeps_past_the_original_deadline
+    identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
+    retry_events = []
+    client = OpenAI::Client.new(
+      api_key: nil,
+      workload_identity: identity,
+      timeout: 0.05,
+      max_retries: 1,
+      on_retry: -> (event) { retry_events << event }
+    )
+    api_attempts = 0
+    dispatch = lambda do |request|
+      if request.url.host == "mtls.auth.openai.com"
+        token_response
+      else
+        api_attempts += 1
+        OpenAI::HTTPClient::Response.new(status: 429, headers: {"retry-after" => "1"}, body: "")
+      end
+    end
+
+    delays = []
+    Thread.current.thread_variable_set(:mock_sleep, delays)
+
+    error = @native.stub(:execute, dispatch) do
+      assert_raises(OpenAI::Errors::APITimeoutError) { client.models.retrieve("fake-model") }
+    end
+
+    assert_equal(1, api_attempts)
+    assert_empty(delays)
+    assert_empty(retry_events)
+    assert_equal("https://mtls.api.openai.com/v1/models/fake-model", error.url.to_s)
+    assert_nil(error.cause)
+  ensure
+    Thread.current.thread_variable_set(:mock_sleep, nil)
+  end
+
+  private def token_response
+    OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {},
+      body: JSON.generate(
+        access_token: "fake-issued-token",
+        issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        token_type: "Bearer",
+        expires_in: 120
+      )
+    )
+  end
+
+  private def model_response
+    OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: JSON.generate(id: "fake-model", created: 1, object: "model", owned_by: "openai")
+    )
+  end
+end

--- a/test/openai/auth/x509_contract_test.rb
+++ b/test/openai/auth/x509_contract_test.rb
@@ -304,7 +304,7 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
     identity = OpenAI::Auth::X509WorkloadIdentity.new(**@identity_options, http_client: @native)
     client = OpenAI::Client.new(api_key: nil, workload_identity: identity)
     auth = client.workload_identity_auth
-    monotonic = 100.0
+    clock = {now: 100.0}
     issued = [
       {id: "fake-first-token", expires_in: 120},
       {id: "fake-rotated-token", expires_in: 10},
@@ -316,16 +316,16 @@ class OpenAI::Test::X509ContractTest < Minitest::Test
       issued.shift
     end
 
-    OpenAI::Internal::Util.stub(:monotonic_secs, -> { monotonic }) do
+    OpenAI::Internal::Util.stub(:monotonic_secs, -> { clock.fetch(:now) }) do
       auth.stub(:fetch_token_from_exchange, fetch) do
         assert_equal("fake-first-token", auth.get_token)
-        monotonic = 161.0
+        clock[:now] = 161.0
         assert_equal("fake-rotated-token", auth.get_token)
 
         auth.invalidate_token("fake-first-token")
         assert_equal("fake-rotated-token", auth.get_token)
 
-        monotonic = 167.0
+        clock[:now] = 167.0
         assert_equal("fake-fresh-token", auth.get_token)
       end
     end

--- a/test/openai/support/x509_installed_gem_smoke.rb
+++ b/test/openai/support/x509_installed_gem_smoke.rb
@@ -63,16 +63,13 @@ native = OpenAI::NetHTTPClient.new(size: 1) do |connection|
   connection.key = certificate.key
 end
 
-transport = OpenAI::Auth::X509Transport.new(
-  http_client: native,
-  certificate_identity: :static,
-  proxy: :http_connect
-)
 identity = OpenAI::Auth::X509WorkloadIdentity.new(
   identity_provider_id: "idp_fake_packaged",
-  service_account_id: "svc_acct_fake_packaged"
+  service_account_id: "svc_acct_fake_packaged",
+  http_client: native,
+  proxy: :http_connect
 )
-client = OpenAI::Client.new(api_key: nil, workload_identity: identity, http_client: transport)
+client = OpenAI::Client.new(api_key: nil, workload_identity: identity)
 
 begin
   harness.with_proxy_environment(proxy.uri) do


### PR DESCRIPTION
## Summary

- Add a stable high-level X.509 workload identity configuration that owns its guarded transport internally while preserving the existing explicit `X509Transport` integration.
- Share OAuth tokens and refresh coordination across scoped clients only after verifying exact identity and certificate-transport provenance; support safe identity adoption, certificate rotation, and regional endpoint changes through `with_options`.
- Harden exact-class trust boundaries against hostile Ruby predicate overrides, reject unsupported identity/native-client subclasses, and retain strict issuer/origin, TLS, proxy, redirect, and credential-redaction protections.
- Apply the complete request timeout consistently to certificate-authenticated token exchange and retry backoff, including explicit disabled timeouts.
- Consolidate supported global/US/EU mTLS routing, publish precise Sorbet/RBS workload-identity types, update the runnable and installed-gem examples, and document unsupported Realtime WebSockets and AE residency.

## Verification

- Two consecutive fresh-context adversarial review rounds, each covering independent security/correctness and public API/architecture; both rounds clean.
- Ruby 3.3 comprehensive suite against the local API mock: **1,434 tests, 13,144 assertions, zero failures/errors**.
- Ruby 4 X.509/auth/transport/examples/packaging compatibility suite: **207 tests, 1,955 assertions, zero failures/errors**.
- Focused hostile-subclass, cross-identity/transport token-substitution, timeout/retry, regional adoption/rotation, and shared-cache regressions.
- Complete lint/type/signature suite: **2,784 RuboCop files clean; Sorbet clean; all 1,246 RBS files valid and correctly formatted**.
- Trusted custom-code gate: **3,049 / 4,000 lines**, preserving 951 lines of headroom without changing the budget.
- Existing owner-controlled one-hour issued-token lifetime policy is intentionally unchanged; no dependency, CI workflow, or release-credential changes.

Security-sensitive authentication/transport change; requesting SDK team review.