### PR TITLE
fix: make error cause contract read-only

### DIFF
--- a/lib/openai/errors.rb
+++ b/lib/openai/errors.rb
@@ -3,7 +3,7 @@
 module OpenAI
   module Errors
     class Error < StandardError
-      # @!attribute cause
+      # @!attribute [r] cause
       #
       #   @return [StandardError, nil]
     end

--- a/rbi/openai/errors.rbi
+++ b/rbi/openai/errors.rbi
@@ -4,7 +4,7 @@ module OpenAI
   module Errors
     class Error < StandardError
       sig { returns(T.nilable(StandardError)) }
-      attr_accessor :cause
+      attr_reader :cause
     end
 
     class PollingError < OpenAI::Errors::Error

--- a/sig/openai/errors.rbs
+++ b/sig/openai/errors.rbs
@@ -1,7 +1,7 @@
 module OpenAI
   module Errors
     class Error < StandardError
-      attr_accessor cause: StandardError?
+      attr_reader cause: StandardError?
     end
 
     class PollingError < OpenAI::Errors::Error

--- a/test/openai/errors_test.rb
+++ b/test/openai/errors_test.rb
@@ -2,10 +2,61 @@
 
 require "logger"
 require "minitest/mock"
+require "open3"
+require "tempfile"
 
 require_relative "test_helper"
 
 class OpenAI::Test::ErrorsTest < Minitest::Test
+  def test_error_cause_is_read_only
+    error = OpenAI::Errors::Error.new("boom")
+
+    assert_respond_to(error, :cause)
+    refute_respond_to(error, :cause=)
+  end
+
+  def test_shipped_rbi_does_not_type_cause_writer
+    root = File.expand_path("../..", __dir__)
+    source = <<~RUBY
+      # typed: strict
+
+      OpenAI::Errors::Error.new("boom").cause = RuntimeError.new("cause")
+    RUBY
+
+    Tempfile.create(["openai-error-cause-writer", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      stdout, stderr, status = Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+
+      refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+      assert_match(/cause=/, "#{stdout}\n#{stderr}")
+    end
+  end
+
+  def test_shipped_rbs_does_not_type_cause_writer
+    root = File.expand_path("../..", __dir__)
+    stdout, stderr, status = Open3.capture3(
+      "rbs",
+      "-I",
+      "sig",
+      "-r",
+      "net-http",
+      "method",
+      "OpenAI::Errors::Error",
+      "cause=",
+      chdir: root
+    )
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_match(/Cannot find method: cause=/, "#{stdout}\n#{stderr}")
+  end
+
   def test_nested_api_errors_include_safe_diagnostics_without_disclosing_the_response
     url = URI("https://example.com/v1/responses")
     headers = {"x-request-id" => "req_nested", "set-cookie" => "fake-session-cookie"}


### PR DESCRIPTION
## Summary\n\n- make OpenAI::Errors::Error#cause read-only in YARD, RBI, and RBS\n- add runtime, Sorbet, and RBS regression coverage so cause= cannot be re-advertised\n- preserve existing exception chaining and specialized subclass behavior\n\n## Verification\n\n- rake lint:rubocop\n- rake typecheck:sorbet\n- rake validate:rbs\n- rake test: 1,520 runs, 13,696 assertions, 0 failures, 1 skip\n\nAll checks ran with Ruby 4.0.6 and the locked bundle.\n\n## Review\n\n- completed three adversarial-review rounds with two fresh, independent read-only reviewers per round\n- fixed the round-one finding by adding negative Sorbet and RBS contract probes\n- rounds two and three were clean with no unresolved in-scope findings\n\n## Scope\n\nNon-goals: no redesign of Ruby exception chaining, no new public exception semantics, and no changes to specialized subclasses with their own cause behavior.\n