### PR TITLE
fix: respect StringIO cursor in multipart uploads

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -510,7 +510,7 @@ module OpenAI
             IO.copy_stream(val, y)
           in StringIO
             y << format(content_line, content_type || "application/octet-stream")
-            y << val.string
+            y << (val.string.byteslice(val.pos..) || "")
           in -> { primitive?(_1) }
             y << format(content_line, content_type || "text/plain")
             y << val.to_s

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -314,6 +314,22 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     end
   end
 
+  def test_multipart_string_io_uses_current_position
+    sensitive_prefix = "fake-sensitive-prefix"
+    file = StringIO.new("#{sensitive_prefix}safe-payload")
+    file.pos = sensitive_prefix.bytesize
+
+    encoded = OpenAI::Internal::Util.encode_content(
+      {"content-type" => "multipart/form-data"},
+      {file: OpenAI::FilePart.new(file, filename: "upload")}
+    )
+    uploaded = FakeCGI.new(*encoded)["file"].read
+
+    assert_equal("safe-payload", uploaded)
+    refute_includes(uploaded, sensitive_prefix)
+    assert_equal(sensitive_prefix.bytesize, file.pos)
+  end
+
   def test_multipart_filename_quoting
     file = OpenAI::FilePart.new(StringIO.new("x"), filename: "a \"b\"\r\nEvil: 1.md")
     _headers, stream = OpenAI::Internal::Util.encode_content(


### PR DESCRIPTION
## Summary
- encode multipart StringIO values from their current byte cursor
- preserve the cursor so replayable multipart retries keep the same payload
- add regression coverage proving a consumed fake-sensitive prefix is not uploaded

## Tests
- TEST=test/openai/internal/util_test.rb bundle exec rake test
- TEST=test/openai/http_client_test.rb bundle exec rake test
- bundle exec rake lint:rubocop
- git diff --check
- ruby -c lib/openai/internal/util.rb
- ruby -c test/openai/internal/util_test.rb

## Security review
- verified direct, FilePart-wrapped, EOF, and retry/replay behavior
- completed two consecutive clean adversarial-review rounds with two fresh independent reviewers per round