### PR TITLE
fix: honor StringIO cursors in vector-store batch uploads

### DIFF
--- a/lib/openai/internal/vector_store_file_uploader.rb
+++ b/lib/openai/internal/vector_store_file_uploader.rb
@@ -132,7 +132,7 @@ module OpenAI
         complete = false
         case content
         in StringIO
-          temporary_file.write(content.string)
+          temporary_file.write(content.string.byteslice(content.pos..) || "")
         in String
           temporary_file.write(content)
         in IO

--- a/test/openai/internal/vector_store_file_uploader_test.rb
+++ b/test/openai/internal/vector_store_file_uploader_test.rb
@@ -286,9 +286,11 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
     string, io_string, io, pathless_io, part, unnamed, io_part, path = observed
     assert_equal(["upload", "text/plain", "string-body"], metadata_and_contents(string))
     assert_equal(
-      ["upload", "application/octet-stream", "string-io-body"],
+      ["upload", "application/octet-stream", "g-io-body"],
       metadata_and_contents(io_string)
     )
+    assert_equal(5, string_io.pos)
+    refute_predicate(string_io, :closed?)
     assert_equal(
       [File.basename(tempfile.path), "application/octet-stream", "file-body"],
       metadata_and_contents(io)
@@ -314,6 +316,37 @@ class OpenAI::Test::VectorStoreFileUploaderTest < Minitest::Test
     source_file&.close
     part_source_file&.close
     tempfile&.close!
+  end
+
+  def test_upload_stages_string_io_from_its_byte_cursor_without_consuming_it
+    prefix = "π-prefix|".b
+    payload = "payload-\x00\xFF".b
+    bare = StringIO.new(prefix + payload).tap { _1.seek(prefix.bytesize) }
+    wrapped = StringIO.new(prefix + payload).tap { _1.seek(prefix.bytesize) }
+    eof = StringIO.new("complete").tap { _1.seek(_1.size) }
+    beyond_eof = StringIO.new("complete").tap { _1.seek(_1.size + 4) }
+    resource = FilesResource.new
+
+    2.times do
+      uploader(resource).upload(
+        [
+          bare,
+          OpenAI::FilePart.new(wrapped, filename: "payload.bin", content_type: "application/custom"),
+          eof,
+          beyond_eof
+        ]
+      )
+    end
+
+    assert_equal([payload, payload, "", "", payload, payload, "", ""], resource.contents)
+    assert_equal(prefix.bytesize, bare.pos)
+    assert_equal(prefix.bytesize, wrapped.pos)
+    assert_equal(eof.size, eof.pos)
+    assert_equal(beyond_eof.size + 4, beyond_eof.pos)
+    [bare, wrapped, eof, beyond_eof].each { refute_predicate(_1, :closed?) }
+    wrapped_file = resource.calls.fetch(1).fetch(:file)
+    assert_equal("payload.bin", wrapped_file.filename)
+    assert_equal("application/custom", wrapped_file.content_type)
   end
 
   def test_staged_file_part_io_upload_omits_absolute_local_path

--- a/test/openai/resources/polling_helpers_test.rb
+++ b/test/openai/resources/polling_helpers_test.rb
@@ -809,6 +809,39 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
     assert_equal("assistants=v2", batch_request.headers["openai-beta"])
   end
 
+  def test_vector_store_batch_upload_matches_direct_string_io_cursor_wire_content
+    upload_bodies = []
+    transport = scripted_transport do |request|
+      case [request.http_method, request.path]
+      in [:post, "/v1/files"]
+        upload_bodies << request.body
+        [200, {}, file_object(id: "file_uploaded_#{upload_bodies.length}", status: "processed")]
+      in [:post, "/v1/vector_stores/vs_123/file_batches"]
+        [200, {}, vector_batch(status: "in_progress")]
+      in [:get, "/v1/vector_stores/vs_123/file_batches/batch_123"]
+        [200, {}, vector_batch(status: "completed")]
+      else
+        flunk("unexpected request: #{request.http_method} #{request.path}")
+      end
+    end
+
+    input = StringIO.new("skip-prefix|payload").tap { _1.seek(12) }
+    client = build_client(transport)
+
+    client.files.create(file: input, purpose: :assistants)
+    result = client.vector_stores.file_batches.upload_and_poll("vs_123", files: [input])
+
+    assert_equal(:completed, result.status)
+    assert_equal(2, upload_bodies.length)
+    upload_bodies.each do |body|
+      refute_includes(body, "skip-prefix|")
+      assert_includes(body, "payload")
+    end
+
+    assert_equal(12, input.pos)
+    refute_predicate(input, :closed?)
+  end
+
   def test_vector_store_batch_upload_preserves_raw_io_non_retry_semantics
     direct_attempts = 0
     direct_transport = scripted_transport do


### PR DESCRIPTION
## Summary

Vector-store batch uploads now stage StringIO inputs from their current byte
cursor, matching established direct multipart uploads. The caller-owned
StringIO remains open and its cursor is not advanced, so the same remaining
bytes can be uploaded again.

## Trigger and affected users

This is triggered when a caller passes a StringIO with a nonzero pos to
client.vector_stores.file_batches.upload_and_poll. Previously, batch staging
uploaded the full backing buffer, while client.files.create already uploaded
only bytes from the current cursor onward.

Affected users are Ruby SDK callers who intentionally position a StringIO before
vector-store batch upload, including callers wrapping it in OpenAI::FilePart.

## Public Ruby SDK example

    require "openai"
    require "stringio"
    client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
    content = StringIO.new("skip-prefix|payload")
    content.seek(12)
    client.files.create(file: content, purpose: :assistants)
    client.vector_stores.file_batches.upload_and_poll("vs_123", files: [content])
    # Both uploads send "payload", and content.pos remains 12.

## Deterministic behavior proof

A network-disabled synthetic reproducer uses
StringIO.new("skip-prefix|payload") at byte position 12 and inspects multipart
wire bodies for both public APIs.

Before: direct includes prefix false; batch includes prefix true; both include
payload true; cursor 12; batch completed.

After: direct includes prefix false; batch includes prefix false; both include
payload true; cursor 12; batch completed.

No live OpenAI request was made. This is deterministic synthetic transport
evidence, not a claim about a live service incident.

## Root cause and minimal fix

OpenAI::Internal::VectorStoreFileUploader#spool wrote StringIO#string, which
always returns the full backing buffer and ignores StringIO#pos. The fix writes
content.string.byteslice(content.pos..) || "", the same byte-oriented remaining
content rule already used by direct multipart encoding.

## Potential impact

A caller may read or deliberately skip a prefix before handing the remaining
file content to the SDK. With the old batch behavior, the uploaded file included
those already-skipped bytes, so switching from a direct upload to a vector-store
batch could change the document content submitted for indexing. The correction
keeps batch content aligned with the caller's cursor and the direct-upload path.
No incident rate or live-service outcome is claimed.

## Compatibility and scope

This is a precise compatibility correction: batch StringIO inputs with a
nonzero cursor now match direct uploads. Cursor position and open state are
preserved; repeated uploads remain replayable; at or beyond EOF, the staged
remainder is empty.

Unchanged: String, Pathname, and raw IO handling; raw IO consumption and
non-retryable semantics; FilePart filename/content type; temporary cleanup;
worker concurrency; retries, endpoints, transports, authentication, and limits.

The production change is confined to the handwritten internal uploader. No
generated resource, shared multipart encoder, FilePart, type converter, public
API signature, dependency, or custom-code budget file changed.

## Verification

- RED uploader tests before fix: 2 failures showing full-buffer staging for
  nonzero cursor and EOF.
- RED public regression before fix: batch multipart body contained skip-prefix|.
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/vector_store_file_uploader_test.rb
  — 22 runs, 142 assertions, 0 failures.
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/polling_helpers_test.rb
  — 42 runs, 230 assertions, 0 failures.
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/polling_helpers_test.rb --name test_vector_store_batch_upload_matches_direct_string_io_cursor_wire_content
  — 1 run, 13 assertions, 0 failures.
- Provided network-disabled reproducer — direct and batch exclude prefix,
  include payload, preserve cursor 12, and batch completes.
- mise exec ruby@4.0.6 -- bundle exec rake lint
  — 2,793 files, 0 RuboCop offenses; directives valid; 0 Sorbet errors;
  1,250 RBS files valid.
- git diff --check — clean.
- Public custom-code gate against base
  2f23d2b5717b165b57ab9cc304075996be257604 and candidate
  e8370a06dcb374ceafac80e437235f085cf51149
  — success, 3,063 / 4,000 custom lines, headroom 937.
- mise exec ruby@4.0.6 -- bundle exec rake test
  — 1,531 runs, 13,752 assertions, 0 errors, 1 skip, and 1 unrelated
  host-path failure in
  FastFormatTest#test_resolves_relative_path_list_from_callers_directory
  (/var expected versus /private/var observed). Affected tests are green.

## Review and security

Required adversarial review converged with two consecutive clean rounds on
unchanged code.

A dedicated upload-security pass found no introduced vulnerability or
disclosure-sensitive issue: prefix bytes are excluded before staging; cursor
and replayability are preserved without reads/seeks; metadata validation,
temporary cleanup, logging, limits, transport, and auth behavior are unchanged.
This is ordinary content correctness, not a security incident.

## Limitations

No live API upload was run. The full suite has the unrelated macOS path-alias
failure above. SDK-team review is required because upload content is touched.
