### PR TITLE
test: make realtime cleanup deadline regression deterministic

### DIFF
--- a/test/openai/realtime/call_creation_test.rb
+++ b/test/openai/realtime/call_creation_test.rb
@@ -288,30 +288,42 @@ class OpenAI::Test::RealtimeCallCreationTest < Minitest::Test
       body: ""
     )
     requests = []
+    cleanup_deadlines = []
     http = Minitest::Mock.new(Object.new)
     http.expect(:execute, creation_response) do |request|
       requests << request
       true
     end
 
-    20.times do
+    20.times do |attempt|
       http.expect(:execute, redirect) do |request|
         requests << request
-        sleep(0.01)
+        raise Timeout::Error if attempt == 2
+
         true
       end
     end
 
-    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    error = assert_raises(IOError) do
-      client(http_client: http, timeout: 0.025).realtime.calls.create(sdp: "v=0\r\n")
+    original_timeout = Timeout.method(:timeout)
+    test_thread = Thread.current
+    deadline = lambda do |duration, *arguments, &operation|
+      unless Thread.current == test_thread
+        next original_timeout.call(duration, *arguments, &operation)
+      end
+
+      cleanup_deadlines << duration
+      operation.call
     end
 
-    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    error = Timeout.stub(:timeout, deadline) do
+      assert_raises(IOError) do
+        client(http_client: http, timeout: 0.025).realtime.calls.create(sdp: "v=0\r\n")
+      end
+    end
 
     assert_equal("synthetic SDP response interrupted", error.message)
-    assert_operator(elapsed, :<, 0.15)
-    assert_operator(requests.length, :<, 20)
+    assert_equal([0.025], cleanup_deadlines)
+    assert_equal([0.025, 0.025, 0.025], requests.drop(1).map(&:timeout))
   end
 
   def test_interrupted_call_cleanup_uses_a_positive_deadline_for_zero_caller_timeouts


### PR DESCRIPTION
## Summary

- Make the interrupted Realtime call-cleanup redirect regression deterministic by replacing real sleeps and wall-clock assertions with a controlled timeout.
- Verify one cleanup deadline spans multiple redirects, preserves the configured per-request timeout, stops redirecting when that deadline expires, and propagates the original interrupted-call error.
- Preserve real timeout behavior for concurrently executing tests by limiting the timeout stub to the owning test thread.

The previous timing-sensitive assertion exceeded its 150 ms threshold on busy GitHub Actions runners, including observed durations of 262 ms on Ruby 4.0 and 161 ms on Ruby 3.3.

## Verification

- 500 consecutive focused regression-test iterations on Ruby 4.0.6.
- Complete Realtime call-creation suite on Ruby 4.0.6 and Ruby 3.3.12: 31 tests and 223 assertions on each runtime.
- Adjacent Realtime authentication/retry suite: 8 tests and 44 assertions.
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop`: Ruby formatting, RuboCop directives, and all 2,792 inspected files pass.
- Two consecutive clean, independent two-reviewer adversarial-review rounds.
