### PR TITLE
fix: support structured chat output with typed function tools

### DIFF
--- a/lib/openai/helpers/structured_output/chat_completion_parser.rb
+++ b/lib/openai/helpers/structured_output/chat_completion_parser.rb
@@ -81,6 +81,10 @@ module OpenAI
                 }
             }
             parsed.dig(:response_format, :json_schema).store(:schema, model.to_json_schema)
+          else
+          end
+
+          case parsed
           in {tools: Array => tools}
             mapped = tools.map do |tool|
               case tool

--- a/test/openai/helpers/chat_completion_parser_test.rb
+++ b/test/openai/helpers/chat_completion_parser_test.rb
@@ -15,11 +15,29 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
     def request(**options) = options
   end
 
+  class RecordingTransport < OpenAI::HTTPClient
+    attr_reader :request
+
+    def initialize(response)
+      super()
+      @response = response
+    end
+
+    def execute(request)
+      @request = request
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: JSON.generate(@response)
+      )
+    end
+  end
+
   class CombinedModels < OpenAI::Resources::Chat::Completions
     def get_structured_output_models(_parsed) = [TextModel, {"known" => ToolModel}]
   end
 
-  def test_response_format_forms_keep_their_precedence_over_tools
+  def test_response_format_forms_and_tools_are_processed_independently
     forms = [
       {response_format: TextModel},
       {response_format: {type: :json_schema, json_schema: TextModel}},
@@ -33,7 +51,10 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
     resource = OpenAI::Resources::Chat::Completions.allocate
 
     forms.each do |params|
-      tools = [ToolModel]
+      function = {name: "explicit_tool", parameters: ToolModel, strict: true}
+      nested = {type: :function, function: function}
+      untouched = {type: :custom, custom: {name: "other"}}
+      tools = [ToolModel, nested, untouched]
       params[:tools] = tools
       original = params[:response_format]
       original_schema = original[:json_schema] if original.is_a?(Hash)
@@ -41,9 +62,19 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
       model, tool_models = resource.get_structured_output_models(params)
 
       assert_same(TextModel, model)
-      assert_empty(tool_models)
+      assert_equal({"ToolModel" => ToolModel, "explicit_tool" => ToolModel}, tool_models)
       assert_same(tools, params[:tools])
-      assert_same(ToolModel, tools.first)
+      assert_equal(
+        {
+          type: :function,
+          function: {strict: true, name: "ToolModel", parameters: ToolModel.to_json_schema}
+        },
+        tools.first
+      )
+      assert_same(nested, tools[1])
+      assert_same(function, nested[:function])
+      assert_equal(ToolModel.to_json_schema, function[:parameters])
+      assert_same(untouched, tools.last)
       schema = params.fetch(:response_format).fetch(:json_schema)
       assert_equal(TextModel.to_json_schema, schema[:schema])
       assert_same(original, params[:response_format]) if original.is_a?(Hash)
@@ -55,6 +86,63 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
         assert_equal("TextModel", schema[:name])
         assert_equal(true, schema[:strict])
       end
+    end
+  end
+
+  def test_public_create_serializes_and_hydrates_structured_text_and_function_tools
+    [
+      [ToolModel, "ToolModel"],
+      [{type: :function, function: {name: "lookup", parameters: ToolModel, strict: true}}, "lookup"]
+    ].each do |tool, name|
+      transport = RecordingTransport.new(
+        id: "chatcmpl_test",
+        object: "chat.completion",
+        created: 0,
+        model: "test",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "tool_calls",
+            message: {
+              role: "assistant",
+              content: JSON.generate(value: "hello"),
+              tool_calls: [
+                {
+                  id: "call_test",
+                  type: "function",
+                  function: {name: name, arguments: JSON.generate(argument: 7)}
+                }
+              ]
+            }
+          }
+        ]
+      )
+      client = OpenAI::Client.new(
+        api_key: "fake-key",
+        base_url: "http://example.test",
+        http_client: transport
+      )
+
+      completion = client.chat.completions.create(
+        model: "test",
+        messages: [{role: "user", content: "hi"}],
+        response_format: TextModel,
+        tools: [tool]
+      )
+
+      request = JSON.parse(transport.request.body)
+      assert_equal("json_schema", request.dig("response_format", "type"))
+      assert_equal("TextModel", request.dig("response_format", "json_schema", "name"))
+      assert_equal("function", request.dig("tools", 0, "type"))
+      assert_equal(name, request.dig("tools", 0, "function", "name"))
+      assert_equal("object", request.dig("tools", 0, "function", "parameters", "type"))
+
+      message = completion.choices.first.message
+      assert_instance_of(TextModel, message.parsed)
+      assert_equal("hello", message.parsed.value)
+      arguments = message.tool_calls.first.function.parsed
+      assert_instance_of(ToolModel, arguments)
+      assert_equal(7, arguments.argument)
     end
   end
 

--- a/test/openai/resources/chat/completions/streaming_test.rb
+++ b/test/openai/resources/chat/completions/streaming_test.rb
@@ -652,6 +652,64 @@ class OpenAI::Test::Resources::Chat::Completions::StreamingTest < Minitest::Test
     end
   end
 
+  def test_structured_output_and_typed_tool_streaming_preserve_both_parsed_results
+    chunk = {id: "chatcmpl-combined", object: "chat.completion.chunk", created: 1, model: "test"}
+    choices = [
+      {
+        index: 0,
+        delta: {
+          role: "assistant",
+          content: JSON.generate(name: "John", age: 30),
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_test",
+              type: "function",
+              function: {
+                name: "WeatherToolModel",
+                arguments: JSON.generate(location: "Paris", units: "celsius")
+              }
+            }
+          ]
+        },
+        finish_reason: nil
+      },
+      {index: 0, delta: {}, finish_reason: "tool_calls"}
+    ]
+    events_body = choices.map { |choice| "data: #{JSON.generate(chunk.merge(choices: [choice]))}\n\n" }
+    stub_streaming_response(events_body.join + "data: [DONE]\n\n")
+
+    stream = @client.chat.completions.stream(
+      **basic_params,
+      response_format: PersonModel,
+      tools: [WeatherToolModel]
+    )
+    events = stream.to_a
+
+    assert_requested(:post, "http://localhost/chat/completions") do |request|
+      body = JSON.parse(request.body)
+
+      assert_equal("PersonModel", body.dig("response_format", "json_schema", "name"))
+      assert_equal("function", body.dig("tools", 0, "type"))
+      assert_equal("WeatherToolModel", body.dig("tools", 0, "function", "name"))
+      assert_equal("object", body.dig("tools", 0, "function", "parameters", "type"))
+    end
+
+    content_done = events.find { |event| event.type == :"content.done" }
+    assert_instance_of(PersonModel, content_done.parsed)
+    assert_equal("John", content_done.parsed.name)
+
+    tool_done = events.find { |event| event.type == :"tool_calls.function.arguments.done" }
+    assert_instance_of(WeatherToolModel, tool_done.parsed)
+    assert_equal("Paris", tool_done.parsed.location)
+
+    message = stream.get_final_completion.choices.first.message
+    assert_instance_of(PersonModel, message.parsed)
+    assert_equal(30, message.parsed.age)
+    assert_instance_of(WeatherToolModel, message.tool_calls.first.function.parsed)
+    assert_equal("celsius", message.tool_calls.first.function.parsed.units)
+  end
+
   private
 
   def weather_tool


### PR DESCRIPTION
## Summary

- Process Chat Completions response formats and typed function tools independently so combined requests serialize valid function-tool objects.
- Preserve existing response-format representations, shorthand/nested tool forms, caller-owned input identity, and structured hydration for both non-streaming and streaming calls.
- Replace the misleading precedence characterization with focused public-entrypoint regressions covering parsed content, typed tool arguments, streaming events, and final completions.

## Verification

- `PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH TMPDIR=/private/tmp MT_CPU=1 bundle exec rake test` — 1,497 runs, 13,588 assertions, 0 failures, 0 errors.
- `PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH bundle exec rake lint` — RuboCop, rubyfmt, Sorbet, 1,250 RBS validations, and suppression checks pass.
- `python3 -I scripts/castiron/custom_code_budget.py check --repo /Users/jbeckwith/.codex/worktrees/98cc/openai-ruby --base 6537fb4ba257cdb30b1da0fe68c16474bc53c5b1 --head 3eba0819e9596bcbe0b5784c16b2d310dd1f2ad8 --public --out /private/tmp/openai-ruby-chat-structured-output-budget` — 3,047 / 4,000 custom lines.
- Two consecutive clean adversarial-review rounds with two independent fresh-context reviewers each; security review found no new logging, credentials, endpoints, dependencies, or deserialization paths.
