### PR TITLE
fix: emit done events for terminal chat tool calls

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -648,11 +648,6 @@ module OpenAI
 
           if choice_snapshot.finish_reason
             events.concat(content_done_events(choice_snapshot, response_format))
-
-            if @current_tool_call_index && !@done_tool_calls.include?(@current_tool_call_index)
-              event = tool_done_event(tool_calls_by_index, @current_tool_call_index)
-              events << event if event
-            end
           end
 
           Array(choice_chunk.delta.tool_calls).each do |tool_call|
@@ -666,6 +661,13 @@ module OpenAI
             end
 
             @current_tool_call_index = tool_call.index
+          end
+
+          if choice_snapshot.finish_reason &&
+              @current_tool_call_index &&
+              !@done_tool_calls.include?(@current_tool_call_index)
+            event = tool_done_event(tool_calls_by_index, @current_tool_call_index)
+            events << event if event
           end
 
           events

--- a/test/openai/helpers/chat_stream_terminal_tool_test.rb
+++ b/test/openai/helpers/chat_stream_terminal_tool_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamTerminalToolTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_terminal_tool_call_emits_done_without_a_tool_header
+    [[], [role_choice]].each do |prefix|
+      stream, events = stream_events(prefix + [terminal_choice(tool_call(0, "strict_tool", "{\"value\":1}"))])
+
+      assert_equal([0], done_events(events).map(&:index))
+      assert_equal(["{\"value\":1}"], argument_deltas(events).map(&:arguments_delta))
+      assert_equal(
+        "{\"value\":1}",
+        stream.get_final_completion.choices.first.message.tool_calls.first.function.arguments
+      )
+      assert_equal({value: 1}, done_events(events).first.parsed)
+    end
+  end
+
+  def test_terminal_chunk_emits_each_completed_function_tool_once
+    calls = [
+      tool_call(0, "strict_tool", "{\"value\":1}"),
+      tool_call(1, "non_strict_tool", "{\"value\":2}"),
+      tool_call(2, "unknown_tool", "{\"value\":3}")
+    ]
+    stream, events = stream_events([terminal_choice(*calls)])
+    dones = done_events(events)
+
+    assert_equal([0, 1, 2], dones.map(&:index))
+    assert_equal(["strict_tool", "non_strict_tool", "unknown_tool"], dones.map(&:name))
+    assert_equal(["{\"value\":1}", "{\"value\":2}", "{\"value\":3}"], dones.map(&:arguments))
+    assert_equal([{value: 1}, nil, nil], dones.map(&:parsed))
+    assert_equal(
+      ["{\"value\":1}", "{\"value\":2}", "{\"value\":3}"],
+      stream.get_final_completion.choices.first.message.tool_calls.map { |call| call.function.arguments }
+    )
+  end
+
+  def test_split_tool_header_and_delta_still_emit_one_done_event
+    chunks = [
+      choice(delta: {role: "assistant", tool_calls: [tool_call(0, "strict_tool", "")]}),
+      choice(delta: {tool_calls: [{index: 0, function: {arguments: "{\"value\":1}"}}]}),
+      terminal_choice
+    ]
+    stream, events = stream_events(chunks)
+
+    assert_equal([0], done_events(events).map(&:index))
+    assert_equal(["", "{\"value\":1}"], argument_deltas(events).map(&:arguments_delta))
+    assert_equal("{\"value\":1}", stream.get_final_completion.choices.first.message.tool_calls.first.function.arguments)
+  end
+
+  private
+
+  def stream_events(choices)
+    WebMock.reset!
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: sse(choices)
+      )
+
+    stream = @client.chat.completions.stream(
+      messages: [{content: "Hello", role: :user}],
+      model: "gpt-4o-mini",
+      tools: input_tools
+    )
+    [stream, stream.to_a]
+  end
+
+  def sse(choices)
+    chunks = choices.map do |choice|
+      payload = {
+        id: "chatcmpl-terminal-tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt-4o-mini",
+        choices: [choice]
+      }
+      "data: #{JSON.generate(payload)}\n\n"
+    end
+
+    chunks.join + "data: [DONE]\n\n"
+  end
+
+  def role_choice
+    choice(delta: {role: "assistant"})
+  end
+
+  def terminal_choice(*tool_calls)
+    delta = tool_calls.empty? ? {} : {tool_calls: tool_calls}
+    choice(delta: delta, finish_reason: "tool_calls")
+  end
+
+  def choice(delta:, finish_reason: nil)
+    {index: 0, delta: delta, finish_reason: finish_reason}
+  end
+
+  def tool_call(index, name, arguments)
+    {
+      index: index,
+      id: "call_#{index}",
+      type: "function",
+      function: {name: name, arguments: arguments}
+    }
+  end
+
+  def input_tools
+    [
+      function_tool("strict_tool", strict: true),
+      function_tool("non_strict_tool", strict: false)
+    ]
+  end
+
+  def function_tool(name, strict:)
+    {
+      type: :function,
+      function: {
+        name: name,
+        strict: strict,
+        parameters: {
+          type: "object",
+          properties: {value: {type: "integer"}},
+          required: ["value"],
+          additionalProperties: false
+        }
+      }
+    }
+  end
+
+  def done_events(events)
+    events.select { |event| event.type == :"tool_calls.function.arguments.done" }
+  end
+
+  def argument_deltas(events)
+    events.select { |event| event.type == :"tool_calls.function.arguments.delta" }
+  end
+end


### PR DESCRIPTION
## Summary

Fix chat-completion helper streams so a function tool call first appearing in the terminating choice chunk emits its expected `tool_calls.function.arguments.done` event.

Applications that react to this done event can otherwise miss a completed tool call even though `get_final_completion` contains the correct call and arguments. This is deterministic synthetic protocol-fixture evidence, not a claim about production frequency or incidents. The SDK does not execute tools itself.

## Trigger and affected callers

The trigger is a valid streamed chat-completion choice whose first function tool call arrives complete in the same chunk that has `finish_reason: "tool_calls"`. It also occurs after a role-only prefix. Callers affected are consumers of:

```ruby
require "openai"

client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))

stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Use the tool"}],
  tools: [
    {
      type: :function,
      function: {
        name: "lookup_value",
        strict: true,
        parameters: {
          type: "object",
          properties: {value: {type: "integer"}},
          required: ["value"],
          additionalProperties: false
        }
      }
    }
  ]
)

stream.each do |event|
  next unless event.type == :"tool_calls.function.arguments.done"

  puts [event.index, event.name, event.arguments, event.parsed].inspect
end
```

## Deterministic evidence

Using a network-disabled WebMock SSE fixture with a complete strict function call carrying `{"value":1}`:

| Prefix before terminal tool chunk | Before | After | Final arguments |
| --- | ---: | ---: | --- |
| none | 0 done events | 1 done event | `{"value":1}` |
| role only | 0 done events | 1 done event | `{"value":1}` |
| earlier tool header | 1 done event | 1 done event | `{"value":1}` |

The new focused public-entrypoint regression also covers multiple tools in one terminal frame, strict parsed arguments, non-strict and unknown-input compatibility, full argument deltas, final completion arguments, and the existing split header/delta sequence without duplicates.

## Root cause and smallest fix

`ChoiceEventState#get_done_events` handled the terminal finish reason before tracking tool indices present in that same chunk. A newly introduced terminal-frame tool therefore was not current when the terminal done event was emitted.

The fix keeps the existing completion-state flow and deduplication set, but performs the terminal tool flush after the current chunk's tool indices are processed. No new event type, public field, parser, index model, or abstraction is introduced.

## Compatibility, ownership, and non-goals

This is a backward-compatible bug fix in the handwritten chat streaming helper. It preserves event shapes, final completions, argument delta payloads, strict parsing semantics, and supported sequential-tool behavior. Production changes are limited to `lib/openai/helpers/streaming/chat_completion_stream.rb`; coverage is a new focused test.

Non-goals include interleaved-tool protocol redesign, changing nonterminal early-completion semantics, adding choice IDs or event fields, changing argument parsing or tool dispatch, handling initial-chunk `length`/`content_filter`, service-tier/fingerprint/logprobs changes, stream transports/lifecycle, generated code, signatures, dependencies, or unrelated cleanup.

## Verification

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_terminal_tool_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_stream_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/chat/completions/streaming_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/chat/completions/streaming_snapshot_test.rb
mise exec ruby@4.0.6 -- bundle exec rake lint
git diff --check
```

Results:

- Focused regression: 3 runs, 16 assertions, 0 failures.
- Chat helper suite: 10 runs, 47 assertions, 0 failures.
- Public chat streaming suite: 22 runs, 107 assertions, 0 failures.
- Streaming snapshot suite: 15 runs, 73 assertions, 0 failures.
- Full lint/type/format task: passed; RuboCop inspected 2,796 files with no offenses, Sorbet had no errors, and 1,250 RBS files validated.
- Diff whitespace check: passed.

All fixtures are synthetic and network-disabled; no live API calls were made.

## Public custom-code budget

The trusted public gate passed against fresh `origin/main` and the committed candidate: 3,063 custom lines against a 4,000-line limit, with 937 lines of headroom. No budget file, reporting code, generation metadata, or exclusion changed.

## Security assessment

The fix improves event completeness while reusing the existing strict-argument parsing path unchanged. It adds no deserialization surface, validation rule, logging, credential handling, transport behavior, dependency, or sensitive fixture. No suspected vulnerability was identified.

## Known limitations

No live API request or full repository/Bedrock test suite was run locally. The focused public-entrypoint tests and complete chat-streaming helper, public-streaming, and snapshot suites listed above were run. The fixture proves the chunk-ordering case deterministically; it does not assert how often a live service emits that shape.
