### PR TITLE
fix: avoid dispatching nil checks during coercion

### DIFF
--- a/lib/openai/internal/type/base_model.rb
+++ b/lib/openai/internal/type/base_model.rb
@@ -119,7 +119,7 @@ module OpenAI
                 Kernel.then do
                   value = @data.fetch(name_sym) { const == OpenAI::Internal::OMIT ? nil : const }
                   state = OpenAI::Internal::Type::Converter.new_coerce_state(translate_names: false)
-                  if (nilable || !required) && value.nil?
+                  if (nilable || !required) && nil.equal?(value)
                     nil
                   else
                     OpenAI::Internal::Type::Converter.coerce(
@@ -321,7 +321,7 @@ module OpenAI
               keys.delete(src_name)
 
               state[:error] = nil
-              converted = if item.nil? && (nilable || !required)
+              converted = if nil.equal?(item) && (nilable || !required)
                 exactness[nilable ? :yes : :maybe] += 1
                 nil
               else

--- a/lib/openai/internal/type/converter.rb
+++ b/lib/openai/internal/type/converter.rb
@@ -199,7 +199,7 @@ module OpenAI
 
               case target
               in -> { _1 <= NilClass }
-                exactness[value.nil? ? :yes : :maybe] += 1
+                exactness[nil.equal?(value) ? :yes : :maybe] += 1
                 return nil
               in -> { _1 <= Integer }
                 case value

--- a/test/openai/internal/type/base_model_nilability_test.rb
+++ b/test/openai/internal/type/base_model_nilability_test.rb
@@ -9,6 +9,11 @@ class OpenAI::Test::BaseModelNilabilityTest < Minitest::Test
     optional :optional_nullable, Integer, nil?: true
   end
 
+  class UnknownFields < OpenAI::Internal::Type::BaseModel
+    required :required_value, OpenAI::Internal::Type::Unknown
+    optional :optional_value, OpenAI::Internal::Type::Unknown, nil?: true
+  end
+
   def test_constructor_accepts_explicit_nil_only_for_nullable_fields
     model = Fields.new(nullable: nil, optional_nullable: nil)
 
@@ -73,5 +78,40 @@ class OpenAI::Test::BaseModelNilabilityTest < Minitest::Test
     assert_nil(model.optional)
     assert_nil(state.fetch(:error))
     assert_equal({yes: 3, no: 0, maybe: 1}, state.fetch(:exactness))
+  end
+
+  def test_response_coercion_does_not_dispatch_nil_query_for_unknown_values
+    calls = 0
+    value = Object.new
+    value.define_singleton_method(:nil?) do
+      calls += 1
+      raise "should not dispatch nil?"
+    end
+
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    model = OpenAI::Internal::Type::Converter.coerce(
+      UnknownFields,
+      {required_value: value, optional_value: value},
+      state: state
+    )
+
+    assert_same(value, model.required_value)
+    assert_same(value, model.optional_value)
+    assert_equal(0, calls)
+    assert_nil(state.fetch(:error))
+  end
+
+  def test_nil_class_coercion_does_not_dispatch_nil_query
+    calls = 0
+    value = Object.new
+    value.define_singleton_method(:nil?) do
+      calls += 1
+      raise "should not dispatch nil?"
+    end
+
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    assert_nil(OpenAI::Internal::Type::Converter.coerce(NilClass, value, state: state))
+    assert_equal(0, calls)
+    assert_equal({yes: 0, no: 0, maybe: 1}, state.fetch(:exactness))
   end
 end


### PR DESCRIPTION
## Summary

- avoid dispatching caller-controlled `nil?` while checking nullable model fields
- use identity-based nil checks for direct `NilClass` coercion exactness
- add focused regressions for hostile `nil?` overrides while preserving existing value identity and exactness behavior

## Why

This is the narrow prerequisite for a later Responses history normalizer. The converter must be safe when replay payloads contain arbitrary values before any helper is added.

## Scope

- central coercion safety invariant only
- no Responses helper, schema/model changes, public API changes, or error-redaction redesign

## Verification

- `TMPDIR=/private/tmp BUNDLE_PATH=/Users/jbeckwith/.cache/openai-ruby-pr504-bundle mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/type/base_model_nilability_test.rb`
- `TMPDIR=/private/tmp BUNDLE_PATH=/Users/jbeckwith/.cache/openai-ruby-pr504-bundle mise exec ruby@4.0.6 -- bundle exec rake test` (1517 runs, 13686 assertions, 0 failures, 0 errors)
- `BUNDLE_PATH=/Users/jbeckwith/.cache/openai-ruby-pr504-bundle mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop`
- `BUNDLE_PATH=/Users/jbeckwith/.cache/openai-ruby-pr504-bundle mise exec ruby@4.0.6 -- bundle exec rake typecheck:sorbet`
- `BUNDLE_PATH=/Users/jbeckwith/.cache/openai-ruby-pr504-bundle mise exec ruby@4.0.6 -- bundle exec rake validate:rbs`
- `git diff --check`

## Review

- two consecutive mandatory adversarial-review rounds, each with two independent fresh-context reviewers: clean
- bounded security review: clean; the diff removes caller-controlled dispatch and adds no logging or error interpolation
