### PR TITLE
fix: preserve late chat completion service tier

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -144,6 +144,7 @@ module OpenAI
 
           completion_snapshot.usage = chunk.usage if chunk.usage
           completion_snapshot.system_fingerprint = chunk.system_fingerprint if chunk.system_fingerprint
+          completion_snapshot.service_tier = chunk.service_tier if chunk.service_tier
 
           completion_snapshot
         end

--- a/test/openai/resources/chat/completions/streaming_snapshot_test.rb
+++ b/test/openai/resources/chat/completions/streaming_snapshot_test.rb
@@ -156,6 +156,64 @@ class OpenAI::Test::Resources::Chat::Completions::StreamingSnapshotTest < Minite
     state
   end
 
+  def test_late_service_tier_is_preserved_through_usage_tail
+    stream = make_service_tier_stream(
+      [
+        streaming_chunk(service_tier: nil, content: "Hello"),
+        streaming_chunk(service_tier: "priority", finish_reason: "stop"),
+        streaming_chunk(
+          service_tier: nil,
+          choices: [],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2
+          }
+        )
+      ]
+    )
+
+    snapshots = []
+    raw_tiers = []
+    stream.each do |event|
+      next unless event.type == :chunk
+
+      raw_tiers << event.chunk.service_tier
+      snapshots << event.snapshot.service_tier
+    end
+
+    completion = stream.get_final_completion
+
+    assert_equal([nil, :priority, nil], raw_tiers)
+    assert_equal([nil, :priority, :priority], snapshots)
+    assert_equal(:priority, completion.service_tier)
+    assert_equal("Hello", completion.choices.first.message.content)
+    assert_equal(2, completion.usage.total_tokens)
+  end
+
+  def test_latest_non_nil_service_tier_wins_without_erasing_initial_tier
+    stream = make_service_tier_stream(
+      [
+        streaming_chunk(service_tier: "priority", content: "Hello"),
+        streaming_chunk(service_tier: nil),
+        streaming_chunk(content: " there"),
+        streaming_chunk(service_tier: "flex", finish_reason: "stop"),
+        streaming_chunk(service_tier: nil, choices: [])
+      ]
+    )
+
+    snapshots = []
+    stream.each do |event|
+      snapshots << event.snapshot.service_tier if event.type == :chunk
+    end
+
+    completion = stream.get_final_completion
+
+    assert_equal([:priority, :priority, :priority, :flex, :flex], snapshots)
+    assert_equal(:flex, completion.service_tier)
+    assert_equal("Hello there", completion.choices.first.message.content)
+  end
+
   def test_parse_nothing
     listener = make_stream_snapshot_request(
       {
@@ -189,6 +247,37 @@ class OpenAI::Test::Resources::Chat::Completions::StreamingSnapshotTest < Minite
           parsed: nil
         )
     end
+  end
+
+  def make_service_tier_stream(chunks)
+    body = chunks.map { |chunk| "data: #{JSON.generate(chunk)}\n\n" }.join
+    body << "data: [DONE]\n\n"
+
+    stub_streaming_response({body: hash_including(model: "gpt-4o-mini", stream: true)}, body)
+    @client.chat.completions.stream(
+      model: "gpt-4o-mini",
+      messages: [{role: "user", content: "Say hello"}]
+    )
+  end
+
+  def streaming_chunk(service_tier: :omitted, content: nil, finish_reason: nil, choices: nil, usage: nil)
+    chunk = {
+      id: "chatcmpl-service-tier",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      choices: choices ||
+        [
+          {
+            index: 0,
+            delta: content.nil? ? {} : {content: content},
+            finish_reason: finish_reason
+          }
+        ]
+    }
+    chunk[:service_tier] = service_tier unless service_tier == :omitted
+    chunk[:usage] = usage if usage
+    chunk
   end
 
   def test_parse_basemodel


### PR DESCRIPTION
## Summary

Preserve the latest non-nil `service_tier` reported by streamed Chat
Completions chunks in both `current_completion_snapshot` and
`get_final_completion`.

The server-reported tier is response metadata and can differ from a caller's
requested tier. This correction only preserves the tier the server actually
returned; it does not select a tier, alter request routing, or change billing.

## Trigger and affected callers

The issue occurs when `client.chat.completions.stream` receives an initial
valid chunk whose `service_tier` is nil or omitted, followed by a later valid
chunk that supplies a non-nil tier such as `priority`. This shape can also
include a final empty-`choices` usage chunk.

Affected callers are users who inspect either:

- `event.snapshot.service_tier` on `:chunk` events, or
- `stream.get_final_completion.service_tier` after consumption.

Before this change, the raw later chunk exposed the server tier while the
accumulated snapshot and final completion stayed nil (or kept an older tier).

## Public Ruby SDK example

```ruby
require "openai"

client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))

stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: "user", content: "Say hello"}]
)

stream.each do |event|
  next unless event.type == :chunk

  # This reflects the latest non-nil tier reported by the server so far.
  puts event.snapshot.service_tier.inspect
end

completion = stream.get_final_completion
puts completion.service_tier.inspect
```

The value shown here is server-reported response metadata. It may differ from
the tier requested by the caller.

## Deterministic reproduction

The regression tests use synthetic, network-disabled WebMock SSE fixtures
through the real public `client.chat.completions.stream` entrypoint:

1. initial chunk: `service_tier: null`, text `Hello`
2. second chunk: `service_tier: "priority"`, finish reason `stop`
3. tail chunk: `service_tier: null`, empty `choices`, usage
   `total_tokens: 2`

Before:

```text
raw tiers:      [nil, :priority, nil]
snapshot tiers: [nil, nil, nil]
final tier:     nil
```

After:

```text
raw tiers:      [nil, :priority, nil]
snapshot tiers: [nil, :priority, :priority]
final tier:     :priority
```

A second synthetic stream starts with `priority`, receives explicit nil and
omitted tier fields, then receives `flex`, followed by another nil empty
chunk. Its snapshots are deterministically:

```text
[:priority, :priority, :priority, :flex, :flex]
```

This verifies initial-tier behavior, nil/omission preservation, and
latest-non-nil-wins semantics. These fixtures are deterministic protocol
examples, not observations of nondeterministic live service behavior.

## Root cause and fix

`ChatCompletionStreamState#convert_initial_chunk_into_snapshot` already copied
`service_tier` from the initial chunk. For subsequent chunks,
`#accumulate_chunk` updated top-level `usage` and `system_fingerprint` but
did not accumulate `service_tier`.

The fix adds the matching guarded assignment beside the existing top-level
metadata updates:

```ruby
completion_snapshot.service_tier = chunk.service_tier if chunk.service_tier
```

That is the smallest correction at the existing accumulation boundary:
non-nil later values become visible immediately, newer non-nil values replace
older ones, and nil or omitted values cannot erase a known tier.

## Compatibility, ownership, and non-goals

- No public API, signatures, request parameters, dependencies, or generated
  files change.
- The production change is limited to
  `lib/openai/helpers/streaming/chat_completion_stream.rb`, which
  `CONTRIBUTING.md` identifies as helper code never modified by generation.
- Focused coverage is limited to the existing public streaming snapshot test
  file.
- Text accumulation, usage accumulation, raw chunks, choice events, and stream
  lifecycle remain unchanged.
- This does not change `system_fingerprint`, moderation, parsing, logprobs,
  headers, transports, service selection, routing, or billing.

## Potential impact

Applications that rely on the accumulated streaming snapshot or final
completion to record the actual server-reported service tier can currently
observe nil or stale metadata when the tier first appears or changes in a
later chunk. For example, application logs or metrics grouped by the actual
processing tier can omit or misclassify those requests. The correction keeps
those accumulated objects aligned with the raw streamed metadata, which was
already available on `event.chunk.service_tier`. No incident rate, frequency,
or change to billing is claimed.

## Verification

The two added regressions failed before the production fix on base
`2359a02dd22fbf599250aaa97e755863562abf53` (2 runs, 3 assertions, 2 failures)
and passed afterward (2 runs, 8 assertions). The separate public-entrypoint
fixture produced the before/after results above.

Checks used Ruby 4.0.6 and the locked bundle; repository-relative commands
are shown below. All commands except the full suite passed:

```text
mise exec ruby@4.0.6 -- bundle exec ruby -Itest \
  test/openai/resources/chat/completions/streaming_snapshot_test.rb --name '/service_tier/'
# 2 runs, 8 assertions, 0 failures

mise exec ruby@4.0.6 -- bundle exec ruby -Itest \
  test/openai/resources/chat/completions/streaming_snapshot_test.rb
# 15 runs, 73 assertions, 0 failures

mise exec ruby@4.0.6 -- bundle exec ruby -Itest \
  test/openai/helpers/chat_completion_stream_test.rb
# 10 runs, 47 assertions, 0 failures

mise exec ruby@4.0.6 -- bundle exec rake lint
# passes: RBS validation, RuboCop-directive validation, example Sorbet
# typecheck, rubyfmt, RuboCop (2,793 files), and RBS formatting

git diff --check
# passes
```

Broader non-Bedrock suite:

```text
mise exec ruby@4.0.6 -- bundle exec rake test
# 1,531 runs, 13,729 assertions, 1 unrelated failure, 0 errors, 1 skip
```

The sole failure is the preexisting environment-sensitive
`FastFormatTest#test_resolves_relative_path_list_from_callers_directory`,
which expected `/var/...` while this macOS environment resolved
`/private/var/...`. It is unrelated to Chat Completions streaming and is not
changed here.

## Security assessment and known limitations

The diff only accumulates an already parsed enum-like response metadata field
and adds synthetic WebMock fixtures with clearly fake values. It does not touch
authentication, endpoints, transports, redirects, TLS, uploads, paths,
deserialization boundaries, logging, dependencies, CI, or release behavior.
No dedicated security review is required.

Known limitation: this change can only preserve values present in valid
Chat Completions chunks received by the helper. It does not infer a missing
tier, validate live service behavior, or make any guarantee about when the
server emits tier metadata.
