### PR TITLE
fix: avoid duplicate late-choice stream logprobs

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -156,6 +156,7 @@ module OpenAI
             insert_choice_snapshot!(completion_snapshot.choices, choice_snapshot)
           else
             update_existing_choice_snapshot(choice, choice_snapshot)
+            accumulate_logprobs!(choice.logprobs, choice_snapshot)
           end
 
           tool_calls_by_index = index_choice_snapshot!(choice_snapshot)
@@ -166,8 +167,6 @@ module OpenAI
           end
 
           parse_tool_calls!(choice.delta.tool_calls, tool_calls_by_index)
-
-          accumulate_logprobs!(choice.logprobs, choice_snapshot)
         end
 
         def create_new_choice_snapshot(choice)

--- a/test/openai/helpers/chat_completion_stream_test.rb
+++ b/test/openai/helpers/chat_completion_stream_test.rb
@@ -169,7 +169,80 @@ class OpenAI::Test::ChatCompletionStreamTest < Minitest::Test
     assert_equal([0, 1, 2], state.current_completion_snapshot.choices.map(&:index))
   end
 
+  def test_late_choice_content_logprobs_are_accumulated_once_per_chunk
+    state = OpenAI::Helpers::Streaming::ChatCompletionStreamState.new
+    state.handle_chunk(build_chunk(choice_index: 0, delta: {role: :assistant, content: "zero"}))
+
+    first_events = state.handle_chunk(
+      build_chunk_with_choices(
+        [
+          {
+            index: 1,
+            delta: {role: :assistant, content: "one"},
+            finish_reason: nil,
+            logprobs: {content: [logprob("one")]}
+          }
+        ]
+      )
+    )
+
+    first_delta = first_events.find { |event| event.type == :"logprobs.content.delta" }
+    assert_equal(["one"], first_delta.snapshot.map(&:token))
+    assert_equal(["one"], state.get_final_completion.choices.last.logprobs.content.map(&:token))
+
+    second_events = state.handle_chunk(
+      build_chunk_with_choices(
+        [
+          {
+            index: 1,
+            delta: {content: "one"},
+            finish_reason: nil,
+            logprobs: {content: [logprob("one")]}
+          }
+        ]
+      )
+    )
+
+    second_delta = second_events.find { |event| event.type == :"logprobs.content.delta" }
+    choice = state.get_final_completion.choices.last
+    assert_equal(["one", "one"], second_delta.snapshot.map(&:token))
+    assert_equal(["one", "one"], choice.logprobs.content.map(&:token))
+    assert_equal("oneone", choice.message.content)
+  end
+
+  def test_late_choice_refusal_logprobs_are_accumulated_once
+    state = OpenAI::Helpers::Streaming::ChatCompletionStreamState.new
+    state.handle_chunk(build_chunk(choice_index: 0, delta: {role: :assistant, content: "zero"}))
+
+    events = state.handle_chunk(
+      build_chunk_with_choices(
+        [
+          {
+            index: 1,
+            delta: {role: :assistant, refusal: "no"},
+            finish_reason: nil,
+            logprobs: {refusal: [logprob("no")]}
+          }
+        ]
+      )
+    )
+
+    delta = events.find { |event| event.type == :"logprobs.refusal.delta" }
+    choice = state.get_final_completion.choices.last
+    assert_equal(["no"], delta.snapshot.map(&:token))
+    assert_equal(["no"], choice.logprobs.refusal.map(&:token))
+  end
+
   private
+
+  def logprob(token)
+    {
+      token: token,
+      logprob: -0.1,
+      bytes: token.bytes,
+      top_logprobs: []
+    }
+  end
 
   def count_choice_snapshot_index_reads
     reads = 0


### PR DESCRIPTION
## Problem

The high-level Chat Completions streaming helper can return duplicated token log probabilities for a choice that first appears after the stream's initial chunk. The generated message text is correct, but the accumulated `choice.logprobs` can describe the first tokens twice.

The triggering sequence is specific:

1. The helper has already created its overall completion snapshot from an earlier chunk.
2. A later chunk introduces a previously unseen choice index.
3. That choice's first chunk contains non-empty content or refusal log probabilities.

This can occur when consuming multiple streamed choices, for example with `n: 2`. It is not a claim that every multi-choice response is affected: a new choice whose first chunk has no logprob entries does not duplicate entries at that point. The same accumulation path also applies if an initial chunk has no choices and a subsequent chunk introduces the first choice.

## What a user sees

Applications use the public streaming helper to collect text and its token-level scores:

```ruby
require "openai"

client = OpenAI::Client.new # Reads OPENAI_API_KEY from the environment.
stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: "user", content: "Reply with one short word."}],
  n: 2,
  logprobs: true
)

completion = stream.get_final_completion
choice = completion.choices.find { |candidate| candidate.index == 1 }

puts choice.message.content
p choice.logprobs.content.map(&:token)
```

The request above illustrates the consumer API; actual output and chunk ordering are nondeterministic. For the deterministic synthetic sequence used by the regression test—choice 0 arrives first, then choice 1 arrives with text `"one"` and one matching logprob entry—the observable difference is:

| Observation for choice 1 | Before | After |
| --- | --- | --- |
| Message text after its first chunk | `"one"` | `"one"` |
| Accumulated content-logprob tokens | `["one", "one"]` | `["one"]` |
| After a subsequent chunk legitimately repeats `"one"` | `["one", "one", "one"]` | `["one", "one"]` |
| Refusal-logprob tokens when the first refusal token is `"no"` | `["no", "no"]` | `["no"]` |

The incorrect accumulated values are visible in `get_final_completion` and the `snapshot` field of the corresponding `logprobs.content.delta` / `logprobs.refusal.delta` events. This is an aggregation error, not an extra token sent by the API.

## Potential impact

- Applications computing sequence scores from summed log probabilities can double-count the initial token scores of a late-arriving choice and compare choices using incorrect values.
- Token-level displays and analyses can have more logprob entries than the actual returned token sequence, disrupting alignment between text and its scores.
- Refusal-token analysis is affected through the same shared accumulation path.

The issue does not duplicate generated message text, issue additional API requests, or change server-reported token usage. It affects client-side accumulation in `chat.completions.stream`; the non-streaming request path and raw streamed chunks are not changed by this patch. These impacts follow from the reproduced aggregation error; the tests use synthetic data, not customer payloads or a measured production incident.

## Root cause and fix

`ChatCompletionStreamState#accumulate_choice!` initializes a late-arriving choice using `create_new_choice_snapshot`, which already copies that chunk's logprobs. Previously, the method then unconditionally called `accumulate_logprobs!`, appending the same entries a second time.

The fix moves the append into the existing-choice branch. Newly created choices keep the values they were initialized with; subsequent chunks append normally. No token deduplication is introduced—identical tokens from separate chunks must remain separate entries.

The scope is deliberately limited to the handwritten streaming helper and its dedicated regression tests: two files, with no generated-code edits, new dependencies, public API changes, parser redesign, or unrelated cleanup.

## Regression coverage and verification

- New content-logprob coverage checks both the event snapshot and final completion for a late-arriving choice, then sends the same token again in a later chunk to verify legitimate repetition is preserved.
- New refusal-logprob coverage checks the same initial-duplication failure for refusal tokens.
- Red/green verification restored the old accumulation placement: both new tests failed with duplicated entries, then passed after restoring the fix.
- Two consecutive adversarial-review rounds completed without in-scope blockers, using two new independent, read-only reviewers per round.

Passing local checks:

```text
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_stream_test.rb
mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/resources/chat/completions/streaming_snapshot_test.rb
mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/structured_outputs_chat_completions_example_test.rb
mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/structured_outputs_chat_completions_function_calling_example_test.rb
mise exec ruby@4.0.6 -- bundle exec rake lint
```

Hosted CI passed for Ruby 3.3, 3.4, and 4.0, Bedrock, lint, type checking, RBS validation, packaging, CodeQL, and Castiron checks on `b7b82f500caaaaf019a7a3f0396f8ac7dbec594c`.

The full local `rake test` run also executed 1,529 tests and 13,693 assertions, with two unrelated failures outside this diff: the macOS `/var` versus `/private/var` `FastFormatTest` assertion and gem packaging missing beta RBI files. Those limitations are retained here rather than folded into this narrowly scoped fix; hosted CI is green.
