### PR TITLE
fix(ci): restore Castiron statuses for fork PRs

### DIFF
--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -142,19 +142,29 @@ jobs:
                 run.repository.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
             const head = run.head_sha;
             if (!/^[0-9a-f]{40}$/.test(head)) throw new Error('Invalid candidate SHA');
-            const {data: main} = await github.rest.git.getRef({...context.repo, ref: 'heads/main'});
+            const {data: repository} = await github.rest.repos.get(context.repo);
+            const branch = repository.default_branch;
+            const {data: main} = await github.rest.git.getRef({...context.repo, ref: `heads/${branch}`});
             const base = main.object.sha;
             if (run.event === 'pull_request') {
+              const headRepository = run.head_repository;
+              if (!headRepository || !Number.isInteger(headRepository.id) || headRepository.id <= 0 ||
+                  !headRepository.full_name || !headRepository.owner?.login || !run.head_branch) return;
               const pulls = run.pull_requests.length ? run.pull_requests : await github.paginate(
-                github.rest.repos.listPullRequestsAssociatedWithCommit, {...context.repo, commit_sha: head});
+                github.rest.pulls.list, {...context.repo, state: 'open',
+                  head: `${headRepository.owner.login}:${run.head_branch}`, base: branch, per_page: 100});
               const current = [];
-              for (const pull of pulls) {
-                const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: pull.number});
+              for (const number of [...new Set(pulls.map(pull => pull.number))].sort((a, b) => a - b)) {
+                if (!Number.isInteger(number) || number <= 0) return;
+                const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: number});
                 if (pr.state === 'open' && pr.head.sha === head && pr.base.sha === base &&
-                    pr.base.ref === 'main' && pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) current.push(pr);
+                    pr.head.ref === run.head_branch && pr.head.repo?.id === headRepository.id &&
+                    pr.head.repo?.full_name === headRepository.full_name &&
+                    pr.base.ref === branch &&
+                    pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) current.push(pr);
               }
               if (current.length !== 1) return;
-            } else if (run.event !== 'merge_group' || !run.head_branch.startsWith('gh-readonly-queue/main/')) {
+            } else if (run.event !== 'merge_group' || !run.head_branch.startsWith(`gh-readonly-queue/${branch}/`)) {
               return;
             }
             const fresh = base === process.env.BASE_SHA && head === process.env.HEAD_SHA;
@@ -220,12 +230,34 @@ jobs:
         with:
           script: |
             const marker = '<!-- castiron:custom-code-report:v1 -->';
-            const run = context.payload.workflow_run;
-            if (run.event !== 'pull_request' || run.path !== '.github/workflows/castiron-custom-code.yml') return;
-            const pulls = run.pull_requests?.length ? run.pull_requests : await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {...context.repo, commit_sha: run.head_sha});
-            for (const pull of pulls) {
-              const {data: current} = await github.rest.pulls.get({...context.repo, pull_number: pull.number});
-              if (current.state !== 'open' || current.head.sha !== run.head_sha) continue;
+            const event = context.payload.workflow_run;
+            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: event.id});
+            if (run.event !== 'pull_request' ||
+                run.head_sha !== event.head_sha || run.run_attempt !== event.run_attempt ||
+                run.status !== 'completed' ||
+                run.path.split('@', 1)[0] !== '.github/workflows/castiron-custom-code.yml' ||
+                run.repository.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
+            const {data: repository} = await github.rest.repos.get(context.repo);
+            const branch = repository.default_branch;
+            const {data: main} = await github.rest.git.getRef({...context.repo, ref: `heads/${branch}`});
+            const headRepository = run.head_repository;
+            if (!headRepository || !Number.isInteger(headRepository.id) || headRepository.id <= 0 ||
+                !headRepository.full_name || !headRepository.owner?.login || !run.head_branch) return;
+            const pulls = run.pull_requests?.length ? run.pull_requests : await github.paginate(
+              github.rest.pulls.list, {...context.repo, state: 'open',
+                head: `${headRepository.owner.login}:${run.head_branch}`, base: branch, per_page: 100});
+            const current = [];
+            for (const number of [...new Set(pulls.map(pull => pull.number))].sort((a, b) => a - b)) {
+              if (!Number.isInteger(number) || number <= 0) return;
+              const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: number});
+              if (pr.state === 'open' && pr.head.sha === run.head_sha &&
+                  pr.head.ref === run.head_branch && pr.head.repo?.id === headRepository.id &&
+                  pr.head.repo?.full_name === headRepository.full_name &&
+                  pr.base.sha === main.object.sha && pr.base.ref === branch &&
+                  pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) current.push(pr);
+            }
+            if (current.length !== 1) return;
+            for (const pull of current) {
               const comments = await github.paginate(github.rest.issues.listComments, {...context.repo, issue_number: pull.number});
               const previous = comments.find(c => c.user?.type === 'Bot' && c.user?.login === 'github-actions[bot]' && c.body?.startsWith(marker));
               const prior = previous?.body?.match(/<!-- castiron:run:v1:(\d+):(\d+) -->/);

--- a/.github/workflows/castiron-custom-code.yml
+++ b/.github/workflows/castiron-custom-code.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REPORTER_SHA256: b971c18701081ff47e7a5f935fd1fe9cd5f58b3d8f570a4daede62c5611e3fc9
+  REPORTER_SHA256: 66b128590c674d4dec7c59b99dc0de54d7d1672eee4ab6d193bfc6b369a664d0
 
 jobs:
   queue-signal:

--- a/scripts/castiron/CUSTOM_CODE.md
+++ b/scripts/castiron/CUSTOM_CODE.md
@@ -55,6 +55,13 @@ head or merge-group SHA, after rechecking head/base freshness:
 - `Castiron / budget-only change`
 - `Castiron / custom-code budget`
 
+For fork PRs, GitHub can omit `workflow_run.pull_requests` while the PR is open.
+The trusted handler then uses the authenticated run's head repository owner and
+branch to list open PRs targeting the default branch, fetches every candidate,
+and accepts exactly one only after matching its head SHA, head repository and
+ref, base repository and ref, and current default-branch SHA. Missing,
+ambiguous, spoofed, or stale metadata still fails closed.
+
 The policy is read from the current base commit, not the PR or its merge base.
 Reporter changes in a PR cannot change the checker executing on that PR. Missing
 snapshots, invalid hashes, unavailable queue membership, and policy errors fail

--- a/scripts/castiron/custom_code_budget.py
+++ b/scripts/castiron/custom_code_budget.py
@@ -300,23 +300,7 @@ def github_evaluate(
         raise ValueError("unexpected or superseded source workflow run")
     head = report.require_sha(run["head_sha"])
     if run["event"] == "pull_request":
-        associated = run["pull_requests"] or report.api(
-            "GET", f"{root}/commits/{head}/pulls?per_page=100"
-        )
-        current: list[int] = []
-        for number in sorted({int(pr["number"]) for pr in associated}):
-            if number <= 0:
-                raise ValueError("invalid associated PR number")
-            pull = report.api("GET", f"{root}/pulls/{number}")
-            if (
-                pull["state"] == "open"
-                and pull["head"]["sha"] == head
-                and pull["base"]["repo"]["full_name"] == repository
-                and pull["base"]["ref"] == branch
-                and pull["base"]["sha"] == main
-            ):
-                current.append(number)
-        if len(current) != 1:
+        if report.current_pull_request(root, repository, run, branch, main) is None:
             raise ValueError("source run must identify exactly one current PR targeting main")
     elif run["event"] == "merge_group":
         if not run["head_branch"].startswith(f"gh-readonly-queue/{branch}/"):

--- a/scripts/castiron/custom_code_report.py
+++ b/scripts/castiron/custom_code_report.py
@@ -22,6 +22,7 @@ import re
 import struct
 import subprocess
 import sys
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -766,6 +767,84 @@ def api(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
     return json.loads(result.stdout)
 
 
+def api_list(path: str) -> list[dict[str, Any]]:
+    """Read every GitHub REST list page or fail closed on malformed pagination."""
+    results: list[dict[str, Any]] = []
+    for page in range(1, 101):
+        suffix = "" if page == 1 else f"&page={page}"
+        entries = api("GET", path + suffix)
+        if not isinstance(entries, list):
+            raise ReportError("GitHub list response is invalid")
+        results.extend(entries)
+        if len(entries) < 100:
+            return results
+    raise ReportError("GitHub list pagination did not terminate")
+
+
+def current_pull_request(
+    root: str,
+    repository: str,
+    run: dict[str, Any],
+    branch: str,
+    main: str,
+) -> dict[str, Any] | None:
+    """Resolve one live PR from trusted run metadata, including fork runs."""
+    head = require_sha(run["head_sha"])
+    head_repository = run.get("head_repository")
+    if not isinstance(head_repository, dict):
+        raise ReportError("source run has no head repository")
+    head_repository_name = head_repository.get("full_name")
+    head_repository_id = head_repository.get("id")
+    owner = head_repository.get("owner")
+    owner_login = owner.get("login") if isinstance(owner, dict) else None
+    head_branch = run.get("head_branch")
+    if (
+        not isinstance(head_repository_name, str)
+        or not REPOSITORY.fullmatch(head_repository_name)
+        or type(head_repository_id) is not int
+        or head_repository_id <= 0
+        or not isinstance(owner_login, str)
+        or not owner_login
+        or not isinstance(head_branch, str)
+        or not head_branch
+    ):
+        raise ReportError("invalid source run head repository or branch")
+    associated = run["pull_requests"]
+    if not associated:
+        query = urllib.parse.urlencode(
+            {
+                "state": "open",
+                "head": f"{owner_login}:{head_branch}",
+                "base": branch,
+                "per_page": 100,
+            }
+        )
+        associated = api_list(f"{root}/pulls?{query}")
+    numbers = sorted({int(pull["number"]) for pull in associated})
+    current: list[dict[str, Any]] = []
+    for number in numbers:
+        if number <= 0:
+            raise ReportError("invalid associated pull request")
+        pull = api("GET", f"{root}/pulls/{number}")
+        pull_head_repository = pull["head"]["repo"]
+        if (
+            pull["state"] == "open"
+            and pull["head"]["sha"] == head
+            and pull["head"]["ref"] == head_branch
+            and pull_head_repository["id"] == head_repository_id
+            and pull_head_repository["full_name"] == head_repository_name
+            and pull["base"]["repo"]["full_name"] == repository
+            and pull["base"]["ref"] == branch
+            and pull["base"]["sha"] == main
+        ):
+            current.append(pull)
+    if not current:
+        return None
+    if len(current) != 1:
+        raise ReportError("workflow run has multiple current pull requests")
+    return current[0]
+
+
 def publish_comment(
     report: dict[str, Any],
     repository: str,
@@ -779,26 +858,22 @@ def publish_comment(
     if not REPOSITORY.fullmatch(repository) or min(number, run_id, run_attempt) <= 0:
         raise ReportError("invalid GitHub publication target")
     root = f"repos/{repository}"
-    pull = api("GET", f"{root}/pulls/{number}")
-    if (
-        pull["state"] != "open"
-        or pull["head"]["sha"] != report["head_sha"]
-        or pull["base"]["sha"] != report["target_base_sha"]
-    ):
-        return "Skipped stale report"
     run = api("GET", f"{root}/actions/runs/{run_id}")
     if (
         run["event"] != "pull_request"
         or run.get("path", "").split("@", 1)[0] != ".github/workflows/castiron-custom-code.yml"
         or run["head_sha"] != report["head_sha"]
+        or run["repository"]["full_name"] != repository
     ):
         raise ReportError("workflow run does not match report PR/head")
-    associated = run["pull_requests"]
-    if not associated:
-        # GitHub can omit the PR association on workflow runs from forks.
-        associated = api("GET", f"{root}/commits/{require_sha(run['head_sha'])}/pulls?per_page=100")
-    if not any(pr["number"] == number for pr in associated):
+    metadata = api("GET", root)
+    branch = metadata["default_branch"]
+    main = require_sha(api("GET", f"{root}/git/ref/heads/{branch}")["object"]["sha"])
+    pull = current_pull_request(root, repository, run, branch, main)
+    if pull is None or pull["number"] != number:
         raise ReportError("workflow run does not match report PR/head")
+    if pull["head"]["sha"] != report["head_sha"] or main != report["target_base_sha"]:
+        return "Skipped stale report"
     if run["run_attempt"] != run_attempt:
         return "Skipped stale report"
     artifact_run_id = artifact_run_id or run_id
@@ -829,12 +904,8 @@ def publish_comment(
         if found["body"] == body:
             return str(found["html_url"])
     # The workflow serializes publishers; recheck after pagination before writing.
-    pull = api("GET", f"{root}/pulls/{number}")
-    if (
-        pull["state"] != "open"
-        or pull["head"]["sha"] != report["head_sha"]
-        or pull["base"]["sha"] != report["target_base_sha"]
-    ):
+    pull = current_pull_request(root, repository, run, branch, main)
+    if pull is None or pull["number"] != number:
         return "Skipped stale report"
     if found is not None:
         result = api("PATCH", f"{root}/issues/comments/{found['id']}", {"body": body})
@@ -885,29 +956,21 @@ def trusted_report(repo: Path, repository: str, run_id: int, run_attempt: int, o
         run["event"] != "pull_request"
         or run.get("path", "").split("@", 1)[0] != ".github/workflows/castiron-custom-code.yml"
         or run["status"] != "completed"
+        or run["repository"]["full_name"] != repository
     ):
         raise ReportError("unexpected source workflow run")
     if run["run_attempt"] != run_attempt:
         return
     head = require_sha(run["head_sha"])
-    associated = run["pull_requests"] or api("GET", f"{root}/commits/{head}/pulls?per_page=100")
-    current: list[tuple[int, str]] = []
-    for number in sorted({int(pr["number"]) for pr in associated}):
-        if number <= 0:
-            raise ReportError("invalid associated pull request")
-        pull = api("GET", f"{root}/pulls/{number}")
-        if (
-            pull["state"] == "open"
-            and pull["head"]["sha"] == head
-            and pull["base"]["repo"]["full_name"] == repository
-        ):
-            current.append((number, require_sha(pull["base"]["sha"])))
-    if not current:
+    metadata = api("GET", root)
+    branch = metadata["default_branch"]
+    main = require_sha(api("GET", f"{root}/git/ref/heads/{branch}")["object"]["sha"])
+    pull = current_pull_request(root, repository, run, branch, main)
+    if pull is None:
         return
-    if len(current) != 1:
-        raise ReportError("workflow run has multiple current pull requests")
-    number, base = current[0]
-    public = not api("GET", root)["private"]
+    number = int(pull["number"])
+    base = main
+    public = not metadata["private"]
     # This must be a new, bare repository: no PR worktree, hooks, configuration,
     # submodules, or Python imports can affect the trusted reporter.
     repo.mkdir()

--- a/scripts/castiron/test_custom_code_budget.py
+++ b/scripts/castiron/test_custom_code_budget.py
@@ -21,6 +21,11 @@ def source_run(head: str, event: str = "pull_request") -> dict[str, Any]:
         "event": event,
         "head_sha": head,
         "head_branch": "gh-readonly-queue/main/pr-7-example" if event == "merge_group" else "sdk",
+        "head_repository": {
+            "id": 7,
+            "full_name": "fork/example",
+            "owner": {"login": "fork"},
+        },
         "repository": {"full_name": "openai/example"},
         "path": ".github/workflows/castiron-custom-code.yml",
         "status": "completed",
@@ -331,9 +336,14 @@ class StatusPublisherTests(unittest.TestCase):
                 },
             },
             "run": {**source_run(head, event_name), **(run_overrides or {})},
+            "candidates": [{"number": 3}],
             "current": {
                 "state": "open",
-                "head": {"sha": "c" * 40 if head_changed else head},
+                "head": {
+                    "sha": "c" * 40 if head_changed else head,
+                    "ref": "sdk",
+                    "repo": {"id": 7, "full_name": "fork/example"},
+                },
                 "base": {
                     "sha": "c" * 40 if base_changed else base,
                     "ref": "main",
@@ -351,11 +361,20 @@ class StatusPublisherTests(unittest.TestCase):
           const fs = require('node:fs');
           const data = JSON.parse(fs.readFileSync(0, 'utf8'));
           const published = [];
-          const github = {rest: {
-            pulls: {get: async () => ({data: data.current})},
+          const github = {
+            paginate: async (_method, options) => {
+              if (options.head !== 'fork:sdk' || options.base !== 'main' ||
+                  options.state !== 'open') throw new Error('unsafe fork lookup');
+              return data.candidates;
+            },
+            rest: {
+            pulls: {list() {}, get: async () => ({data: data.current})},
             actions: {getWorkflowRun: async () => ({data: data.run})},
             git: {getRef: async () => ({data: {object: {sha: data.current.base.sha}}})},
-            repos: {createCommitStatus: async value => published.push(value)},
+            repos: {
+              get: async () => ({data: {default_branch: 'main'}}),
+              createCommitStatus: async value => published.push(value),
+            },
           }};
           const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
           new AsyncFunction('github','context','process', data.script)(github, data.context, {env:data.env})
@@ -382,6 +401,10 @@ class StatusPublisherTests(unittest.TestCase):
 
     def test_stale_pr_head_is_not_published(self) -> None:
         self.assertEqual(self.publish(head_changed=True), [])
+
+    def test_fork_run_without_association_uses_scoped_open_pr_lookup(self) -> None:
+        results = self.publish(run_overrides={"pull_requests": []})
+        self.assertEqual(len(results), 2)
 
     def test_stale_base_and_missing_evaluation_cannot_publish_success(self) -> None:
         for event in ("pull_request", "merge_group"):
@@ -465,7 +488,7 @@ class GitHubBudgetTests(unittest.TestCase):
         event = {"repository": {"full_name": "openai/example"}, "workflow_run": source_run(head)}
         pull = {
             "state": "open",
-            "head": {"sha": head},
+            "head": {"sha": head, "ref": "sdk", "repo": {"id": 7, "full_name": "fork/example"}},
             "base": {
                 "sha": base,
                 "ref": "main",
@@ -565,7 +588,7 @@ class GitHubBudgetTests(unittest.TestCase):
         }
         pull = {
             "state": "open",
-            "head": {"sha": head},
+            "head": {"sha": head, "ref": "sdk", "repo": {"id": 7, "full_name": "fork/example"}},
             "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
         }
         responses = [
@@ -603,7 +626,7 @@ class GitHubBudgetTests(unittest.TestCase):
                 }
                 pull: dict[str, Any] = {
                     "state": "open",
-                    "head": {"sha": head},
+                    "head": {"sha": head, "ref": "sdk", "repo": {"id": 7, "full_name": "fork/example"}},
                     "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
                 }
                 if kind == "head":

--- a/scripts/castiron/test_custom_code_report.py
+++ b/scripts/castiron/test_custom_code_report.py
@@ -20,6 +20,41 @@ import custom_code_report as report
 GENERATION = "550e8400-e29b-41d4-a716-446655440000"
 
 
+def source_run(head: str, pull_requests: list[dict[str, int]] | None = None) -> dict[str, Any]:
+    return {
+        "event": "pull_request",
+        "status": "completed",
+        "path": ".github/workflows/castiron-custom-code.yml",
+        "head_sha": head,
+        "head_branch": "sdk",
+        "head_repository": {
+            "id": 7,
+            "full_name": "fork/example",
+            "owner": {"login": "fork"},
+        },
+        "repository": {"full_name": "openai/example"},
+        "run_attempt": 1,
+        "pull_requests": [{"number": 1}] if pull_requests is None else pull_requests,
+    }
+
+
+def source_pull(head: str, base: str, number: int = 1) -> dict[str, Any]:
+    return {
+        "number": number,
+        "state": "open",
+        "head": {
+            "sha": head,
+            "ref": "sdk",
+            "repo": {"id": 7, "full_name": "fork/example"},
+        },
+        "base": {
+            "sha": base,
+            "ref": "main",
+            "repo": {"full_name": "openai/example"},
+        },
+    }
+
+
 class CustomCodeTests(unittest.TestCase):
     # Keep the vendored test stdlib-only on Python 3.10 (no typing.override yet).
     def setUp(self) -> None:  # pyright: ignore[reportImplicitOverride]
@@ -286,11 +321,18 @@ const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
 async function check(stale, exists, priorRun, expected) {
   const writes = [];
   const event = {id: 20, run_attempt: 1, event: 'pull_request', path: '.github/workflows/castiron-custom-code.yml', head_sha: 'a'.repeat(40), pull_requests: [{number: 1}]};
-  const current = {state: 'open', head: {sha: (stale ? 'c' : 'a').repeat(40)}};
+  const run = {...event, status: 'completed', repository: {full_name: 'openai/example'},
+    head_branch: 'sdk', head_repository: {id: 7, full_name: 'fork/example', owner: {login: 'fork'}}};
+  const current = {number: 1, state: 'open',
+    head: {sha: (stale ? 'c' : 'a').repeat(40), ref: 'sdk', repo: {id: 7, full_name: 'fork/example'}},
+    base: {sha: 'b'.repeat(40), ref: 'main', repo: {full_name: 'openai/example'}}};
   const previous = {id: 42, user: {type: 'Bot', login: 'github-actions[bot]'},
     body: `<!-- castiron:custom-code-report:v1 -->\n<!-- castiron:run:v1:${priorRun}:1 -->`};
   const github = {paginate: async () => exists ? [previous] : [], rest: {
     pulls: {get: async () => ({data: current})},
+    actions: {getWorkflowRun: async () => ({data: run})},
+    repos: {get: async () => ({data: {default_branch: 'main'}})},
+    git: {getRef: async () => ({data: {object: {sha: 'b'.repeat(40)}}})},
     issues: {listComments() {}, updateComment: async x => writes.push(['update', x]),
       createComment: async x => writes.push(['create', x])}}};
   const context = {payload: {workflow_run: event}, repo: {owner: 'openai', repo: 'example'},
@@ -382,16 +424,20 @@ async function check(stale, exists, priorRun, expected) {
 
         _, base = self.baseline()
         result, _ = report.build_report(self.repo, base, base)
-        pull = {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
-        run = {
-            "event": "pull_request",
-            "path": ".github/workflows/castiron-custom-code.yml",
-            "head_sha": base,
-            "run_attempt": 1,
-            "pull_requests": [{"number": 1}],
-        }
+        pull = source_pull(base, base)
+        run = source_run(base)
         with mock.patch.object(
-            report, "api", side_effect=[pull, run, [], pull, {"html_url": "published"}]
+            report,
+            "api",
+            side_effect=[
+                run,
+                {"default_branch": "main"},
+                {"object": {"sha": base}},
+                pull,
+                [],
+                pull,
+                {"html_url": "published"},
+            ],
         ) as api:
             self.assertEqual(
                 report.publish_comment(
@@ -452,19 +498,8 @@ async function check(stale, exists, priorRun, expected) {
             with self.subTest(label=label):
                 calls: list[tuple[str, str]] = []
                 bodies: list[str] = []
-                pull = {
-                    "state": "open",
-                    "head": {"sha": revision},
-                    "base": {"sha": base, "repo": {"full_name": "openai/example"}},
-                }
-                run: dict[str, Any] = {
-                    "event": "pull_request",
-                    "status": "completed",
-                    "path": ".github/workflows/castiron-custom-code.yml",
-                    "head_sha": revision,
-                    "run_attempt": 1,
-                    "pull_requests": [],
-                }
+                pull = source_pull(revision, base)
+                run = source_run(revision, [])
                 forged: dict[str, Any] = {**legitimate, "head_sha": revision, "files": []}
                 self.assertIn("Generated baselines verified", report.render_report(forged))
                 producer = self.repo / f"producer-{label}"
@@ -475,9 +510,10 @@ async function check(stale, exists, priorRun, expected) {
                     calls.append((method, path))
                     if method == "GET":
                         responses: dict[str, Any] = {
-                            "repos/openai/example": {"private": False},
+                            "repos/openai/example": {"default_branch": "main", "private": False},
                             "repos/openai/example/actions/runs/2": run,
-                            f"repos/openai/example/commits/{revision}/pulls?per_page=100": [
+                            "repos/openai/example/git/ref/heads/main": {"object": {"sha": base}},
+                            "repos/openai/example/pulls?state=open&head=fork%3Asdk&base=main&per_page=100": [
                                 {"number": 1}
                             ],
                             "repos/openai/example/pulls/1": pull,
@@ -536,31 +572,22 @@ async function check(stale, exists, priorRun, expected) {
                     self.assertIn("--name castiron-custom-code-9-3", body)
 
     def test_trusted_report_rejects_invalid_or_stale_association_before_fetch(self) -> None:
-        run = {
-            "event": "pull_request",
-            "status": "completed",
-            "path": ".github/workflows/castiron-custom-code.yml",
-            "head_sha": "a" * 40,
-            "run_attempt": 1,
-            "pull_requests": [{"number": 1}],
-        }
-        pull = {
-            "state": "open",
-            "head": {"sha": "a" * 40},
-            "base": {"sha": "b" * 40, "repo": {"full_name": "openai/example"}},
-        }
+        run = source_run("a" * 40)
+        pull = source_pull("a" * 40, "b" * 40)
+        metadata = {"default_branch": "main", "private": False}
+        main = {"object": {"sha": "b" * 40}}
         cases: list[tuple[list[Any], bool]] = [
             ([{**run, "path": "other.yml"}], True),
             ([{**run, "status": "in_progress"}], True),
             ([{**run, "run_attempt": 2}], False),
-            ([run, {**pull, "state": "closed"}], False),
-            ([run, {**pull, "head": {"sha": "c" * 40}}], False),
+            ([run, metadata, main, {**pull, "state": "closed"}], False),
+            ([run, metadata, main, {**pull, "head": {**pull["head"], "sha": "c" * 40}}], False),
             (
-                [run, {**pull, "base": {"sha": "b" * 40, "repo": {"full_name": "other/repo"}}}],
+                [run, metadata, main, {**pull, "base": {**pull["base"], "repo": {"full_name": "other/repo"}}}],
                 False,
             ),
-            ([{**run, "pull_requests": []}, []], False),
-            ([{**run, "pull_requests": [{"number": 1}, {"number": 2}]}, pull, pull], True),
+            ([{**run, "pull_requests": []}, metadata, main, []], False),
+            ([{**run, "pull_requests": [{"number": 1}, {"number": 2}]}, metadata, main, pull, {**pull, "number": 2}], True),
         ]
         for responses, raises in cases:
             with (
@@ -579,6 +606,86 @@ async function check(stale, exists, priorRun, expected) {
                     )
                 git.assert_not_called()
                 self.assertFalse((self.repo / "out").exists())
+
+    def test_fork_run_uses_scoped_open_pr_lookup_and_rejects_unsafe_matches(self) -> None:
+        head, base = "a" * 40, "b" * 40
+        run = source_run(head, [])
+        pull = source_pull(head, base)
+        with mock.patch.object(report, "api", side_effect=[[{"number": 1}], pull]) as api:
+            self.assertEqual(
+                report.current_pull_request(
+                    "repos/openai/example", "openai/example", run, "main", base
+                ),
+                pull,
+            )
+        self.assertEqual(
+            api.call_args_list[0].args[1],
+            "repos/openai/example/pulls?state=open&head=fork%3Asdk&base=main&per_page=100",
+        )
+        cases = (
+            (
+                [[{"number": 1}], {**pull, "head": {**pull["head"], "ref": "spoofed"}}],
+                None,
+            ),
+            (
+                [[{"number": 1}], {**pull, "base": {**pull["base"], "sha": "c" * 40}}],
+                None,
+            ),
+            (
+                [
+                    [{"number": 1}, {"number": 2}],
+                    pull,
+                    {**pull, "number": 2},
+                ],
+                report.ReportError,
+            ),
+        )
+        for responses, expected in cases:
+            with self.subTest(expected=expected), mock.patch.object(
+                report, "api", side_effect=responses
+            ):
+                if expected is report.ReportError:
+                    with self.assertRaises(report.ReportError):
+                        report.current_pull_request(
+                            "repos/openai/example", "openai/example", run, "main", base
+                        )
+                else:
+                    self.assertIsNone(
+                        report.current_pull_request(
+                            "repos/openai/example", "openai/example", run, "main", base
+                        )
+                    )
+
+        def later_page(
+            method: str, path: str, payload: dict[str, Any] | None = None
+        ) -> Any:
+            self.assertEqual(method, "GET")
+            self.assertIsNone(payload)
+            if path.endswith("per_page=100"):
+                return [{"number": number} for number in range(1, 101)]
+            if path.endswith("per_page=100&page=2"):
+                return [{"number": 101}]
+            number = int(path.rsplit("/", 1)[1])
+            if number == 101 or (ambiguous and number == 1):
+                return source_pull(head, base, number)
+            return {**source_pull(head, base, number), "state": "closed"}
+
+        for ambiguous in (False, True):
+            with self.subTest(ambiguous=ambiguous), mock.patch.object(
+                report, "api", side_effect=later_page
+            ):
+                if ambiguous:
+                    with self.assertRaises(report.ReportError):
+                        report.current_pull_request(
+                            "repos/openai/example", "openai/example", run, "main", base
+                        )
+                else:
+                    self.assertEqual(
+                        report.current_pull_request(
+                            "repos/openai/example", "openai/example", run, "main", base
+                        )["number"],
+                        101,
+                    )
 
     def test_removals_include_changed_baselines_but_not_handwritten_only_files(self) -> None:
         _, base = self.baseline()
@@ -816,15 +923,13 @@ async function check(stale, exists, priorRun, expected) {
         def fake_api(method: str, path: str, payload: object = None) -> object:
             calls.append((method, path, payload))
             if "/pulls/" in path:
-                return {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
+                return source_pull(base, base)
             if "/actions/runs/" in path:
-                return {
-                    "event": "pull_request",
-                    "path": ".github/workflows/castiron-custom-code.yml",
-                    "head_sha": base,
-                    "run_attempt": 1,
-                    "pull_requests": [{"number": 1}],
-                }
+                return source_run(base)
+            if path == "repos/openai/example":
+                return {"default_branch": "main"}
+            if path == "repos/openai/example/git/ref/heads/main":
+                return {"object": {"sha": base}}
             if "/comments?" in path:
                 return [
                     {"id": 7, "user": {"login": "someone"}, "body": report.MARKER},
@@ -842,63 +947,65 @@ async function check(stale, exists, priorRun, expected) {
             self.assertEqual(calls[-1][:2], ("PATCH", "repos/openai/example/issues/comments/8"))
             calls.clear()
             result["head_sha"] = "f" * 40
-            self.assertEqual(
-                report.publish_comment(result, "openai/example", 1, 2, 1), "Skipped stale report"
-            )
-            self.assertEqual(len(calls), 1)
+            with self.assertRaisesRegex(report.ReportError, "does not match report PR"):
+                report.publish_comment(result, "openai/example", 1, 2, 1)
+            self.assertFalse(any(method in {"PATCH", "POST"} for method, _, _ in calls))
 
     def test_comment_rejects_older_runs_attempts_and_wrong_pr(self) -> None:
         _, base = self.baseline()
         result, _ = report.build_report(self.repo, base, base)
-        pull = {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
-        run = {
-            "event": "pull_request",
-            "path": ".github/workflows/castiron-custom-code.yml",
-            "head_sha": base,
-            "run_attempt": 2,
-            "pull_requests": [{"number": 1}],
-        }
+        pull = source_pull(base, base)
+        run = {**source_run(base), "run_attempt": 2}
+        metadata = {"default_branch": "main"}
+        main = {"object": {"sha": base}}
         comment = {
             "id": 8,
             "user": {"login": "github-actions[bot]"},
             "body": report.MARKER + "\n<!-- castiron:run:v1:3:1 -->",
             "html_url": "existing",
         }
-        with mock.patch.object(report, "api", side_effect=[pull, run]) as api:
+        with mock.patch.object(report, "api", side_effect=[run, metadata, main, pull]) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 1), "Skipped stale report"
             )
-            self.assertEqual(api.call_count, 2)
-        with mock.patch.object(report, "api", side_effect=[pull, run, [comment]]) as api:
+            self.assertEqual(api.call_count, 4)
+        with mock.patch.object(report, "api", side_effect=[run, metadata, main, pull, [comment]]) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 2), "Skipped stale report"
             )
-            self.assertEqual(api.call_count, 3)
+            self.assertEqual(api.call_count, 5)
         with (
-            mock.patch.object(report, "api", side_effect=[pull, {**run, "pull_requests": []}, []]),
+            mock.patch.object(report, "api", side_effect=[{**run, "pull_requests": []}, metadata, main, []]),
             self.assertRaisesRegex(report.ReportError, "does not match report PR"),
         ):
             report.publish_comment(result, "openai/example", 1, 2, 2)
         with (
-            mock.patch.object(report, "api", side_effect=[pull, {**run, "path": "other.yml"}]),
+            mock.patch.object(report, "api", side_effect=[{**run, "path": "other.yml"}]),
             self.assertRaisesRegex(report.ReportError, "does not match report PR"),
         ):
             report.publish_comment(result, "openai/example", 1, 2, 2)
         with mock.patch.object(
             report,
             "api",
-            side_effect=[pull, {**run, "pull_requests": []}, [{"number": 1}], [comment]],
+            side_effect=[
+                {**run, "pull_requests": []},
+                metadata,
+                main,
+                [{"number": 1}],
+                pull,
+                [comment],
+            ],
         ) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 2), "Skipped stale report"
             )
-            self.assertIn(f"/commits/{base}/pulls", api.call_args_list[2].args[1])
-        changed = {**pull, "head": {"sha": "f" * 40}}
-        with mock.patch.object(report, "api", side_effect=[pull, run, [], changed]) as api:
+            self.assertIn("/pulls?state=open&head=fork%3Asdk", api.call_args_list[3].args[1])
+        changed = {**pull, "head": {**pull["head"], "sha": "f" * 40}}
+        with mock.patch.object(report, "api", side_effect=[run, metadata, main, pull, [], changed]) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 2), "Skipped stale report"
             )
-            self.assertEqual(api.call_count, 4)
+            self.assertEqual(api.call_count, 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Resolve fork pull requests when workflow_run.pull_requests is empty by listing open PRs scoped to the authenticated run head owner/branch and current default branch.
- Re-fetch candidates and require exactly one open PR matching head SHA, head repository ID/name/ref, base repository/ref, and current base SHA before trusted computation or publication.
- Apply the same fail-closed resolution to the reporter, budget checker, required-status publisher, and failure-comment path.
- Document the fallback and add regressions for empty associations, pagination, spoofed/stale matches, and ambiguity.

Ports the applicable behavior from https://github.com/openai/openai-java/pull/959.

## Security
- The pull_request workflow remains unprivileged.
- The workflow_run handler continues to use main-owned code and does not execute or trust candidate artifacts for authority.
- Missing, malformed, stale, mismatched, or ambiguous metadata fails closed.

## Testing
- env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/castiron -p test_custom_code*.py
- env PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q scripts/castiron/custom_code_report.py scripts/castiron/custom_code_budget.py scripts/castiron/test_custom_code_report.py scripts/castiron/test_custom_code_budget.py
- git diff --check origin/main

## Review
- Adversarial review converged after two consecutive clean rounds.
- Security diff review completed with no findings.