### PR TITLE
fix: handle nullable structured-output literals

### DIFF
--- a/lib/openai/helpers/structured_output/json_schema_converter.rb
+++ b/lib/openai/helpers/structured_output/json_schema_converter.rb
@@ -56,6 +56,8 @@ module OpenAI
                   {type: null}
                 ]
               }
+            in {const: _}
+              {anyOf: [schema, {type: null}]}
             in {anyOf: schemas}
               null = {type: null}
               schemas.any? { _1 == null || _1 == {type: ["null"]} } ? schema : {anyOf: [*schemas, null]}

--- a/test/openai/helpers/structured_output_nullable_literal_test.rb
+++ b/test/openai/helpers/structured_output_nullable_literal_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::StructuredOutputNullableLiteralTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class NullableStatus < OpenAI::BaseModel
+    required :status, const: :ready, nil?: true
+  end
+
+  class Status < OpenAI::BaseModel
+    required :status, const: :ready
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_nullable_symbol_literal_schema_preserves_literal_or_null
+    expected = {
+      type: "object",
+      properties: {
+        status: {anyOf: [{const: "ready"}, {type: "null"}]}
+      },
+      required: ["status"],
+      additionalProperties: false
+    }
+
+    schema = NullableStatus.to_json_schema
+
+    assert_equal(expected, schema)
+    assert_equal(JSON.parse(JSON.generate(expected)), JSON.parse(JSON.generate(schema)))
+    assert_equal({const: "ready"}, Status.to_json_schema.dig(:properties, :status))
+  end
+
+  def test_public_chat_completion_request_serializes_nullable_symbol_literal_schema
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(
+      status: 200,
+      body: {
+        id: "chatcmpl_nullable_literal",
+        choices: [
+          {
+            finish_reason: "stop",
+            index: 0,
+            message: {content: "{\"status\":null}", role: "assistant"}
+          }
+        ],
+        created: 1_700_000_000,
+        model: "gpt-4o-mini",
+        object: "chat.completion"
+      }
+    )
+
+    response = @client.chat.completions.create(
+      messages: [{content: "Return the status", role: :user}],
+      model: "gpt-4o-mini",
+      response_format: NullableStatus
+    )
+
+    assert_requested(:post, "http://localhost/chat/completions") do |request|
+      schema = JSON.parse(request.body).dig("response_format", "json_schema", "schema")
+
+      assert_equal(
+        [{"const" => "ready"}, {"type" => "null"}],
+        schema.dig("properties", "status", "anyOf")
+      )
+    end
+
+    assert_instance_of(NullableStatus, response.choices.first.message.parsed)
+    assert_nil(response.choices.first.message.parsed.status)
+  end
+end


### PR DESCRIPTION
## Summary

Allow nullable symbol-literal fields in structured-output models to generate a
JSON Schema and flow through public structured-output requests.

An existing supported declaration such as:

```ruby
class NullableStatus < OpenAI::BaseModel
  required :status, const: :ready, nil?: true
end
```

previously raised locally while building the schema. The converter now preserves
the symbol literal as `"ready"` and adds JSON `null` as the only other allowed
value:

```ruby
{
  type: "object",
  properties: {
    status: {
      anyOf: [
        {const: "ready"},
        {type: "null"}
      ]
    }
  },
  required: ["status"],
  additionalProperties: false
}
```

## Trigger and affected callers

The trigger is a structured-output `OpenAI::BaseModel` field declared with a
symbol `const:` and `nil?: true`. `BaseModel.to_json_schema_inner` converts
the symbol literal to `{const: "ready"}`, then delegates nilability to
`JsonSchemaConverter.to_nilable`.

This affects callers that build structured-output schemas through the public
`.to_json_schema` API and public structured-output request paths that invoke it,
including Chat Completions `response_format:` models. The failure happens
locally before an HTTP request is sent.

Idiomatic public SDK usage:

```ruby
require "openai"

class NullableStatus < OpenAI::BaseModel
  required :status, const: :ready, nil?: true
end

client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))

completion = client.chat.completions.create(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Return the current status"}],
  response_format: NullableStatus
)

status = completion.choices.first.message.parsed.status
```

## Deterministic reproduction

These results use only local schema generation and synthetic fixtures. They do
not make a live API request and are distinct from nondeterministic model output.

Before, on exact base
`2359a02dd22fbf599250aaa97e755863562abf53`:

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Ilib -e 'require "openai"; klass = Class.new(OpenAI::BaseModel) { required :status, const: :ready, nil?: true }; p klass.to_json_schema'
```

```text
.../json_schema_converter.rb:51:in
'OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.to_nilable':
{const: "ready"} (NoMatchingPatternError)
```

After:

```text
{type: "object", properties: {status: {anyOf: [{const: "ready"}, {type: "null"}]}}, required: ["status"], additionalProperties: false}
```

The regression test also uses WebMock with `http://localhost`, a clearly fake
API key, and a synthetic `{"status":null}` response to verify the public Chat
Completions request body and parsed result without network access.

## Root cause and fix

`JsonSchemaConverter.to_nilable` already handled `$ref`, `anyOf`, and
`type` schemas, but had no pattern for the `{const: ...}` schema emitted for
a symbol literal. Ruby pattern matching therefore fell through and raised
`NoMatchingPatternError`.

The smallest fix adds one `const` branch at that existing nilability boundary:

```ruby
in {const: _}
  {anyOf: [schema, {type: null}]}
```

That keeps the original literal schema intact and admits only JSON null as the
additional value.

## Compatibility, ownership, and non-goals

- Non-nullable symbol literals remain `{const: "ready"}`.
- Existing nullable string, enum, reference, union, and typed-schema branches
  are unchanged.
- The resulting public schema is JSON-serializable; the focused test compares
  a JSON round trip and the mocked request body, so internal marker objects do
  not escape.
- Production scope is limited to the handwritten
  `lib/openai/helpers/structured_output/json_schema_converter.rb`. The new
  focused regression test is also handwritten. No generated runtime, resources,
  models, signatures, dependencies, or public API shape changed.
- This does not add numeric or boolean constant support to `BaseModel`, support
  direct Ruby String constants at declaration, normalize schemas generally,
  redesign recursion/unions, or change Sorbet/Responses parsing.

## Potential impact

Valid literal-or-null structured-output models can currently fail during local
schema construction, preventing the SDK from issuing the intended request. This
fix restores the supported declaration shape without relaxing its constraint.
There is no claim of a measured incident rate, billing impact, or live production
incident.

## Verification

Red proof:

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_nullable_literal_test.rb
```

Before the production fix: `2 runs, 0 assertions, 0 failures, 2 errors`, both
with `NoMatchingPatternError: {const: "ready"}`.

Green and regression checks:

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_nullable_literal_test.rb
# 2 runs, 6 assertions, 0 failures, 0 errors, 0 skips

mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_test.rb
# 8 runs, 60 assertions, 0 failures, 0 errors, 0 skips

mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_parser_test.rb
# 9 runs, 123 assertions, 0 failures, 0 errors, 0 skips

mise exec ruby@4.0.6 -- bundle exec rubocop lib/openai/helpers/structured_output/json_schema_converter.rb test/openai/helpers/structured_output_nullable_literal_test.rb
# 2 files inspected, no offenses detected

mise exec ruby@4.0.6 -- bundle exec rake lint
# RuboCop: 2794 files inspected, no offenses detected
# Sorbet: No errors! Great job.
# RBS: Validated 1250 RBS files with no errors.

python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'
# Ran 51 tests ... OK (skipped=1)

# Required public gate, run against fresh origin/main and the committed candidate:
python3 -I scripts/castiron/custom_code_budget.py check --repo . --base 2f23d2b5717b165b57ab9cc304075996be257604 --head 562932540bf04927ea198ba2b8cacc0a03cd23ed --public --fetch --out <temporary-output-directory>
# isolation: success
# budget: success — +2793 / -270 = 3063 custom lines; limit 4000; headroom 937

git diff --check
# clean
```

A broad `bundle exec rake test` run reached `1531 runs, 13725 assertions, 2
failures, 0 errors, 1 skips`. One failure remains outside this change's paths:
`FastFormatTest#test_resolves_relative_path_list_from_callers_directory`
expects `/var/...` while macOS reports `/private/var/...`. The broad run's
`GemPackagingTest#test_installed_gem_completes_real_x509_issuer_and_api_handshakes`
failure was not reproducible in isolation:

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/gem_packaging_test.rb -n test_installed_gem_completes_real_x509_issuer_and_api_handshakes
# 1 run, 6 assertions, 0 failures, 0 errors, 0 skips
```

The required public custom-code budget check passed against fresh
`origin/main` `2f23d2b5717b165b57ab9cc304075996be257604` and committed
candidate `562932540bf04927ea198ba2b8cacc0a03cd23ed`: isolation success,
budget success, 3063 custom lines against limit 4000, with 937 lines headroom.
Focused and relevant structured-output coverage passes.

## Known limitations

- This covers the supported symbol-literal declaration in the requested
  `BaseModel` path; adjacent primitive-literal behavior remains intentionally
  out of scope.
- The public-request regression is deterministic and mocked; no live model
  behavior is asserted.
