### PR TITLE
fix: resume Responses streams from server-side cursors

### DIFF
--- a/lib/openai/helpers/streaming/response_events.rb
+++ b/lib/openai/helpers/streaming/response_events.rb
@@ -4,7 +4,7 @@ module OpenAI
   module Helpers
     module Streaming
       class ResponseTextDeltaEvent < OpenAI::Models::Responses::ResponseTextDeltaEvent
-        required :snapshot, String
+        optional :snapshot, String, nil?: true
       end
 
       class ResponseTextDoneEvent < OpenAI::Models::Responses::ResponseTextDoneEvent
@@ -12,7 +12,7 @@ module OpenAI
       end
 
       class ResponseFunctionCallArgumentsDeltaEvent < OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
-        required :snapshot, String
+        optional :snapshot, String, nil?: true
       end
 
       class ResponseCompletedEvent < OpenAI::Models::Responses::ResponseCompletedEvent

--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -13,7 +13,8 @@ module OpenAI
           @last_response = raw_stream.last_response
           @iterator = iterator
           @state = ResponseStreamState.new(
-            text_format: text_format
+            text_format: text_format,
+            starting_after: starting_after
           )
         end
 
@@ -80,10 +81,12 @@ module OpenAI
       class ResponseStreamState
         attr_reader :completed_response
 
-        def initialize(text_format:)
+        def initialize(text_format:, starting_after: nil)
           @current_snapshot = nil
           @completed_response = nil
           @text_format = text_format
+          @resumed = !starting_after.nil?
+          @resumed_snapshots = {}
         end
 
         def handle_event(event)
@@ -98,11 +101,17 @@ module OpenAI
 
           case event
           when OpenAI::Models::Responses::ResponseTextDeltaEvent
-            output = @current_snapshot.output[event.output_index]
-            assert_type(output, :message)
+            snapshot = if @current_snapshot
+              output = @current_snapshot.output[event.output_index]
+              assert_type(output, :message)
 
-            content = output.content[event.content_index]
-            assert_type(content, :output_text)
+              content = output.content[event.content_index]
+              assert_type(content, :output_text)
+              content.text
+            else
+              key = [:text, event.output_index, event.content_index]
+              (@resumed_snapshots[key] ||= +"").concat(event.delta).dup
+            end
 
             events_to_yield <<
               OpenAI::Streaming::ResponseTextDeltaEvent.new(
@@ -112,17 +121,22 @@ module OpenAI
                 output_index: event.output_index,
                 sequence_number: event.sequence_number,
                 type: event.type,
-                snapshot: content.text
+                snapshot: snapshot
               )
 
           when OpenAI::Models::Responses::ResponseTextDoneEvent
-            output = @current_snapshot.output[event.output_index]
-            assert_type(output, :message)
+            text = if @current_snapshot
+              output = @current_snapshot.output[event.output_index]
+              assert_type(output, :message)
 
-            content = output.content[event.content_index]
-            assert_type(content, :output_text)
+              content = output.content[event.content_index]
+              assert_type(content, :output_text)
+              content.text
+            else
+              event.text
+            end
 
-            parsed = parse_structured_text(content.text)
+            parsed = parse_structured_text(text)
 
             events_to_yield <<
               OpenAI::Streaming::ResponseTextDoneEvent.new(
@@ -136,8 +150,14 @@ module OpenAI
               )
 
           when OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
-            output = @current_snapshot.output[event.output_index]
-            assert_type(output, :function_call)
+            snapshot = if @current_snapshot
+              output = @current_snapshot.output[event.output_index]
+              assert_type(output, :function_call)
+              output.arguments
+            else
+              key = [:function, event.output_index]
+              (@resumed_snapshots[key] ||= +"").concat(event.delta).dup
+            end
 
             events_to_yield <<
               OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
@@ -146,7 +166,7 @@ module OpenAI
                 output_index: event.output_index,
                 sequence_number: event.sequence_number,
                 type: event.type,
-                snapshot: output.arguments
+                snapshot: snapshot
               )
 
           when OpenAI::Models::Responses::ResponseCompletedEvent
@@ -167,16 +187,25 @@ module OpenAI
 
         def accumulate_event(event:, current_snapshot:)
           if current_snapshot.nil?
-            unless event.is_a?(OpenAI::Models::Responses::ResponseCreatedEvent)
+            if event.is_a?(OpenAI::Models::Responses::ResponseCreatedEvent)
+              # Use the converter to create a new, isolated copy of the response object.
+              # This ensures proper type validation and prevents shared object references.
+              return OpenAI::Internal::Type::Converter.coerce(
+                OpenAI::Models::Responses::Response,
+                event.response
+              )
+            end
+
+            unless @resumed
               raise "Expected first event to be response.created"
             end
 
-            # Use the converter to create a new, isolated copy of the response object.
-            # This ensures proper type validation and prevents shared object references.
-            return OpenAI::Internal::Type::Converter.coerce(
-              OpenAI::Models::Responses::Response,
-              event.response
-            )
+            if event.is_a?(OpenAI::Models::Responses::ResponseCompletedEvent)
+              @completed_response = event.response
+              return event.response
+            end
+
+            return nil
           end
 
           case event

--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -27,7 +27,7 @@ module OpenAI
           OpenAI::Internal::Util.chain_fused(@iterator) do |yielder|
             @iterator.each do |event|
               case event
-              when OpenAI::Streaming::ResponseTextDeltaEvent
+              when OpenAI::Models::Responses::ResponseTextDeltaEvent
                 yielder << event.delta
               end
             end
@@ -86,7 +86,6 @@ module OpenAI
           @completed_response = nil
           @text_format = text_format
           @resumed = !starting_after.nil?
-          @resumed_snapshots = {}
         end
 
         def handle_event(event)
@@ -101,28 +100,28 @@ module OpenAI
 
           case event
           when OpenAI::Models::Responses::ResponseTextDeltaEvent
-            snapshot = if @current_snapshot
+            if @current_snapshot
               output = @current_snapshot.output[event.output_index]
               assert_type(output, :message)
 
               content = output.content[event.content_index]
               assert_type(content, :output_text)
-              content.text
+              events_to_yield <<
+                OpenAI::Streaming::ResponseTextDeltaEvent.new(
+                  content_index: event.content_index,
+                  delta: event.delta,
+                  item_id: event.item_id,
+                  output_index: event.output_index,
+                  sequence_number: event.sequence_number,
+                  type: event.type,
+                  snapshot: content.text
+                )
             else
-              key = [:text, event.output_index, event.content_index]
-              (@resumed_snapshots[key] ||= +"").concat(event.delta).dup
+              # A server-directed resumed stream may begin after response.created.
+              # Without the omitted prefix, a snapshot would be incomplete and
+              # materializing every partial prefix would make streaming quadratic.
+              events_to_yield << event
             end
-
-            events_to_yield <<
-              OpenAI::Streaming::ResponseTextDeltaEvent.new(
-                content_index: event.content_index,
-                delta: event.delta,
-                item_id: event.item_id,
-                output_index: event.output_index,
-                sequence_number: event.sequence_number,
-                type: event.type,
-                snapshot: snapshot
-              )
 
           when OpenAI::Models::Responses::ResponseTextDoneEvent
             text = if @current_snapshot
@@ -150,24 +149,23 @@ module OpenAI
               )
 
           when OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
-            snapshot = if @current_snapshot
+            if @current_snapshot
               output = @current_snapshot.output[event.output_index]
               assert_type(output, :function_call)
-              output.arguments
+              events_to_yield <<
+                OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
+                  delta: event.delta,
+                  item_id: event.item_id,
+                  output_index: event.output_index,
+                  sequence_number: event.sequence_number,
+                  type: event.type,
+                  snapshot: output.arguments
+                )
             else
-              key = [:function, event.output_index]
-              (@resumed_snapshots[key] ||= +"").concat(event.delta).dup
+              # See the text-delta branch above: a partial server resume has no
+              # complete argument prefix from which to build a truthful snapshot.
+              events_to_yield << event
             end
-
-            events_to_yield <<
-              OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
-                delta: event.delta,
-                item_id: event.item_id,
-                output_index: event.output_index,
-                sequence_number: event.sequence_number,
-                type: event.type,
-                snapshot: snapshot
-              )
 
           when OpenAI::Models::Responses::ResponseCompletedEvent
             events_to_yield <<

--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -120,7 +120,8 @@ module OpenAI
               # A server-directed resumed stream may begin after response.created.
               # Without the omitted prefix, a snapshot would be incomplete and
               # materializing every partial prefix would make streaming quadratic.
-              events_to_yield << event
+              events_to_yield <<
+                OpenAI::Streaming::ResponseTextDeltaEvent.new(event.to_h.merge(snapshot: nil))
             end
 
           when OpenAI::Models::Responses::ResponseTextDoneEvent
@@ -164,7 +165,10 @@ module OpenAI
             else
               # See the text-delta branch above: a partial server resume has no
               # complete argument prefix from which to build a truthful snapshot.
-              events_to_yield << event
+              events_to_yield <<
+                OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
+                  event.to_h.merge(snapshot: nil)
+                )
             end
 
           when OpenAI::Models::Responses::ResponseCompletedEvent

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -220,7 +220,7 @@ module OpenAI
         end
 
         if response_id
-          retrieve_params = params.slice(:include, :request_options)
+          retrieve_params = params.slice(:include, :request_options, :starting_after)
 
           raw_stream = retrieve_streaming_internal(
             response_id,

--- a/lib/openai/resources/responses.rb
+++ b/lib/openai/resources/responses.rb
@@ -220,7 +220,8 @@ module OpenAI
         end
 
         if response_id
-          retrieve_params = params.slice(:include, :request_options, :starting_after)
+          retrieve_params = parsed.slice(:include, :starting_after)
+          retrieve_params[:request_options] = options
 
           raw_stream = retrieve_streaming_internal(
             response_id,

--- a/rbi/openai/helpers/streaming/events.rbi
+++ b/rbi/openai/helpers/streaming/events.rbi
@@ -4,7 +4,7 @@ module OpenAI
   module Helpers
     module Streaming
       class ResponseTextDeltaEvent < OpenAI::Models::Responses::ResponseTextDeltaEvent
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         def snapshot
         end
       end
@@ -16,7 +16,7 @@ module OpenAI
       end
 
       class ResponseFunctionCallArgumentsDeltaEvent < OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         def snapshot
         end
       end

--- a/rbi/openai/helpers/streaming/response_stream.rbi
+++ b/rbi/openai/helpers/streaming/response_stream.rbi
@@ -78,8 +78,8 @@ module OpenAI
         sig { returns(T.nilable(OpenAI::Models::Responses::Response)) }
         attr_reader :completed_response
 
-        sig { params(text_format: T.untyped).void }
-        def initialize(text_format:)
+        sig { params(text_format: T.untyped, starting_after: T.nilable(Integer)).void }
+        def initialize(text_format:, starting_after: nil)
         end
 
         sig { params(event: T.untyped).returns(T::Array[T.untyped]) }
@@ -91,7 +91,7 @@ module OpenAI
             event: T.untyped,
             current_snapshot: T.nilable(OpenAI::Models::Responses::Response)
           )
-            .returns(OpenAI::Models::Responses::Response)
+            .returns(T.nilable(OpenAI::Models::Responses::Response))
         end
         def accumulate_event(event:, current_snapshot:)
         end

--- a/test/openai/resources/responses/streaming_test.rb
+++ b/test/openai/resources/responses/streaming_test.rb
@@ -417,7 +417,7 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
 
   def test_resume_stream_with_response_id_and_starting_after
     # Stub the GET request to retrieve the response.
-    stub_request(:get, "http://localhost/responses/msg_456?stream=true")
+    stub_request(:get, "http://localhost/responses/msg_456?starting_after=7&stream=true")
       .to_return(
         status: 200,
         headers: {"Content-Type" => "text/event-stream"},
@@ -451,6 +451,138 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     completed = events.find { |e| e.type == :"response.completed" }
     assert_equal("msg_456", completed.response[:id])
     assert_equal(11, completed.sequence_number)
+  end
+
+  def test_incrementally_resume_stream_from_output_item
+    stub_request(:get, "http://localhost/responses/msg_001?starting_after=2&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: incremental_sse_response(basic_text_sse_response, starting_after: 2)
+      )
+
+    stream = @client.responses.stream(response_id: "msg_001", starting_after: 2)
+    events = stream.to_a
+
+    assert_instance_of(OpenAI::Models::Responses::ResponseOutputItemAddedEvent, events.first)
+    assert_text_delta_events(
+      events,
+      expected_deltas: ["Hello there! ", "How can I help you ", "today?"],
+      expected_snapshot: "Hello there! How can I help you today?"
+    )
+    assert_equal("Hello there! How can I help you today?", stream.get_output_text)
+  ensure
+    stream&.close
+  end
+
+  def test_incrementally_resume_stream_from_text_delta
+    stub_request(:get, "http://localhost/responses/msg_001?starting_after=5&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: incremental_sse_response(basic_text_sse_response, starting_after: 5)
+      )
+
+    stream = @client.responses.stream(response_id: "msg_001", starting_after: 5)
+    events = stream.to_a
+
+    assert_text_delta_events(
+      events,
+      expected_deltas: ["How can I help you ", "today?"],
+      expected_snapshot: "How can I help you today?"
+    )
+    assert_equal("Hello there! How can I help you today?", stream.get_output_text)
+  ensure
+    stream&.close
+  end
+
+  def test_incrementally_resume_stream_from_completed_event
+    stub_request(:get, "http://localhost/responses/msg_001?starting_after=10&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: incremental_sse_response(basic_text_sse_response, starting_after: 10)
+      )
+
+    stream = @client.responses.stream(response_id: "msg_001", starting_after: 10)
+    events = stream.to_a
+
+    assert_equal(1, events.length)
+    assert_instance_of(OpenAI::Streaming::ResponseCompletedEvent, events.first)
+    assert_equal("Hello there! How can I help you today?", stream.get_output_text)
+  ensure
+    stream&.close
+  end
+
+  def test_incrementally_resume_stream_with_structured_output
+    stub_request(:get, "http://localhost/responses/msg_structured?starting_after=3&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: incremental_sse_response(resume_stream_structured_output_sse_response, starting_after: 3)
+      )
+
+    stream = @client.responses.stream(response_id: "msg_structured", starting_after: 3, text: WeatherModel)
+    events = stream.to_a
+
+    assert_pattern do
+      events.first => OpenAI::Streaming::ResponseTextDoneEvent(
+          parsed: WeatherModel(location: "San Francisco", temperature: 72)
+        )
+    end
+
+    assert_pattern do
+      stream.get_final_response.output.first.content.first.parsed => WeatherModel(
+          location: "San Francisco",
+          temperature: 72
+        )
+    end
+
+  ensure
+    stream&.close
+  end
+
+  def test_incrementally_resume_stream_with_typed_function_arguments
+    stub_request(:get, "http://localhost/responses/resp_stream_001?starting_after=9&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: incremental_sse_response(text_and_tools_sse_response, starting_after: 9)
+      )
+
+    stream = @client.responses.stream(
+      response_id: "resp_stream_001",
+      starting_after: 9,
+      text: CalendarEvent,
+      tools: [LookupCalendar]
+    )
+    events = stream.to_a
+
+    assert_function_delta_events(
+      events,
+      expected_deltas: ["{\"first_name\":\"Ada\",", "\"last_name\":\"Lovelace\"}"],
+      expected_snapshot: "{\"first_name\":\"Ada\",\"last_name\":\"Lovelace\"}"
+    )
+    assert_pattern do
+      stream.get_final_response.output.last.parsed => LookupCalendar(
+          first_name: "Ada",
+          last_name: "Lovelace"
+        )
+    end
+
+  ensure
+    stream&.close
+  end
+
+  def test_non_resumed_stream_still_requires_response_created
+    stub_streaming_response(incremental_sse_response(basic_text_sse_response, starting_after: 5))
+
+    stream = @client.responses.stream(**basic_params)
+    error = assert_raises(RuntimeError) { stream.to_a }
+
+    assert_equal("Expected first event to be response.created", error.message)
+  ensure
+    stream&.close
   end
 
   def test_resume_stream_with_structured_output
@@ -606,6 +738,17 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
   end
 
   private
+
+  def incremental_sse_response(response, starting_after:)
+    response
+      .split("\n\n")
+      .select do |event|
+        data = event.lines.find { |line| line.start_with?("data: ") }
+        JSON.parse(data.delete_prefix("data: ")).fetch("sequence_number") > starting_after
+      end
+      .join("\n\n") +
+      "\n\n"
+  end
 
   def function_tool_params
     basic_params.merge(

--- a/test/openai/resources/responses/streaming_test.rb
+++ b/test/openai/resources/responses/streaming_test.rb
@@ -415,6 +415,21 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     end
   end
 
+  def test_resume_stream_with_string_keyed_starting_after
+    stub_request(:get, "http://localhost/responses/msg_456?starting_after=7&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: resume_stream_with_starting_after_sse_response
+      )
+
+    stream = @client.responses.stream("response_id" => "msg_456", "starting_after" => 7)
+
+    assert(stream.to_a.all? { |event| event.sequence_number > 7 })
+  ensure
+    stream&.close
+  end
+
   def test_resume_stream_with_response_id_and_starting_after
     # Stub the GET request to retrieve the response.
     stub_request(:get, "http://localhost/responses/msg_456?starting_after=7&stream=true")
@@ -489,6 +504,9 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
       events,
       expected_deltas: ["How can I help you ", "today?"]
     )
+    text_delta = events.find { |event| event.sequence_number == 6 }
+    assert_equal(["How"], text_delta.logprobs.map(&:token))
+    assert_equal("msg_001", text_delta[:response_id])
     assert_equal("Hello there! How can I help you today?", stream.get_output_text)
   ensure
     stream&.close
@@ -576,6 +594,8 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
       events,
       expected_deltas: ["{\"first_name\":\"Ada\",", "\"last_name\":\"Lovelace\"}"]
     )
+    function_delta = events.find { |event| event.sequence_number == 10 }
+    assert_equal("resp_stream_001", function_delta[:response_id])
     assert_pattern do
       stream.get_final_response.output.last.parsed => LookupCalendar(
           first_name: "Ada",
@@ -798,22 +818,24 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
   end
 
   def assert_incremental_text_delta_events(events, expected_deltas:)
-    text_deltas = events.select { |event| event.type == :"response.output_text.delta" }
+    text_deltas = events.select do |event|
+      event.is_a?(OpenAI::Streaming::ResponseTextDeltaEvent)
+    end
 
     assert_equal(expected_deltas, text_deltas.map(&:delta))
     text_deltas.each do |event|
-      assert_instance_of(OpenAI::Models::Responses::ResponseTextDeltaEvent, event)
-      refute_respond_to(event, :snapshot)
+      assert_nil(event.snapshot)
     end
   end
 
   def assert_incremental_function_delta_events(events, expected_deltas:)
-    function_deltas = events.select { |event| event.type == :"response.function_call_arguments.delta" }
+    function_deltas = events.select do |event|
+      event.is_a?(OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent)
+    end
 
     assert_equal(expected_deltas, function_deltas.map(&:delta))
     function_deltas.each do |event|
-      assert_instance_of(OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent, event)
-      refute_respond_to(event, :snapshot)
+      assert_nil(event.snapshot)
     end
   end
 
@@ -835,7 +857,7 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
       data: {"type":"response.output_text.delta","sequence_number":5,"response_id":"msg_001","item_id":"item_001","output_index":0,"content_index":0,"delta":"Hello there! "}
 
       event: response.output_text.delta
-      data: {"type":"response.output_text.delta","sequence_number":6,"response_id":"msg_001","item_id":"item_001","output_index":0,"content_index":0,"delta":"How can I help you "}
+      data: {"type":"response.output_text.delta","sequence_number":6,"response_id":"msg_001","item_id":"item_001","output_index":0,"content_index":0,"delta":"How can I help you ","logprobs":[{"token":"How","logprob":-0.5,"top_logprobs":[]}]}
 
       event: response.output_text.delta
       data: {"type":"response.output_text.delta","sequence_number":7,"response_id":"msg_001","item_id":"item_001","output_index":0,"content_index":0,"delta":"today?"}
@@ -1136,7 +1158,7 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
       data: {"type":"response.output_item.added","sequence_number":9,"response_id":"resp_stream_001","output_index":1,"item":{"id":"call_001","object":"realtime.item","type":"function_call","status":"in_progress","name":"LookupCalendar","arguments":"","call_id":"call_001"}}
 
       event: response.function_call_arguments.delta
-      data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"call_001","output_index":1,"delta":"{\\"first_name\\":\\"Ada\\","}
+      data: {"type":"response.function_call_arguments.delta","sequence_number":10,"response_id":"resp_stream_001","item_id":"call_001","output_index":1,"delta":"{\\"first_name\\":\\"Ada\\","}
 
       event: response.function_call_arguments.delta
       data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"call_001","output_index":1,"delta":"\\"last_name\\":\\"Lovelace\\"}"}

--- a/test/openai/resources/responses/streaming_test.rb
+++ b/test/openai/resources/responses/streaming_test.rb
@@ -465,10 +465,9 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     events = stream.to_a
 
     assert_instance_of(OpenAI::Models::Responses::ResponseOutputItemAddedEvent, events.first)
-    assert_text_delta_events(
+    assert_incremental_text_delta_events(
       events,
-      expected_deltas: ["Hello there! ", "How can I help you ", "today?"],
-      expected_snapshot: "Hello there! How can I help you today?"
+      expected_deltas: ["Hello there! ", "How can I help you ", "today?"]
     )
     assert_equal("Hello there! How can I help you today?", stream.get_output_text)
   ensure
@@ -486,11 +485,26 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     stream = @client.responses.stream(response_id: "msg_001", starting_after: 5)
     events = stream.to_a
 
-    assert_text_delta_events(
+    assert_incremental_text_delta_events(
       events,
-      expected_deltas: ["How can I help you ", "today?"],
-      expected_snapshot: "How can I help you today?"
+      expected_deltas: ["How can I help you ", "today?"]
     )
+    assert_equal("Hello there! How can I help you today?", stream.get_output_text)
+  ensure
+    stream&.close
+  end
+
+  def test_incrementally_resumed_text_method
+    stub_request(:get, "http://localhost/responses/msg_001?starting_after=5&stream=true")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: incremental_sse_response(basic_text_sse_response, starting_after: 5)
+      )
+
+    stream = @client.responses.stream(response_id: "msg_001", starting_after: 5)
+
+    assert_equal(["How can I help you ", "today?"], stream.text.to_a)
     assert_equal("Hello there! How can I help you today?", stream.get_output_text)
   ensure
     stream&.close
@@ -558,10 +572,9 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     )
     events = stream.to_a
 
-    assert_function_delta_events(
+    assert_incremental_function_delta_events(
       events,
-      expected_deltas: ["{\"first_name\":\"Ada\",", "\"last_name\":\"Lovelace\"}"],
-      expected_snapshot: "{\"first_name\":\"Ada\",\"last_name\":\"Lovelace\"}"
+      expected_deltas: ["{\"first_name\":\"Ada\",", "\"last_name\":\"Lovelace\"}"]
     )
     assert_pattern do
       stream.get_final_response.output.last.parsed => LookupCalendar(
@@ -782,6 +795,26 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     assert_equal(expected_deltas.length, function_deltas.length, "Incorrect number of function delta events")
     assert_equal(expected_deltas, function_deltas.map(&:delta), "Incorrect delta values")
     assert_equal(expected_snapshot, function_deltas.last.snapshot, "Incorrect final snapshot")
+  end
+
+  def assert_incremental_text_delta_events(events, expected_deltas:)
+    text_deltas = events.select { |event| event.type == :"response.output_text.delta" }
+
+    assert_equal(expected_deltas, text_deltas.map(&:delta))
+    text_deltas.each do |event|
+      assert_instance_of(OpenAI::Models::Responses::ResponseTextDeltaEvent, event)
+      refute_respond_to(event, :snapshot)
+    end
+  end
+
+  def assert_incremental_function_delta_events(events, expected_deltas:)
+    function_deltas = events.select { |event| event.type == :"response.function_call_arguments.delta" }
+
+    assert_equal(expected_deltas, function_deltas.map(&:delta))
+    function_deltas.each do |event|
+      assert_instance_of(OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent, event)
+      refute_respond_to(event, :snapshot)
+    end
   end
 
   def basic_text_sse_response

--- a/test/openai/unknown_response_stream_event_test.rb
+++ b/test/openai/unknown_response_stream_event_test.rb
@@ -157,12 +157,11 @@ class OpenAI::Test::UnknownResponseStreamEventTest < Minitest::Test
       :get,
       "/responses/resp_unknown",
       events: [
-        lifecycle_event("response.created", 1),
         unknown_event(sequence_number: 6),
         unknown_event(sequence_number: 8),
         completed_event(9)
       ],
-      query: {"stream" => "true"}
+      query: {"starting_after" => "7", "stream" => "true"}
     )
 
     stream = @client.responses.stream(response_id: "resp_unknown", starting_after: 7)
@@ -183,8 +182,8 @@ class OpenAI::Test::UnknownResponseStreamEventTest < Minitest::Test
     stub_stream(
       :get,
       "/responses/resp_unknown",
-      events: [lifecycle_event("response.created", 1), unknown_event(sequence_number: nil), completed_event(9)],
-      query: {"stream" => "true"}
+      events: [unknown_event(sequence_number: nil), completed_event(9)],
+      query: {"starting_after" => "7", "stream" => "true"}
     )
 
     stream = @client.responses.stream(response_id: "resp_unknown", starting_after: 7)


### PR DESCRIPTION
## Summary

- Forward `starting_after` when `client.responses.stream(response_id:, starting_after:)` retrieves an existing response, so the server resumes from the requested event sequence.
- Handle genuine incremental resumed streams that begin with text or tool deltas, finalized structured text, unknown events, or `response.completed`, while preserving normal stream validation and typed final responses.
- Add public-entrypoint regression coverage for cursor forwarding, partial snapshots, completion-only resumes, structured text/tool outputs, unknown-event filtering, and unchanged non-resumed behavior.

## Verification

- `TMPDIR=/private/tmp bundle exec rake test`
- `BUNDLE_FROZEN=true BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec rake test:bedrock`
- `bundle exec rake lint:rubocop`
- `bundle exec rake typecheck:sorbet`
- `bundle exec rake validate:rbs`
- `python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'`
- Trusted-main Castiron custom-code budget check: 3,047 / 4,000 lines.
- Two consecutive clean adversarial-review rounds with two independent reviewers per round, including endpoint/deserialization security review.

@openai/sdks-team
