### PR TITLE
fix: support flattened responses typed function tools

### DIFF
--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -109,7 +109,7 @@ module OpenAI
                   parameters: tool.to_json_schema
                 }
               in {type: :function, parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}
-                func = tool.fetch(:function)
+                func = tool.fetch(:function, tool)
                 name = func[:name] ||= params.name.split("::").last
                 tool_models.store(name, params)
                 func.update(parameters: params.to_json_schema)

--- a/test/openai/helpers/response_parser_test.rb
+++ b/test/openai/helpers/response_parser_test.rb
@@ -83,12 +83,23 @@ class OpenAI::Test::ResponseParserTest < Minitest::Test
     assert_same(ToolModel, tool[:parameters])
   end
 
-  def test_flat_converter_without_function_preserves_key_error
-    error = assert_raises(KeyError) do
-      ResponsesProbe.allocate.prepare(tools: [{type: :function, parameters: ToolModel}])
-    end
+  def test_flat_converter_preserves_tool_fields_and_infers_missing_names
+    [nil, "explicit"].each do |name|
+      tool = {type: :function, strict: false, description: "A tool", parameters: ToolModel}
+      tool[:name] = name unless name.nil?
+      tools = [tool]
 
-    assert_equal(:function, error.key)
+      model, tool_models = ResponsesProbe.allocate.prepare(tools: tools)
+
+      assert_nil(model)
+      assert_equal({(name || "ToolModel") => ToolModel}, tool_models)
+      assert_same(tool, tools.first)
+      assert_equal(name || "ToolModel", tool[:name])
+      assert_equal(false, tool[:strict])
+      assert_equal("A tool", tool[:description])
+      assert_equal(ToolModel.to_json_schema, tool[:parameters])
+      refute(tool.key?(:function))
+    end
   end
 
   def test_parse_updates_known_outputs_in_place_and_leaves_other_types_alone

--- a/test/openai/helpers/responses_tool_model_test.rb
+++ b/test/openai/helpers/responses_tool_model_test.rb
@@ -3,14 +3,41 @@
 require_relative "../test_helper"
 
 class OpenAI::Test::ResponsesToolModelTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
   class LegacyToolModel < OpenAI::Internal::Type::BaseModel
     def self.to_json_schema = {type: "object"}
+  end
+
+  class ToolModel < OpenAI::BaseModel
+    required :city, String
   end
 
   class ResponsesProbe < OpenAI::Resources::Responses
     def convert_tools(tools)
       get_structured_output_models(tools: tools)
     end
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
   end
 
   def test_legacy_model_tool_is_converted_in_place
@@ -41,6 +68,97 @@ class OpenAI::Test::ResponsesToolModelTest < Minitest::Test
       assert_empty(tool_models)
       assert(parameters.equal?(function[:parameters]))
       assert_same(tool, tools.first)
+    end
+  end
+
+  def test_create_serializes_flat_function_tools_and_hydrates_arguments
+    function_call = {
+      type: "function_call",
+      call_id: "call_tool",
+      name: "lookup",
+      arguments: JSON.generate(city: "Paris")
+    }
+    stub_request(:post, "http://localhost/responses").to_return_json(
+      status: 200,
+      body: {id: "resp_tool", output: [function_call]}
+    )
+
+    tools = [
+      {type: :function, name: "lookup", strict: false, description: "Look up a city", parameters: ToolModel},
+      OpenAI::Responses::FunctionTool.new(
+        name: "lookup",
+        strict: false,
+        description: "Look up a city",
+        parameters: ToolModel
+      )
+    ]
+
+    tools.each do |tool|
+      response = @client.responses.create(model: "test", input: "hi", tools: [tool])
+
+      assert_instance_of(ToolModel, response.output.first.parsed)
+      assert_equal("Paris", response.output.first.parsed.city)
+    end
+
+    assert_requested(:post, "http://localhost/responses", times: tools.length) do |request|
+      assert_equal(
+        {
+          "type" => "function",
+          "name" => "lookup",
+          "strict" => false,
+          "description" => "Look up a city",
+          "parameters" => JSON.parse(JSON.generate(ToolModel.to_json_schema))
+        },
+        JSON.parse(request.body).fetch("tools").fetch(0)
+      )
+    end
+  end
+
+  def test_stream_serializes_flat_function_tools_and_hydrates_arguments
+    function_call = {
+      type: "function_call",
+      call_id: "call_tool",
+      name: "lookup",
+      arguments: JSON.generate(city: "Paris")
+    }
+    response = {id: "resp_tool_stream", status: "in_progress", output: []}
+    events = [
+      {type: "response.created", sequence_number: 0, response: response},
+      {
+        type: "response.completed",
+        sequence_number: 1,
+        response: response.merge(status: "completed", output: [function_call])
+      }
+    ]
+    stub_request(:post, "http://localhost/responses").to_return(
+      status: 200,
+      headers: {"Content-Type" => "text/event-stream"},
+      body: events.map { |event| "data: #{JSON.generate(event)}\n\n" }.join
+    )
+
+    stream = @client.responses.stream(
+      model: "test",
+      input: "hi",
+      tools: [{type: :function, name: "lookup", strict: true, description: "Look up a city", parameters: ToolModel}]
+    )
+    function_call = stream.get_final_response.output.first
+
+    assert_instance_of(ToolModel, function_call.parsed)
+    assert_equal("Paris", function_call.parsed.city)
+    assert_requested(:post, "http://localhost/responses") do |request|
+      body = JSON.parse(request.body)
+
+      assert_equal(true, body.fetch("stream"))
+      assert_equal(
+        {
+          "type" => "function",
+          "name" => "lookup",
+          "strict" => true,
+          "description" => "Look up a city",
+          "parameters" => JSON.parse(JSON.generate(ToolModel.to_json_schema))
+        },
+        body.fetch("tools").fetch(0)
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

- Fix flattened Responses function tools with typed structured-output `parameters` so they convert the top-level tool instead of fetching the Chat Completions-style nested `function` key.
- Preserve explicit and inferred top-level names, `strict`, unrelated tool fields, typed `FunctionTool` instances, and existing shorthand/nested compatibility.
- Replace the erroneous `KeyError` characterization and add public `responses.create` and `responses.stream` regressions that verify request JSON Schema serialization and typed function-call argument hydration.

## Verification

- `PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH TMPDIR=/private/tmp MT_CPU=1 ./scripts/test` — 1,497 runs, 13,573 assertions, 0 failures, 0 errors.
- `PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH bundle exec rake lint:rubocop` — RuboCop, rubyfmt, and suppression checks pass across 2,792 files.
- `PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH bundle exec rake typecheck:sorbet` — passes.
- `PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH bundle exec rake validate:rbs` — 1,250 RBS files validate.
- `BUNDLE_FROZEN=true BUNDLE_GEMFILE=gemfiles/bedrock.gemfile PATH=/Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin:$PATH bundle exec rake test:bedrock` — 38 runs, 377 assertions, 0 failures, 0 errors.
- Two consecutive clean adversarial-review rounds with two independent fresh-context reviewers each.

## Security

The change reuses the existing JSON Schema conversion and typed argument hydration paths. Security review found no new logging, credential exposure, endpoint, transport, dependency, or deserialization behavior.
