### PR TITLE
fix: enforce workload identity request deadlines

### DIFF
--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -15,6 +15,12 @@ module OpenAI
       DEFAULT_REFRESH_BUFFER_SECONDS = 1200
       MAX_REJECTED_TOKEN_REFRESH_ATTEMPTS = 3
       private_constant :MAX_REJECTED_TOKEN_REFRESH_ATTEMPTS
+      # Provider implementations wrap StandardError, but scheduler deadlines
+      # must cross that boundary before normalization to Timeout::Error.
+      # rubocop:disable Lint/InheritException
+      PROVIDER_DEADLINE_ERROR = Class.new(Exception)
+      # rubocop:enable Lint/InheritException
+      private_constant :PROVIDER_DEADLINE_ERROR
 
       def initialize(
         config,
@@ -274,14 +280,19 @@ module OpenAI
       private def fetch_token_from_exchange(deadline:)
         return @token_exchange.fetch(deadline: deadline) unless @token_exchange.nil?
 
-        timeout = remaining_timeout(deadline)
-        subject_token = Timeout.timeout(timeout, nil, "request timed out during workload identity authentication") do
-          @config.provider.get_token
+        message = "request timed out during workload identity authentication"
+        subject_token, token_type = begin
+          timeout = remaining_timeout(deadline)
+          Timeout.timeout(timeout, PROVIDER_DEADLINE_ERROR, message) do
+            [@config.provider.get_token, @config.provider.token_type]
+          end
+
+        rescue PROVIDER_DEADLINE_ERROR
+          raise Timeout::Error, message
         end
 
         check_deadline!(deadline)
 
-        token_type = @config.provider.token_type
         subject_token_type = SUBJECT_TOKEN_TYPES.fetch(token_type) do
           raise(
             ArgumentError,

--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -274,7 +274,11 @@ module OpenAI
       private def fetch_token_from_exchange(deadline:)
         return @token_exchange.fetch(deadline: deadline) unless @token_exchange.nil?
 
-        subject_token = @config.provider.get_token
+        timeout = remaining_timeout(deadline)
+        subject_token = Timeout.timeout(timeout, nil, "request timed out during workload identity authentication") do
+          @config.provider.get_token
+        end
+
         check_deadline!(deadline)
 
         token_type = @config.provider.token_type

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -18,6 +18,8 @@ module OpenAI
     DEFAULT_MAX_RETRY_DELAY = 8.0
 
     WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER = "workload-identity-auth"
+    WORKLOAD_IDENTITY_DEADLINE_ERROR = Class.new(Timeout::Error)
+    private_constant :WORKLOAD_IDENTITY_DEADLINE_ERROR
 
     # @return [String, nil]
     attr_reader :api_key
@@ -250,7 +252,7 @@ module OpenAI
     private def validate_retry_delay!(request, delay:)
       deadline = request[:x509_request_context]&.fetch(:deadline) || request[:workload_identity_deadline]
       if deadline && delay >= deadline - OpenAI::Internal::Util.monotonic_secs
-        raise Timeout::Error, "request timed out during workload identity authentication"
+        raise WORKLOAD_IDENTITY_DEADLINE_ERROR, "request timed out during workload identity authentication"
       end
 
       super
@@ -362,12 +364,13 @@ module OpenAI
 
     rescue Timeout::Error => error
       unless x509_request
-        raise if request[:workload_identity_deadline].nil?
+        raise unless error.is_a?(WORKLOAD_IDENTITY_DEADLINE_ERROR)
 
         url = request.fetch(:url).dup
         url.query = nil
         url.fragment = nil
-        raise OpenAI::Errors::APITimeoutError.new(url: url, message: error.message)
+        cause = Timeout::Error.new(error.message)
+        raise OpenAI::Errors::APITimeoutError.new(url: url, message: error.message), cause: cause
       end
 
       url = request.fetch(:url).dup

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -248,7 +248,7 @@ module OpenAI
 
     # @api private
     private def validate_retry_delay!(request, delay:)
-      deadline = request[:x509_request_context]&.fetch(:deadline)
+      deadline = request[:x509_request_context]&.fetch(:deadline) || request[:workload_identity_deadline]
       if deadline && delay >= deadline - OpenAI::Internal::Util.monotonic_secs
         raise Timeout::Error, "request timed out during workload identity authentication"
       end
@@ -281,7 +281,8 @@ module OpenAI
           request[:workload_identity_deadline] ||
           request[:timeout]&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
       else
-        request[:timeout]&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
+        request[:workload_identity_deadline] ||
+          request[:timeout]&.then { OpenAI::Internal::Util.monotonic_secs + _1 }
       end
 
       request = request.merge(workload_identity_deadline: deadline)
@@ -359,8 +360,12 @@ module OpenAI
         end
       end
 
-    rescue Timeout::Error
-      raise unless x509_request
+    rescue Timeout::Error => error
+      unless x509_request
+        raise unless request.key?(:workload_identity_deadline)
+
+        raise OpenAI::Errors::APITimeoutError.new(url: request.fetch(:url), message: error.message)
+      end
 
       url = request.fetch(:url).dup
       url.query = nil

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -362,9 +362,12 @@ module OpenAI
 
     rescue Timeout::Error => error
       unless x509_request
-        raise unless request.key?(:workload_identity_deadline)
+        raise if request[:workload_identity_deadline].nil?
 
-        raise OpenAI::Errors::APITimeoutError.new(url: request.fetch(:url), message: error.message)
+        url = request.fetch(:url).dup
+        url.query = nil
+        url.fragment = nil
+        raise OpenAI::Errors::APITimeoutError.new(url: url, message: error.message)
       end
 
       url = request.fetch(:url).dup
@@ -448,7 +451,10 @@ module OpenAI
     rescue Timeout::Error => e
       raise if x509_transport?(@requester)
 
-      raise OpenAI::Errors::APITimeoutError.new(url: request.fetch(:url), message: e.message)
+      url = request.fetch(:url).dup
+      url.query = nil
+      url.fragment = nil
+      raise OpenAI::Errors::APITimeoutError.new(url: url, message: e.message)
     end
 
     # @api private

--- a/test/openai/auth/workload_identity_test.rb
+++ b/test/openai/auth/workload_identity_test.rb
@@ -241,6 +241,110 @@ class WorkloadIdentityTest < Minitest::Test
     assert_equal("oauth-access-token", token)
   end
 
+  def test_workload_identity_provider_deadline_interrupts_provider_error_wrapping
+    provider = Class
+      .new do
+        attr_reader(:completed)
+
+        def get_token
+          sleep(0.1)
+          @completed = true
+          "fake-subject-token"
+        rescue StandardError => error
+          raise(
+            OpenAI::Errors::SubjectTokenProviderError.new(
+              message: "provider failed",
+              provider: "fake",
+              cause: error
+            )
+          )
+        end
+
+        def token_type = OpenAI::Auth::TokenType::JWT
+      end
+      .new
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      identity_provider_id: "idp-123",
+      service_account_id: "sa-456",
+      provider: provider
+    )
+    auth = OpenAI::Auth::WorkloadIdentityAuth.new(config, "org-123")
+    deadline = OpenAI::Internal::Util.monotonic_secs + 0.01
+
+    assert_raises(Timeout::Error) { auth.get_token(deadline: deadline) }
+    refute(provider.completed)
+    refute(auth.instance_variable_get(:@refreshing))
+  end
+
+  def test_workload_identity_provider_timeout_releases_concurrent_refresh_waiters
+    provider_started = Queue.new
+    release_provider = Queue.new
+    provider = Class
+      .new do
+        attr_reader(:calls, :completed_calls)
+
+        def initialize(started, release)
+          @started = started
+          @release = release
+          @calls = 0
+          @completed_calls = 0
+        end
+
+        def get_token
+          @calls += 1
+          if @calls == 1
+            Thread.handle_interrupt(Exception => :never) do
+              @started << true
+              @release.pop
+            end
+
+            sleep(0.1)
+          end
+
+          @completed_calls += 1
+          "fake-subject-token"
+        end
+
+        def token_type = OpenAI::Auth::TokenType::JWT
+      end
+      .new(provider_started, release_provider)
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      identity_provider_id: "idp-123",
+      service_account_id: "sa-456",
+      provider: provider
+    )
+    auth = OpenAI::Auth::WorkloadIdentityAuth.new(config, "org-123")
+    stub_request(:post, "https://auth.openai.com/oauth/token")
+      .to_return(
+        status: 200,
+        body: JSON.generate({"access_token" => "recovered-token", "expires_in" => 3600})
+      )
+
+    refresher = Thread.new do
+      deadline = OpenAI::Internal::Util.monotonic_secs + 0.03
+      auth.get_token(deadline: deadline)
+    end
+
+    refresher.report_on_exception = false
+    Timeout.timeout(1) { provider_started.pop }
+    waiter = Thread.new { auth.get_token }
+    waiter.report_on_exception = false
+    Timeout.timeout(1) { Thread.pass until waiter.status == "sleep" }
+    release_provider << true
+
+    assert_raises(Timeout::Error) { refresher.value }
+    assert_raises(OpenAI::Errors::AuthenticationError) { waiter.value }
+    refute(auth.instance_variable_get(:@refreshing))
+    assert_equal("recovered-token", auth.get_token)
+    assert_equal(2, provider.calls)
+    assert_equal(1, provider.completed_calls)
+
+  ensure
+    release_provider&.push(true) if refresher&.alive?
+    refresher&.kill&.join if refresher&.alive?
+    waiter&.kill&.join if waiter&.alive?
+  end
+
   def test_workload_identity_refresh_cleanup_is_installed_before_interrupts_resume
     config = OpenAI::Auth::WorkloadIdentity.new(
       identity_provider_id: "idp-123",

--- a/test/openai/auth/workload_identity_test.rb
+++ b/test/openai/auth/workload_identity_test.rb
@@ -276,6 +276,104 @@ class WorkloadIdentityTest < Minitest::Test
     refute(auth.instance_variable_get(:@refreshing))
   end
 
+  def test_workload_identity_provider_deadline_bounds_token_type_resolution
+    provider = Class
+      .new do
+        attr_reader(:completed)
+
+        def get_token = "fake-subject-token"
+
+        def token_type
+          sleep(0.1)
+          @completed = true
+          OpenAI::Auth::TokenType::JWT
+        rescue StandardError => error
+          raise(
+            OpenAI::Errors::SubjectTokenProviderError.new(
+              message: "provider failed",
+              provider: "fake",
+              cause: error
+            )
+          )
+        end
+      end
+      .new
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      identity_provider_id: "idp-123",
+      service_account_id: "sa-456",
+      provider: provider
+    )
+    auth = OpenAI::Auth::WorkloadIdentityAuth.new(config, "org-123")
+    deadline = OpenAI::Internal::Util.monotonic_secs + 0.01
+
+    assert_raises(Timeout::Error) { auth.get_token(deadline: deadline) }
+    refute(provider.completed)
+    refute(auth.instance_variable_get(:@refreshing))
+  end
+
+  def test_workload_identity_provider_deadline_survives_fiber_scheduler_wrapping
+    scheduler = Class
+      .new do
+        def fiber(&block) = Fiber.new(blocking: false, &block).tap(&:resume)
+        def block(*) = false
+        def unblock(*) = nil
+        def io_wait(*) = 0
+        def fiber_interrupt(fiber, exception) = fiber.raise exception
+
+        def timeout_after(_duration, exception_class, message)
+          @exception_class = exception_class
+          @message = message
+          yield
+        ensure
+          @exception_class = nil
+          @message = nil
+        end
+
+        def kernel_sleep(*)
+          raise @exception_class, @message
+        end
+      end
+      .new
+    provider = Class
+      .new do
+        def get_token
+          sleep(0.1)
+          "fake-subject-token"
+        rescue StandardError => error
+          raise(
+            OpenAI::Errors::SubjectTokenProviderError.new(
+              message: "provider failed",
+              provider: "fake",
+              cause: error
+            )
+          )
+        end
+
+        def token_type = OpenAI::Auth::TokenType::JWT
+      end
+      .new
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      identity_provider_id: "idp-123",
+      service_account_id: "sa-456",
+      provider: provider
+    )
+    auth = OpenAI::Auth::WorkloadIdentityAuth.new(config, "org-123")
+    error = nil
+    Fiber.set_scheduler(scheduler)
+    Fiber.schedule do
+      deadline = OpenAI::Internal::Util.monotonic_secs + 1
+      auth.get_token(deadline: deadline)
+    rescue StandardError => exception
+      error = exception
+    end
+
+    assert_instance_of(Timeout::Error, error)
+    refute(auth.instance_variable_get(:@refreshing))
+
+  ensure
+    Fiber.set_scheduler(nil)
+  end
+
   def test_workload_identity_provider_timeout_releases_concurrent_refresh_waiters
     provider_started = Queue.new
     release_provider = Queue.new

--- a/test/openai/resources/polling_helpers_test.rb
+++ b/test/openai/resources/polling_helpers_test.rb
@@ -53,16 +53,18 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
   end
 
   class SlowSubjectTokenProvider
-    attr_reader :calls
+    attr_reader :calls, :completed_calls
 
     def initialize(delay:)
       @delay = delay
       @calls = 0
+      @completed_calls = 0
     end
 
     def get_token
       @calls += 1
       sleep(@delay)
+      @completed_calls += 1
       "subject-token"
     end
 
@@ -259,9 +261,28 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     assert_empty(transport.requests)
   end
 
+  def test_workload_identity_api_retries_preserve_the_original_authentication_deadline
+    responses = [
+      [429, {"retry-after" => "0"}, {error: {message: "retry", type: "rate_limit_error"}}],
+      [200, {}, file_object(status: "processed")]
+    ]
+    transport = scripted_transport { responses.shift }
+    auth = ScriptedWorkloadIdentityAuth.new(slow_token_requests: [])
+    client = build_workload_identity_client(transport, auth)
+
+    result = client.files.retrieve("file_123", request_options: {timeout: 1})
+
+    assert_equal(:processed, result.status)
+    assert_equal(2, transport.requests.length)
+    assert_equal(2, auth.token_requests)
+    assert_equal(1, auth.deadlines.uniq.length)
+    assert_instance_of(Float, auth.deadlines.fetch(0))
+  end
+
   def test_workload_identity_timeout_uses_the_sdk_error_and_retry_contract
     transport = scripted_transport { flunk("request should not be sent") }
-    provider = SlowSubjectTokenProvider.new(delay: 0.02)
+    provider = SlowSubjectTokenProvider.new(delay: 0.1)
+    retries = []
     config = OpenAI::Auth::WorkloadIdentity.new(
       identity_provider_id: "idp-123",
       service_account_id: "sa-456",
@@ -275,7 +296,8 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
       http_client: transport,
       max_retries: 2,
       initial_retry_delay: 0,
-      max_retry_delay: 0
+      max_retry_delay: 0,
+      on_retry: -> (event) { retries << event }
     )
 
     error = assert_raises(OpenAI::Errors::APITimeoutError) do
@@ -283,7 +305,9 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     end
 
     assert_instance_of(Timeout::Error, error.cause)
-    assert_equal(3, provider.calls)
+    assert_equal(1, provider.calls)
+    assert_equal(0, provider.completed_calls)
+    assert_empty(retries)
     assert_empty(transport.requests)
   end
 

--- a/test/openai/resources/polling_helpers_test.rb
+++ b/test/openai/resources/polling_helpers_test.rb
@@ -234,6 +234,20 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     assert_nil(transport.requests.fetch(0).timeout)
   end
 
+  def test_unbounded_workload_identity_preserves_an_inner_timeout_error
+    transport = scripted_transport { raise Timeout::Error, "inner timeout" }
+    auth = ScriptedWorkloadIdentityAuth.new(slow_token_requests: [])
+    client = build_workload_identity_client(transport, auth)
+
+    error = assert_raises(Timeout::Error) do
+      client.files.retrieve("file_123", request_options: {timeout: nil})
+    end
+
+    assert_equal("inner timeout", error.message)
+    assert_nil(auth.deadlines.fetch(0))
+    assert_equal(1, transport.requests.length)
+  end
+
   def test_workload_identity_authentication_consumes_the_request_timeout
     transport = scripted_transport { flunk("request should not be sent") }
     auth = Class
@@ -279,6 +293,27 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     assert_instance_of(Float, auth.deadlines.fetch(0))
   end
 
+  def test_workload_identity_retry_deadline_redacts_the_timeout_error_url
+    transport = scripted_transport do
+      [429, {"retry-after" => "1"}, {error: {message: "retry", type: "rate_limit_error"}}]
+    end
+
+    auth = ScriptedWorkloadIdentityAuth.new(slow_token_requests: [])
+    client = build_workload_identity_client(transport, auth)
+
+    error = assert_raises(OpenAI::Errors::APITimeoutError) do
+      client.files.retrieve(
+        "file_123",
+        request_options: {timeout: 0.01, extra_query: {"signature" => "fake-sensitive-query"}}
+      )
+    end
+
+    assert_nil(error.url.query)
+    assert_nil(error.url.fragment)
+    refute_match(/fake-sensitive-query/, error.inspect)
+    assert_equal(1, transport.requests.length)
+  end
+
   def test_workload_identity_timeout_uses_the_sdk_error_and_retry_contract
     transport = scripted_transport { flunk("request should not be sent") }
     provider = SlowSubjectTokenProvider.new(delay: 0.1)
@@ -301,10 +336,16 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     )
 
     error = assert_raises(OpenAI::Errors::APITimeoutError) do
-      client.files.retrieve("file_123", request_options: {timeout: 0.005})
+      client.files.retrieve(
+        "file_123",
+        request_options: {timeout: 0.005, extra_query: {"signature" => "fake-sensitive-query"}}
+      )
     end
 
     assert_instance_of(Timeout::Error, error.cause)
+    assert_nil(error.url.query)
+    assert_nil(error.url.fragment)
+    refute_match(/fake-sensitive-query/, error.inspect)
     assert_equal(1, provider.calls)
     assert_equal(0, provider.completed_calls)
     assert_empty(retries)

--- a/test/openai/resources/polling_helpers_test.rb
+++ b/test/openai/resources/polling_helpers_test.rb
@@ -248,6 +248,20 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     assert_equal(1, transport.requests.length)
   end
 
+  def test_bounded_workload_identity_preserves_an_inner_timeout_error
+    transport = scripted_transport { raise Timeout::Error, "inner timeout" }
+    auth = ScriptedWorkloadIdentityAuth.new(slow_token_requests: [])
+    client = build_workload_identity_client(transport, auth)
+
+    error = assert_raises(Timeout::Error) do
+      client.files.retrieve("file_123", request_options: {timeout: 1})
+    end
+
+    assert_equal("inner timeout", error.message)
+    assert_instance_of(Float, auth.deadlines.fetch(0))
+    assert_equal(1, transport.requests.length)
+  end
+
   def test_workload_identity_authentication_consumes_the_request_timeout
     transport = scripted_transport { flunk("request should not be sent") }
     auth = Class


### PR DESCRIPTION
## Summary

- Bound non-X.509 workload-identity subject-token acquisition and token-type resolution by the request's remaining monotonic deadline without changing the provider interface.
- Preserve the original authentication deadline across API retries and reject retry delays once that deadline expires, while retaining `APITimeoutError` compatibility.
- Preserve `timeout: nil` behavior and redact query/fragment data from the new provider- and retry-timeout error paths.
- Add public-client and deterministic concurrent-refresh regressions covering interrupted providers, fiber schedulers, retry suppression, deadline reuse, refresh cleanup, unbounded requests, and timeout URL redaction.
- Preserve polling helpers, ordinary client error behavior, and existing X.509 authentication contracts.

## Verification

- Focused polling/public-client suite — 41 tests, 217 assertions, zero failures.
- Complete authentication/X.509 suite — 171 tests, 1,573 assertions, zero failures.
- `bundle exec rake lint:rubocop` — 2,792 files, zero offenses; Ruby and RBS formatting checks pass.
- `bundle exec rake typecheck` — Sorbet clean; 1,250 RBS files validate.
- Trusted custom-code budget — 3,061 / 4,000 lines; 939 lines of headroom.
- Independent adversarial/security review — two consecutive clean two-reviewer rounds; no credential exposure or public API changes.
- `./scripts/test` was attempted after the review fixes but hung in unrelated Realtime network-invariant tests; interrupted after 280 tests and 1,647 assertions with zero failures and one skip. The earlier pre-review full suite was green.

Authentication ownership review requested from `@openai/sdks-team`.

Castiron companion: [openai/openai#1377018](https://github.com/openai/openai/pull/1377018).
