### PR TITLE
fix: handle custom chat completion tool calls

### DIFF
--- a/lib/openai/helpers/structured_output/chat_completion_parser.rb
+++ b/lib/openai/helpers/structured_output/chat_completion_parser.rb
@@ -28,6 +28,8 @@ module OpenAI
 
             raw[:choices]&.each do |choice|
               choice.dig(:message, :tool_calls)&.each do |tool_call|
+                next if tool_call[:type] == "custom"
+
                 func = tool_call.fetch(:function)
                 next if (model = tool_models[func.fetch(:name)]).nil?
 

--- a/test/openai/helpers/chat_completion_parser_test.rb
+++ b/test/openai/helpers/chat_completion_parser_test.rb
@@ -246,6 +246,47 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
     refute(third_message.key?(:parsed))
   end
 
+  def test_unwrap_preserves_custom_tool_calls
+    transport = RecordingTransport.new(
+      id: "chatcmpl_test",
+      object: "chat.completion",
+      created: 0,
+      model: "test",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "tool_calls",
+          message: {
+            role: "assistant",
+            content: nil,
+            tool_calls: [
+              {
+                id: "call_custom",
+                type: "custom",
+                custom: {name: "code_exec", input: "puts 'hello'"}
+              }
+            ]
+          }
+        }
+      ]
+    )
+    client = OpenAI::Client.new(
+      api_key: "fake-key",
+      base_url: "http://example.test",
+      http_client: transport
+    )
+
+    completion = client.chat.completions.create(
+      model: "test",
+      messages: [{role: "user", content: "hi"}]
+    )
+
+    tool_call = completion.choices.first.message.tool_calls.first
+    assert_instance_of(OpenAI::Chat::ChatCompletionMessageCustomToolCall, tool_call)
+    assert_equal("code_exec", tool_call.custom.name)
+    assert_equal("puts 'hello'", tool_call.custom.input)
+  end
+
   def test_unwrap_preserves_nil_malformed_json_and_missing_key_behavior
     [nil, "not json"].each do |value|
       function = {name: "known", arguments: value}


### PR DESCRIPTION
## Summary
- skip valid custom tool calls in the non-streaming Chat Completions structured-output unwrap helper
- preserve existing function-call parsing and malformed-function error behavior
- add a public-path regression covering custom tool-call hydration and payload preservation

## Validation
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_parser_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/chat/completions_test.rb
- mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop
- ruby -c for both changed files
- git diff --check
- two consecutive clean adversarial-review rounds
- security boundary and bypass reviews found no issues

## Full suite
- mise exec ruby@4.0.6 -- bundle exec rake test was attempted: 1518 runs, 13687 assertions, 2 unrelated failures in FastFormatTest temp-path normalization and GemPackagingTest installed-gem x509 smoke coverage.