### PR TITLE
fix: delimit JSONL request records

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -630,7 +630,7 @@ module OpenAI
           in [OpenAI::Internal::Util::JSON_CONTENT, Hash | Array | -> { primitive?(_1) }]
             [headers, JSON.generate(body)]
           in [OpenAI::Internal::Util::JSONL_CONTENT, Enumerable] unless OpenAI::Internal::Type::FileInput === body
-            [headers, body.lazy.map { JSON.generate(_1) }]
+            [headers, body.lazy.map { "#{JSON.generate(_1)}\n" }]
           in [%r{^multipart/form-data}, Hash | OpenAI::Internal::Type::FileInput]
             boundary, strio = encode_multipart_streaming(body)
             headers = {**headers, "content-type" => "#{content_type}; boundary=#{boundary}"}

--- a/test/openai/internal/content_type_test.rb
+++ b/test/openai/internal/content_type_test.rb
@@ -63,7 +63,16 @@ class OpenAI::Test::ContentTypeDispatchTest < Minitest::Test
       [{id: 1}, {id: 2}]
     )
 
-    assert_equal(["{\"id\":1}", "{\"id\":2}"], encoded.to_a)
+    assert_equal(["{\"id\":1}\n", "{\"id\":2}\n"], encoded.to_a)
+  end
+
+  def test_jsonl_multi_record_byte_stream_is_newline_delimited
+    _headers, encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "application/jsonl"},
+      [{id: 1}, {id: 2}]
+    )
+
+    assert_equal("{\"id\":1}\n{\"id\":2}\n".b, encoded.to_a.join.b)
   end
 
   def test_mixed_case_jsonl_is_decoded_as_individual_records


### PR DESCRIPTION
## Summary
- append one LF delimiter after each lazily encoded JSONL/NDJSON record
- add a byte-stream regression for multi-record JSONL framing
- preserve ordinary JSON, multipart, file-input, and one-shot streaming behavior

## Security finding
Fixes the Codex Cloud Security finding: JSONL encoder omits required record delimiters.

## Test plan
- /opt/homebrew/bin/mise exec ruby@4.0.6 -- env BUNDLE_PATH=/tmp/openai-ruby-jsonl-bundle bundle exec ruby -Itest test/openai/internal/content_type_test.rb
- /opt/homebrew/bin/mise exec ruby@4.0.6 -- env BUNDLE_PATH=/tmp/openai-ruby-jsonl-bundle bundle exec ruby -Itest test/openai/http_client_test.rb
- /opt/homebrew/bin/mise exec ruby@4.0.6 -- env BUNDLE_PATH=/tmp/openai-ruby-jsonl-bundle bundle exec rake lint:rubocop
- git diff --check c8d6d32e178563e38585d3ad928136e3c6f10ac1...HEAD

## Review
- completed required adversarial review: two consecutive clean rounds with two independent read-only reviewers per round
- completed focused security review of the shared JSONL encoder boundary and transport path