### PR TITLE
fix: accept custom request hash in RBS

### DIFF
--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -154,22 +154,7 @@ module OpenAI
         } -> OpenAI::HTTPClient::Response
 
         def request: (
-          Symbol method,
-          String | ::Array[String] path,
-          ?query: ::Hash[String, (::Array[String] | String)?]?,
-          ?headers: ::Hash[String, (String
-          | Integer
-          | ::Array[(String | Integer)?])?]?,
-          ?body: top?,
-          ?unwrap: (Symbol
-          | Integer
-          | ::Array[(Symbol | Integer)]
-          | (^(top arg0) -> top))?,
-          ?page: Class?,
-          ?stream: Class?,
-          ?model: OpenAI::Internal::Type::Converter::input?,
-          ?security: { :bearer_auth? => bool, :admin_api_key_auth? => bool }?,
-          ?options: OpenAI::request_opts?
+          OpenAI::Internal::Transport::BaseClient::request_components req
         ) -> top
 
         private def perform_request: (

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -20,10 +20,7 @@ module OpenAI
             page: Class?,
             stream: Class?,
             model: OpenAI::Internal::Type::Converter::input?,
-            security: ({  }
-            | { bearer_auth: bool }
-            | { admin_api_key_auth: bool }
-            | { bearer_auth: bool, admin_api_key_auth: bool })?,
+            security: ::Hash[(:bearer_auth | :admin_api_key_auth), bool]?,
             options: OpenAI::request_opts?
           }
         type request_input =

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -8,8 +8,8 @@ module OpenAI
           {
             method: Symbol,
             path: String | ::Array[String],
-            query: ::Hash[String, (::Array[String] | String)?]?,
-            headers: ::Hash[String, (String
+            query: ::Hash[(String | Symbol), (::Array[String] | String)?]?,
+            headers: ::Hash[(String | Symbol), (String
             | Integer
             | ::Array[(String | Integer)?])?]?,
             body: top?,
@@ -20,7 +20,10 @@ module OpenAI
             page: Class?,
             stream: Class?,
             model: OpenAI::Internal::Type::Converter::input?,
-            security: { :bearer_auth? => bool, :admin_api_key_auth? => bool }?,
+            security: ({  }
+            | { bearer_auth: bool }
+            | { admin_api_key_auth: bool }
+            | { bearer_auth: bool, admin_api_key_auth: bool })?,
             options: OpenAI::request_opts?
           }
         type request_input =

--- a/test/openai/request_rbs_test.rb
+++ b/test/openai/request_rbs_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+require_relative "test_helper"
+
+class OpenAI::Test::RequestRBSTest < Minitest::Test
+  def test_shipped_rbs_types_documented_custom_request_call
+    root = File.expand_path("../..", __dir__)
+    source = <<~RUBY
+      client = OpenAI::Client.new(api_key: "test-key")
+      client.request(
+        method: :post,
+        path: "/undocumented/endpoint",
+        query: {"dog" => "woof"},
+        headers: {"useful-header" => "interesting-value"},
+        body: {"hello" => "world"}
+      )
+    RUBY
+
+    Dir.mktmpdir("custom-request-rbs") do |directory|
+      FileUtils.cp_r(File.join(root, "sig"), directory)
+      File.write(File.join(directory, "probe.rb"), source)
+      File.write(
+        File.join(directory, "Steepfile"),
+        <<~RUBY
+          target :lib do
+            signature "sig"
+            library "net-http"
+            check "probe.rb"
+          end
+        RUBY
+      )
+      stdout, stderr, status = Open3.capture3(
+        "steep",
+        "check",
+        "--no-daemon",
+        "--jobs=1",
+        "--validate=skip",
+        chdir: directory
+      )
+
+      assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    end
+  end
+end

--- a/test/openai/request_rbs_test.rb
+++ b/test/openai/request_rbs_test.rb
@@ -14,9 +14,22 @@ class OpenAI::Test::RequestRBSTest < Minitest::Test
       client.request(
         method: :post,
         path: "/undocumented/endpoint",
+        query: {dog: "woof"},
+        headers: {useful_header: "interesting-value"},
+        body: {"hello" => "world"},
+        security: {bearer_auth: true}
+      )
+      client.request(
+        method: :post,
+        path: "/undocumented/endpoint",
         query: {"dog" => "woof"},
         headers: {"useful-header" => "interesting-value"},
         body: {"hello" => "world"}
+      )
+      client.request(
+        method: :post,
+        path: "/undocumented/endpoint",
+        security: {admin_api_key_auth: true}
       )
     RUBY
 

--- a/test/openai/request_rbs_test.rb
+++ b/test/openai/request_rbs_test.rb
@@ -8,7 +8,6 @@ require_relative "test_helper"
 
 class OpenAI::Test::RequestRBSTest < Minitest::Test
   def test_shipped_rbs_types_documented_custom_request_call
-    root = File.expand_path("../..", __dir__)
     source = <<~RUBY
       client = OpenAI::Client.new(api_key: "test-key")
       client.request(
@@ -33,6 +32,32 @@ class OpenAI::Test::RequestRBSTest < Minitest::Test
       )
     RUBY
 
+    stdout, stderr, status = steep_check(source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbs_rejects_invalid_custom_request_security
+    source = <<~RUBY
+      client = OpenAI::Client.new(api_key: "test-key")
+      client.request(
+        method: :post,
+        path: "/undocumented/endpoint",
+        security: {bearer_auth: true, admin_api_key_auth: "false"}
+      )
+    RUBY
+
+    stdout, stderr, status = steep_check(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes(stdout, "Ruby::ArgumentTypeMismatch")
+  end
+
+  private
+
+  def steep_check(source)
+    root = File.expand_path("../..", __dir__)
+
     Dir.mktmpdir("custom-request-rbs") do |directory|
       FileUtils.cp_r(File.join(root, "sig"), directory)
       File.write(File.join(directory, "probe.rb"), source)
@@ -46,7 +71,7 @@ class OpenAI::Test::RequestRBSTest < Minitest::Test
           end
         RUBY
       )
-      stdout, stderr, status = Open3.capture3(
+      Open3.capture3(
         "steep",
         "check",
         "--no-daemon",
@@ -54,8 +79,6 @@ class OpenAI::Test::RequestRBSTest < Minitest::Test
         "--validate=skip",
         chdir: directory
       )
-
-      assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
     end
   end
 end


### PR DESCRIPTION
## Summary
- model BaseClient#request as its runtime request-components hash in shipped RBS
- add focused Steep coverage for the README-documented custom request call

## Scope
- no Ruby runtime request changes
- no README API shape changes
- no unrelated signatures

## Verification
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/request_rbs_test.rb
- mise exec ruby@4.0.6 -- bundle exec rake validate:rbs
- mise exec ruby@4.0.6 -- bundle exec rake lint:rbs_format
- mise exec ruby@4.0.6 -- bundle exec rubocop test/openai/request_rbs_test.rb
- git diff --check

## Adversarial review
- completed two consecutive clean rounds with two independent fresh-context reviewers per round
- no in-scope findings or follow-up observations