### PR TITLE
test: make fast-format relative-path regression portable on macOS

### DIFF
--- a/test/scripts/fast_format_test.rb
+++ b/test/scripts/fast_format_test.rb
@@ -20,7 +20,7 @@ class FastFormatTest < Minitest::Test
 
       assert_equal(ROOT, invocation.fetch("directory"))
       assert_equal(
-        ["exec", "rake", "format", "FORMAT_FILE=#{File.join(directory, path_list)}"],
+        ["exec", "rake", "format", "FORMAT_FILE=#{File.join(File.realpath(directory), path_list)}"],
         invocation.fetch("arguments")
       )
     end


### PR DESCRIPTION
## Summary

Make the existing `scripts/fast-format` relative-path regression use the caller directory's physical path when constructing its expected `FORMAT_FILE=` argument.

This is a one-test-only portability correction. It does not change `scripts/fast-format` or any OpenAI Ruby SDK runtime behavior.

## Trigger and affected callers

Contributors can hit a false local test failure on macOS when a temporary directory is spelled through the `/var` symlink alias but the child shell reports its physical working directory under `/private/var`.

The affected caller is the repository's fast-format test runner, for example:

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/scripts/fast_format_test.rb
```

No public OpenAI SDK API call or SDK user path is affected.

## Reproduction

On macOS, Ruby can retain the logical temporary-directory spelling while a child shell resolves its physical working directory:

```ruby
require "tmpdir"

Dir.mktmpdir do |directory|
  puts directory
  puts File.realpath(directory)
end
```

Sanitized example:

```text
/var/.../caller
/private/var/.../caller
```

Before this change, the focused test reported:

```text
2 runs, 5 assertions, 1 failure
expected FORMAT_FILE=/var/.../caller/paths.txt
actual   FORMAT_FILE=/private/var/.../caller/paths.txt
```

The formatter invocation is valid: `scripts/fast-format` captures the caller shell's `$PWD` before changing to the repository root, and the child shell uses the physical `/private/var/...` spelling.

## Root cause and smallest fix

The relative-path test constructed its expected argument from `Dir.mktmpdir`'s logical path spelling. The child process constructs the actual argument from its physical shell working directory. The test now uses `File.realpath(directory)` only for that relative-path expectation, matching the boundary it is verifying.

The assertion remains exact; it does not skip, suffix-match, or otherwise weaken the regression.

## Preserved coverage and non-goals

The two existing tests still verify:

- a relative path list is prefixed with the caller's directory before the script changes to the repository root;
- the formatter runs from the exact repository root;
- an absolute path list is forwarded with its original supplied spelling unchanged;
- all additional formatter arguments are forwarded exactly.

Non-goals:

- no production formatter behavior change;
- no broader pathname normalization or symlink policy;
- no Rake, CI, dependency, generated-code, SDK runtime, signature, architecture, or public API changes.

Linux hosted CI should be unchanged because canonical and temporary path spellings are ordinarily the same there.

## Potential impact

The prior expectation can make an otherwise valid local Ruby suite fail for macOS contributors. The correction removes that false failure while preserving the formatter contract checks.

## Verification

```text
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/scripts/fast_format_test.rb
# 2 runs, 5 assertions, 0 failures, 0 errors, 0 skips

mise exec ruby@4.0.6 -- bundle exec ruby -Itest -e 'Dir["test/scripts/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
# 124 runs, 858 assertions, 0 failures, 0 errors, 1 skip

mise exec ruby@4.0.6 -- bundle exec rake lint
# passed

mise exec ruby@4.0.6 -- bundle exec rake lint:rubyfmt
# passed

mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop
# 2795 files inspected, no offenses detected

git diff --check
# passed
```

`mise exec ruby@4.0.6 -- bundle exec rake test` completed with `1538 runs, 13782 assertions, 1 failure, 0 errors, 1 skip`. The only failure was the unrelated timing-boundary assertion in `OpenAI::Test::Resources::PollingHelpersTest#test_files_wait_for_processing_bounds_retrieval_by_polling_deadline` (`0.02000000001862645 <= 0.02`). The changed fast-format regression passed both focused and all-script runs; this test-only PR does not modify the unrelated polling helper.

The genuine public custom-code budget check passed for the committed candidate: isolation succeeded and measured `3063` custom lines against the `4000`-line limit.

## Security assessment

This changes only a test expectation. It does not alter production execution, authentication, input handling, SDK path behavior, logging, CI, dependencies, secrets, or customer data. No security-sensitive surface is changed.
