### PR TITLE
fix: load YAML for BaseModel serialization

### DIFF
--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -14,6 +14,7 @@ require "securerandom"
 require "stringio"
 require "time"
 require "uri"
+require "yaml"
 
 # We already ship the preferred sorbet manifests in the package itself.
 # `tapioca` currently does not offer us a way to opt out of unnecessary compilation.

--- a/test/openai/load_order_test.rb
+++ b/test/openai/load_order_test.rb
@@ -6,6 +6,26 @@ require "rbconfig"
 require_relative "test_helper"
 
 class OpenAI::Test::LoadOrderTest < Minitest::Test
+  def test_to_yaml_works_after_normal_require
+    script = <<~RUBY
+      require "openai"
+
+      yaml = OpenAI::StructuredOutput::BaseModel.new.to_yaml
+      raise "unexpected YAML output" unless yaml == "--- {}\n"
+    RUBY
+
+    _, stderr, status = Open3.capture3(
+      {"RUBYOPT" => nil},
+      RbConfig.ruby,
+      "-I",
+      File.expand_path("../../lib", __dir__),
+      "-e",
+      script
+    )
+
+    assert_predicate(status, :success?, stderr)
+  end
+
   def test_skips_auto_require_during_tapioca_gem
     script = <<~RUBY
       module Tapioca


### PR DESCRIPTION
## Summary

- Load Ruby YAML support during the normal SDK entrypoint require path.
- Add an isolated regression test proving the public BaseModel to_yaml API works after require "openai".

## Verification

- BUNDLE_PATH=/tmp/openai-ruby-bundle-406 mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/load_order_test.rb
- BUNDLE_PATH=/tmp/openai-ruby-bundle-406 mise exec ruby@4.0.6 -- bundle exec rubocop --force-exclusion lib/openai.rb test/openai/load_order_test.rb
- BUNDLE_PATH=/tmp/openai-ruby-bundle-406 mise exec ruby@4.0.6 -- ./scripts/rubyfmt --check lib/openai.rb test/openai/load_order_test.rb
- BUNDLE_PATH=/tmp/openai-ruby-bundle-406 mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop

The full non-Bedrock suite ran 1,518 tests and surfaced two unrelated existing/environment-sensitive failures: polling deadline float precision and /var versus /private/var temp-path normalization.

## Security review

This only loads the standard YAML library; it does not add YAML parsing or deserialization of untrusted input.