### PR TITLE
feat: expose opt-in raw response bodies on response metadata

### DIFF
--- a/lib/openai/http_client.rb
+++ b/lib/openai/http_client.rb
@@ -20,11 +20,18 @@ module OpenAI
     # @return [String, nil]
     attr_reader :request_id
 
+    # The exact response body when `include_raw_body: true` was requested.
+    # Bodies are never retained by default or for streaming responses.
+    #
+    # @return [String, nil]
+    attr_reader :body
+
     # @api private
     #
     # @param status [Integer]
     # @param headers [Hash{String=>String}]
-    def initialize(status:, headers:)
+    # @param body [String, nil]
+    def initialize(status:, headers:, body: nil)
       @status = Integer(status)
       @headers = headers
         .to_h do |name, value|
@@ -32,6 +39,7 @@ module OpenAI
         end
         .freeze
       @request_id = @headers["x-request-id"]
+      @body = body.nil? || body.frozen? ? body : body.dup.freeze
       freeze
     end
 
@@ -39,6 +47,37 @@ module OpenAI
     #
     # @return [String]
     def inspect = "#<#{self.class} status=#{@status} request_id=#{@request_id.inspect}>"
+
+    # Keep retained response bodies out of Psych object serialization.
+    #
+    # @api private
+    # @param coder [Psych::Coder]
+    # @return [void]
+    def encode_with(coder)
+      coder["status"] = @status
+      coder["headers"] = @headers
+    end
+
+    # @api private
+    # @param coder [Psych::Coder]
+    # @return [void]
+    def init_with(coder)
+      initialize(status: coder["status"], headers: coder["headers"])
+    end
+
+    # Keep retained response bodies out of Marshal object serialization.
+    #
+    # @api private
+    # @return [Array(Integer, Hash{String=>String})]
+    def marshal_dump = [@status, @headers]
+
+    # @api private
+    # @param values [Array(Integer, Hash{String=>String})]
+    # @return [void]
+    def marshal_load(values)
+      status, headers = values
+      initialize(status: status, headers: headers)
+    end
   end
 
   # Details about an API request retry that is about to run.

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -785,6 +785,8 @@ module OpenAI
         #
         #   @option options [Float, nil] :timeout
         #
+        #   @option options [Boolean, nil] :include_raw_body
+        #
         # @raise [OpenAI::Errors::APIError]
         # @return [Object]
         def request(req)
@@ -802,6 +804,10 @@ module OpenAI
           self.class.validate!(req)
           opts = req[:options].to_h
           OpenAI::RequestOptions.validate!(opts)
+          if req[:stream] && opts[:include_raw_body] == true
+            raise ArgumentError, "`include_raw_body` is not supported for streaming responses"
+          end
+
           request = build_request(req.except(:options), opts)
           url = request.fetch(:url)
           log_context = OpenAI::Internal::Logging::Context.new(
@@ -868,8 +874,27 @@ module OpenAI
 
           unwrap = req[:unwrap]
           response_metadata = response.metadata
+          include_raw_body = req[:options].to_h[:include_raw_body] == true &&
+            (req[:page] ||
+              (model.is_a?(Class) && model <= OpenAI::Internal::Type::BaseModel) ||
+              model.is_a?(OpenAI::Internal::Type::Union))
+          raw_body = nil
+          decoded = if include_raw_body
+            OpenAI::Internal::Util.decode_content(response.headers, stream: response.body) do |body|
+              raw_body = body
+            end
+          else
+            OpenAI::Internal::Util.decode_content(response.headers, stream: response.body)
+          end
 
-          decoded = OpenAI::Internal::Util.decode_content(response.headers, stream: response.body)
+          if include_raw_body && !decoded.is_a?(StringIO)
+            response_metadata = OpenAI::ResponseMetadata.new(
+              status: response.status,
+              headers: response.headers,
+              body: raw_body&.freeze
+            )
+          end
+
           case req
           in {stream: Class => st}
             st.new(

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -673,13 +673,16 @@ module OpenAI
         # @param headers [Hash{String=>String}]
         # @param stream [Enumerable<String>]
         # @param suppress_error [Boolean]
+        # @yieldparam [String] The buffered response body before decoding.
         #
         # @raise [JSON::ParserError]
         # @return [Object]
-        def decode_content(headers, stream:, suppress_error: false)
+        def decode_content(headers, stream:, suppress_error: false, &body_observer)
           case (content_type = headers["content-type"])
           in OpenAI::Internal::Util::JSON_CONTENT
-            return nil if (json = stream.to_a.join).empty?
+            json = stream.to_a.join
+            body_observer&.call(json)
+            return nil if json.empty?
 
             begin
               JSON.parse(json, symbolize_names: true)
@@ -703,6 +706,7 @@ module OpenAI
             decode_sse(lines)
           else
             text = stream.to_a.join
+            body_observer&.call(text)
             force_charset!(content_type, text: text)
             StringIO.new(text)
           end

--- a/lib/openai/request_options.rb
+++ b/lib/openai/request_options.rb
@@ -65,6 +65,14 @@ module OpenAI
     #   @return [Float, nil]
     optional :timeout, Float
 
+    # @!attribute include_raw_body
+    #   Retain the exact successful HTTP response body on the returned model or
+    #   page through `last_response.body`. Body retention is disabled by default
+    #   and cannot be enabled for streaming responses.
+    #
+    #   @return [Boolean, nil]
+    optional :include_raw_body, OpenAI::Internal::Type::Boolean
+
     # @!method initialize(values = {})
     #   Returns a new instance of RequestOptions.
     #

--- a/rbi/openai/http_client.rbi
+++ b/rbi/openai/http_client.rbi
@@ -11,13 +11,36 @@ module OpenAI
     sig { returns(T.nilable(String)) }
     attr_reader :request_id
 
+    sig { returns(T.nilable(String)) }
+    attr_reader :body
+
     # @api private
     sig do
-      params(status: Integer, headers: T::Hash[String, String]).returns(
+      params(status: Integer, headers: T::Hash[String, String], body: T.nilable(String)).returns(
         T.attached_class
       )
     end
-    def self.new(status:, headers:)
+    def self.new(status:, headers:, body: nil)
+    end
+
+    # @api private
+    sig { params(coder: T.untyped).void }
+    def encode_with(coder)
+    end
+
+    # @api private
+    sig { params(coder: T.untyped).void }
+    def init_with(coder)
+    end
+
+    # @api private
+    sig { returns(T::Array[T.any(Integer, T::Hash[String, String])]) }
+    def marshal_dump
+    end
+
+    # @api private
+    sig { params(values: T::Array[T.any(Integer, T::Hash[String, String])]).void }
+    def marshal_load(values)
     end
   end
 

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -374,11 +374,12 @@ module OpenAI
           params(
             headers: T::Hash[String, String],
             stream: T::Enumerable[String],
-            suppress_error: T::Boolean
+            suppress_error: T::Boolean,
+            body_observer: T.nilable(T.proc.params(body: String).void)
           )
             .returns(T.anything)
         end
-        def decode_content(headers, stream:, suppress_error: false)
+        def decode_content(headers, stream:, suppress_error: false, &body_observer)
         end
       end
 

--- a/rbi/openai/request_options.rbi
+++ b/rbi/openai/request_options.rbi
@@ -47,6 +47,10 @@ module OpenAI
     sig { returns(T.nilable(Float)) }
     attr_accessor :timeout
 
+    # Retain the exact successful response body on `last_response.body`.
+    sig { returns(T.nilable(T::Boolean)) }
+    attr_accessor :include_raw_body
+
     # Returns a new instance of RequestOptions.
     sig { params(values: OpenAI::Internal::AnyHash).returns(T.attached_class) }
     def self.new(values = {})

--- a/sig/openai/http_client.rbs
+++ b/sig/openai/http_client.rbs
@@ -10,8 +10,21 @@ module OpenAI
     attr_reader status: Integer
     attr_reader headers: ::Hash[String, String]
     attr_reader request_id: String?
+    attr_reader body: String?
 
-    def initialize: (status: Integer, headers: ::Hash[String, String]) -> void
+    def initialize: (
+      status: Integer,
+      headers: ::Hash[String, String],
+      ?body: String?
+    ) -> void
+
+    def encode_with: (top coder) -> void
+
+    def init_with: (top coder) -> void
+
+    def marshal_dump: -> [Integer, ::Hash[String, String]]
+
+    def marshal_load: ([Integer, ::Hash[String, String]] values) -> void
   end
 
   class RetryEvent

--- a/sig/openai/internal/util.rbs
+++ b/sig/openai/internal/util.rbs
@@ -146,7 +146,9 @@ module OpenAI
         ::Hash[String, String] headers,
         stream: Enumerable[String],
         ?suppress_error: bool
-      ) -> top
+      ) ?{
+        (String body) -> void
+      } -> top
 
       def self?.fused_enum: (
         Enumerable[top] enum,

--- a/sig/openai/request_options.rbs
+++ b/sig/openai/request_options.rbs
@@ -9,7 +9,8 @@ module OpenAI
       extra_headers: ::Hash[String, String?]?,
       extra_body: top?,
       max_retries: Integer?,
-      timeout: Float?
+      timeout: Float?,
+      include_raw_body: bool?
     }
 
   class RequestOptions < OpenAI::Internal::Type::BaseModel
@@ -26,6 +27,8 @@ module OpenAI
     attr_accessor max_retries: Integer?
 
     attr_accessor timeout: Float?
+
+    attr_accessor include_raw_body: bool?
 
     def initialize: (
       ?OpenAI::request_options | ::Hash[Symbol, top] values

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -338,6 +338,7 @@ class OpenAITest < Minitest::Test
     assert_equal(200, response.last_response.status)
     assert_equal("req_success", response.last_response.request_id)
     assert_equal("req_success", response.last_response.headers["x-request-id"])
+    assert_nil(response.last_response.body)
     assert_nil(response.choices.first.last_response)
     refute_includes(response.to_h, :_request_id)
     refute_includes(response.to_h, :last_response)
@@ -378,6 +379,148 @@ class OpenAITest < Minitest::Test
     assert_equal("req_page", response._request_id)
     assert_equal(200, response.last_response.status)
     assert_equal("req_page", response.last_response.request_id)
+    assert_nil(response.last_response.body)
+  end
+
+  def test_raw_response_body_is_opt_in_and_preserves_exact_bytes
+    body = "{\n  \"id\": \"model_123\", \"object\": \"model\", " \
+      "\"created\": 123, \"owned_by\": \"sensitive-owner\"\n}\n"
+    stub_request(:get, "http://localhost/models/model_123").to_return(
+      status: 200,
+      headers: {"content-type" => "application/json", "x-request-id" => "req_raw"},
+      body: body
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    response = openai.models.retrieve("model_123", request_options: {include_raw_body: true})
+
+    assert_instance_of(OpenAI::Model, response)
+    assert_equal(body, response.last_response.body)
+    assert_equal("req_raw", response.last_response.request_id)
+    assert_predicate(response.last_response.body, :frozen?)
+    refute_includes(response.last_response.inspect, "sensitive-owner")
+    refute_includes(YAML.dump(response), "@last_response")
+    refute_includes(Marshal.dump(response), body)
+  end
+
+  def test_raw_response_body_accepts_request_options_objects
+    body = "{\"id\":\"model_123\",\"object\":\"model\",\"created\":123,\"owned_by\":\"openai\"}"
+    stub_request(:get, "http://localhost/models/model_123").to_return(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: body
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    options = OpenAI::RequestOptions.new(include_raw_body: true)
+    response = openai.models.retrieve("model_123", request_options: options)
+
+    assert_equal(body, response.last_response.body)
+  end
+
+  def test_raw_response_body_captures_only_the_final_successful_attempt
+    error_body = "{\"error\":{\"message\":\"sensitive retry body\"}}"
+    successful_body = "{ \"id\": \"model_123\", \"object\": \"model\", " \
+      "\"created\": 123, \"owned_by\": \"openai\" }\n"
+    stub_request(:get, "http://localhost/models/model_123").to_return(
+      {status: 500, headers: {"content-type" => "application/json"}, body: error_body},
+      {status: 200, headers: {"content-type" => "application/json"}, body: successful_body}
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key", max_retries: 1)
+    response = openai.models.retrieve("model_123", request_options: {include_raw_body: true})
+
+    assert_equal(successful_body, response.last_response.body)
+    refute_includes(response.last_response.body, "sensitive retry body")
+    assert_requested(:get, "http://localhost/models/model_123", times: 2)
+  end
+
+  def test_raw_response_body_is_available_on_union_backed_models
+    body = "{\n  \"text\": \"transcribed audio\"\n}\n"
+    stub_request(:post, "http://localhost/audio/transcriptions").to_return(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: body
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    response = openai.audio.transcriptions.create(
+      file: StringIO.new("synthetic audio"),
+      model: "gpt-4o-transcribe",
+      request_options: {include_raw_body: true}
+    )
+
+    assert_instance_of(OpenAI::Models::Audio::Transcription, response)
+    assert_equal(body, response.last_response.body)
+  end
+
+  def test_raw_response_body_requires_an_explicit_boolean_true
+    body = "{\"id\":\"model_123\",\"object\":\"model\",\"created\":123,\"owned_by\":\"openai\"}"
+    stub_request(:get, "http://localhost/models/model_123").to_return(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: body
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+
+    ["false", 0, false, nil].each do |value|
+      response = openai.models.retrieve("model_123", request_options: {include_raw_body: value})
+
+      assert_nil(response.last_response.body)
+    end
+  end
+
+  def test_raw_response_body_does_not_freeze_union_backed_text_responses
+    stub_request(:post, "http://localhost/audio/transcriptions").to_return(
+      status: 200,
+      headers: {"content-type" => "text/plain"},
+      body: "transcribed audio"
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    response = openai.audio.transcriptions.create(
+      file: StringIO.new("synthetic audio"),
+      model: "gpt-4o-transcribe",
+      response_format: :text,
+      request_options: {include_raw_body: true}
+    )
+
+    assert_instance_of(StringIO, response)
+    assert_equal("transcribed audio", response.read)
+    assert_equal(1, response.write("!"))
+  end
+
+  def test_raw_response_body_is_available_on_paginated_responses
+    body = "{\n  \"data\": [],\n  \"object\": \"list\", " \
+      "\"ignored_secret\": \"raw-page-only-secret\"\n}\n"
+    stub_request(:get, "http://localhost/models").to_return(
+      status: 200,
+      headers: {"content-type" => "application/json", "x-request-id" => "req_page_raw"},
+      body: body
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    response = openai.models.list(request_options: {include_raw_body: true})
+
+    assert_equal(body, response.last_response.body)
+    assert_equal("req_page_raw", response.last_response.request_id)
+    refute_includes(YAML.dump(response), "raw-page-only-secret")
+  end
+
+  def test_raw_response_body_rejects_streaming_without_starting_a_request
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+
+    error = assert_raises(ArgumentError) do
+      openai.responses.stream_raw(
+        model: "gpt-4.1",
+        input: "hello",
+        request_options: {include_raw_body: true}
+      )
+    end
+
+    assert_match(/include_raw_body.*streaming/, error.message)
+    assert_not_requested(:post, "http://localhost/responses")
   end
 
   def test_each_paginated_response_has_its_own_metadata
@@ -453,6 +596,24 @@ class OpenAITest < Minitest::Test
 
     assert_instance_of(StringIO, content)
     assert_equal("file contents", content.read)
+    refute_respond_to(content, :last_response)
+    assert_nil(result)
+  end
+
+  def test_raw_response_body_does_not_change_non_model_results
+    stub_request(:get, "http://localhost/files/file_123/content")
+      .to_return(status: 200, body: "file contents")
+    stub_request(:delete, "http://localhost/responses/resp_123")
+      .to_return(status: 204, body: "")
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+
+    content = openai.files.content("file_123", request_options: {include_raw_body: true})
+    result = openai.responses.delete("resp_123", request_options: {include_raw_body: true})
+
+    assert_instance_of(StringIO, content)
+    assert_equal("file contents", content.read)
+    assert_equal(1, content.write("!"))
     refute_respond_to(content, :last_response)
     assert_nil(result)
   end

--- a/test/openai/large_payload_test.rb
+++ b/test/openai/large_payload_test.rb
@@ -30,6 +30,24 @@ class OpenAI::Test::LargePayloadTest < Minitest::Test
     end
   end
 
+  def test_blocking_response_preserves_large_raw_body_when_explicitly_requested
+    text = large_text
+    body = JSON.generate(response_with_text(text))
+
+    with_http_body(body, content_type: "application/json") do |client|
+      response = client.responses.create(
+        model: "gpt-4.1",
+        input: "Synthetic payload test",
+        request_options: {include_raw_body: true}
+      )
+
+      assert_large_text(text, response.output_text)
+      assert_equal(body.bytesize, response.last_response.body.bytesize)
+      assert_equal(Digest::SHA256.hexdigest(body), Digest::SHA256.hexdigest(response.last_response.body))
+      assert_predicate(response.last_response.body, :frozen?)
+    end
+  end
+
   def test_response_stream_preserves_large_delta_snapshot_and_final_output_text
     text = large_text
     response = response_with_text(text)

--- a/test/openai/logging_test.rb
+++ b/test/openai/logging_test.rb
@@ -300,6 +300,30 @@ class LoggingTest < Minitest::Test
     refute_includes(debug_log, "response-secret")
   end
 
+  def test_opt_in_raw_response_body_never_appears_in_debug_logs
+    logger = CapturingLogger.new
+    body = JSON.generate(
+      id: "model_123",
+      object: "model",
+      created: 123,
+      owned_by: "sensitive-response-owner"
+    )
+    http_client = StubHTTPClient.new do |_request|
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: body
+      )
+    end
+
+    client = diagnostic_client(http_client: http_client, logger: logger, log_level: :debug)
+    response = client.models.retrieve("model_123", request_options: {include_raw_body: true})
+
+    assert_equal(body, response.last_response.body)
+    refute_includes(logger.events.map(&:last).join("\n"), "sensitive-response-owner")
+    refute_includes(response.last_response.inspect, "sensitive-response-owner")
+  end
+
   def test_redaction_is_case_insensitive_for_headers_and_credential_query_parameters
     headers = OpenAI::Internal::Logging.format_headers(
       "Authorization" => "authorization-secret",

--- a/test/openai/response_metadata_test.rb
+++ b/test/openai/response_metadata_test.rb
@@ -29,5 +29,44 @@ class OpenAI::Test::ResponseMetadataTest < Minitest::Test
     response = OpenAI::ResponseMetadata.new(status: 204, headers: {})
 
     assert_nil(response.request_id)
+    assert_nil(response.body)
+  end
+
+  def test_optional_response_body_is_immutable_and_redacted_from_inspection
+    source = +"sensitive response body"
+    response = OpenAI::ResponseMetadata.new(status: 200, headers: {}, body: source)
+
+    source.replace("changed")
+
+    assert_equal("sensitive response body", response.body)
+    assert_predicate(response.body, :frozen?)
+    assert_raises(FrozenError) { response.body.replace("changed") }
+    refute_includes(response.inspect, "sensitive response body")
+  end
+
+  def test_frozen_response_body_is_retained_without_copying
+    body = "large response body".b.freeze
+    response = OpenAI::ResponseMetadata.new(status: 200, headers: {}, body: body)
+
+    assert_same(body, response.body)
+  end
+
+  def test_serialization_omits_retained_response_bodies
+    response = OpenAI::ResponseMetadata.new(
+      status: 200,
+      headers: {"x-request-id" => "req_serialized"},
+      body: "sensitive response body"
+    )
+
+    [YAML.dump(response), Marshal.dump(response)].each do |serialized|
+      refute_includes(serialized, "sensitive response body")
+    end
+
+    [YAML.unsafe_load(YAML.dump(response)), Marshal.load(Marshal.dump(response))].each do |copy|
+      assert_equal(200, copy.status)
+      assert_equal("req_serialized", copy.request_id)
+      assert_nil(copy.body)
+      assert_predicate(copy, :frozen?)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Add opt-in access to exact successful HTTP response bodies through the existing, Ruby-idiomatic response metadata API:

```ruby
response = client.responses.create(
  model: "gpt-4.1",
  input: "Hello!",
  request_options: {include_raw_body: true}
)

response.last_response.body
```

- Support typed response models, union-backed typed responses, and paginated results without changing generated resource methods.
- Keep body retention disabled by default and require the literal boolean `true`; preserve retries, request IDs, binary/nil return values, writable plain-text audio responses, and streaming behavior.
- Freeze retained bytes and exclude them from inspection, logging, YAML, and Marshal serialization.
- Update the matching handwritten RBI/RBS declarations and add focused coverage for union responses, pagination, retry handling, serialization/redaction, streaming rejection, and real HTTP payloads larger than 32 MiB.

## Castiron ownership and custom-code budget

All 14 changed files are explicitly excluded by the current Ruby generated-file ownership policy. No generated resources, generated snapshots, Castiron compiler/configuration, ownership exclusions, or custom-code budget files are changed.

The trusted candidate budget check passes: **3,047 / 4,000 custom lines**, with **953 lines of headroom**; budget isolation also passes.

## Verification

- Ruby 3.4: **488 tests, 4,466 assertions**, across 36 relevant transport, model, helper, security, and large-payload suites.
- Ruby 3.3: **157 tests, 963 assertions**, across the directly affected suites.
- Sorbet typechecking passes; all **1,250 RBS signatures** validate.
- Full-repository RuboCop and formatting checks pass: **2,792 files**, zero offenses.
- Two consecutive independent adversarial-review rounds completed with no unresolved in-scope findings.

## Security and rollout

Raw response bytes are retained only on explicitly opted-in successful non-streaming responses. Sensitive contents remain excluded from debug logs, object inspection, YAML, and Marshal serialization; retry-failure bodies are never attached to the returned metadata. The default behavior and generated SDK surface remain unchanged.

Design notes: https://app.notion.com/p/openai/Raw-response-headers-3c88e50b62b0816da5a4cc09c4545b37
