### PR TITLE
fix: preserve numeric and boolean structured-output constants

### DIFF
--- a/lib/openai/helpers/structured_output/base_model.rb
+++ b/lib/openai/helpers/structured_output/base_model.rb
@@ -32,13 +32,27 @@ module OpenAI
             OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.cache_def!(state, type: self) do
               path = state.fetch(:path)
               properties = field_values.to_h do |field|
-                api_name, type, nilable, meta = field.fetch_values(:api_name, :type, :nilable, :meta)
+                api_name, type, nilable, const, meta = field.fetch_values(:api_name, :type, :nilable, :const, :meta)
                 new_state = {**state, path: [*path, ".#{api_name}"]}
 
-                schema = OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.to_json_schema_inner(
-                  type,
-                  state: new_state
-                )
+                literal_const = case const
+                when Integer, TrueClass, FalseClass
+                  true
+                when Float
+                  const.finite?
+                else
+                  false
+                end
+
+                schema = if literal_const
+                  {const: const}
+                else
+                  OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.to_json_schema_inner(
+                    type,
+                    state: new_state
+                  )
+                end
+
                 schema = OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.to_nilable(schema) if nilable
                 OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.assoc_meta!(
                   schema,

--- a/test/openai/helpers/structured_output_constant_test.rb
+++ b/test/openai/helpers/structured_output_constant_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::StructuredOutputConstantTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class ConstantFormat < OpenAI::BaseModel
+    required :version, Integer, const: 7, doc: "Schema version"
+    required :score, const: 1.5
+    required :published, const: true
+    required :archived, const: false
+    required :status, const: :ready
+    required :missing, const: nil
+    required :label, String
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "fake-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_schema_preserves_non_nullable_numeric_and_boolean_constants
+    assert_equal(
+      {
+        type: "object",
+        properties: {
+          version: {const: 7, description: "Schema version"},
+          score: {const: 1.5},
+          published: {const: true},
+          archived: {const: false},
+          status: {const: "ready"},
+          missing: {type: "null"},
+          label: {type: "string"}
+        },
+        required: %w[version score published archived status missing label],
+        additionalProperties: false
+      },
+      ConstantFormat.to_json_schema
+    )
+  end
+
+  def test_non_finite_float_constants_keep_a_serializable_numeric_schema
+    [Float::INFINITY, -Float::INFINITY, Float::NAN].each do |literal|
+      model = Class.new(OpenAI::BaseModel) { required(:value, const: literal) }
+      schema = model.to_json_schema
+
+      assert_equal({type: "number"}, schema.dig(:properties, :value))
+      JSON.generate(schema)
+    end
+  end
+
+  def test_public_chat_request_serializes_constant_schema
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(
+      status: 200,
+      body: {
+        id: "chatcmpl_constant",
+        object: "chat.completion",
+        created: 0,
+        model: "test",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: JSON.generate(
+                version: 7,
+                score: 1.5,
+                published: true,
+                archived: false,
+                status: "ready",
+                missing: nil,
+                label: "synthetic"
+              )
+            }
+          }
+        ]
+      }
+    )
+
+    completion = @client.chat.completions.create(
+      model: "test",
+      messages: [{role: "user", content: "Return the synthetic format"}],
+      response_format: ConstantFormat
+    )
+
+    assert_requested(:post, "http://localhost/chat/completions") do |request|
+      schema = JSON.parse(request.body).dig("response_format", "json_schema", "schema")
+
+      assert_equal(7, schema.dig("properties", "version", "const"))
+      assert_equal(1.5, schema.dig("properties", "score", "const"))
+      assert_equal(true, schema.dig("properties", "published", "const"))
+      assert_equal(false, schema.dig("properties", "archived", "const"))
+      assert_equal("ready", schema.dig("properties", "status", "const"))
+      assert_equal("null", schema.dig("properties", "missing", "type"))
+      assert_equal("string", schema.dig("properties", "label", "type"))
+    end
+
+    parsed = completion.choices.first.message.parsed
+
+    assert_instance_of(ConstantFormat, parsed)
+    assert_equal(7, parsed.version)
+    assert_equal(1.5, parsed.score)
+    assert_equal(true, parsed.published)
+    assert_equal(false, parsed.archived)
+    assert_equal(:ready, parsed.status)
+    assert_nil(parsed.missing)
+    assert_equal("synthetic", parsed.label)
+  end
+end


### PR DESCRIPTION
## Summary

Preserve exact JSON Schema `const` constraints for required, non-nullable
`OpenAI::BaseModel` fields declared with integer, finite float, `true`, or
`false` constants.

## Trigger and affected callers

The trigger is a public structured-output model that declares a supported
numeric or boolean literal:

```ruby
class InvoiceFormat < OpenAI::BaseModel
  required :schema_version, const: 2
  required :requires_review, const: false
end
```

The affected callers are public SDK entry points that serialize an
`OpenAI::BaseModel` as a structured-output schema, including Chat Completions
`response_format:`:

```ruby
client.chat.completions.create(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Return an invoice summary"}],
  response_format: InvoiceFormat
)
```

The schema example was executed locally against the changed source and verified
to equal:

```ruby
{
  type: "object",
  properties: {
    schema_version: {const: 2},
    requires_review: {const: false}
  },
  required: %w[schema_version requires_review],
  additionalProperties: false
}
```

## Deterministic before/after

These results use local synthetic model classes; they are deterministic schema
serialization behavior, not evidence from live model generation.

Before, on exact base `2359a02dd22fbf599250aaa97e755863562abf53`:

```ruby
Class.new(OpenAI::BaseModel) { required :value, const: 7 }.to_json_schema
# property: {type: "integer"}

Class.new(OpenAI::BaseModel) { required :value, const: 1.5 }.to_json_schema
# property: {type: "number"}

Class.new(OpenAI::BaseModel) { required :value, const: true }.to_json_schema
# raises ArgumentError because OpenAI::Internal::Type::Boolean is not a
# structured-output schema helper
```

After:

```ruby
Class.new(OpenAI::BaseModel) { required :value, const: 7 }.to_json_schema
# property: {const: 7}

Class.new(OpenAI::BaseModel) { required :value, const: 1.5 }.to_json_schema
# property: {const: 1.5}

Class.new(OpenAI::BaseModel) { required :value, const: true }.to_json_schema
# property: {const: true}

Class.new(OpenAI::BaseModel) { required :value, const: false }.to_json_schema
# property: {const: false}
```

The mocked public Chat Completions test additionally parses the actual JSON
request body and verifies these literals appear under
`response_format.json_schema.schema.properties`.

## Root cause and smallest fix

`OpenAI::Internal::Type::BaseModel` already retains required, non-nullable
field constant metadata in `field[:const]`. The handwritten structured-output
`BaseModel` schema builder read only the resolved field type. Integer and float
constants therefore became unconstrained numeric schemas, while booleans
resolved to the internal boolean type that the schema converter does not accept.

The fix stays at the owning handwritten field-to-schema boundary:
`lib/openai/helpers/structured_output/base_model.rb` now reads the existing
`:const` metadata and emits `{const: ...}` only for integers, finite floats,
and booleans. Non-finite floats have no JSON literal representation, so they
continue through the prior numeric-schema path to preserve request
serializability.

## Compatibility, ownership, and non-goals

- Existing symbol constants still use the converter and remain string
  `const` values.
- `const: nil` still emits `{type: "null"}`.
- Ordinary typed fields, metadata, required fields, API field names, and
  reference handling remain on their existing paths.
- Nullable constant declarations remain unchanged; the runtime omits their
  constant metadata.
- No generated runtime/resources/models, signatures, dependencies, public API,
  model accessors, raw storage, coercion, or runtime validation changed.
- No changes were made to `json_schema_converter.rb` or neighboring schema
  conversion paths.

## Potential impact

Callers who deliberately declare a numeric or boolean literal in a public
structured-output model now send the constraint they declared, instead of
silently allowing every number or encountering a local boolean schema exception.
This improves schema fidelity for format/version fields and boolean markers.
This is a credible contract-correctness issue; there is no claim here about
production incident frequency, billing impact, or live-generation guarantees.

## Verification

- Focused test:
  `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_constant_test.rb`
  — 3 runs, 19 assertions, 0 failures, 0 errors.
- Existing structured-output tests:
  `test/openai/helpers/structured_output_test.rb`,
  `structured_output_api_names_test.rb`, and
  `chat_completion_parser_test.rb` — all passed.
- Full helper suite:
  `TEST='test/openai/helpers/**/*_test.rb' mise exec ruby@4.0.6 -- bundle exec rake test`
  — 79 runs, 577 assertions, 0 failures, 0 errors; offline examples inventory
  also completed.
- RuboCop on both changed files — 2 files inspected, no offenses.
- Pinned rubyfmt check on both changed files — passed.
- Full `mise exec ruby@4.0.6 -- bundle exec rake lint` (including
  Sorbet/RBS) — exit 0 with no output.
- `ruby -c` on both changed files — Syntax OK.
- `git diff --check` — passed.
- Public example schema above — executed and JSON-serialized locally.
- Trusted public custom-code budget check against fresh `origin/main`
  `2f23d2b5717b165b57ab9cc304075996be257604` and committed candidate
  `aefbdc23e8565152fa94c6ab66279c0686b6d658` — isolation success; budget
  success, `+2793 / -270 = 3063` custom lines against limit `4000`
  (`937` lines headroom).

## Known limitations

- No live API request was made; the request-path proof uses WebMock with a
  synthetic response.
- Non-finite float constants remain `{type: "number"}` because JSON cannot
  represent NaN or infinities as literal values.
- No full repository or Bedrock suite was run; the full relevant helper suite
  was run.
