### PR TITLE
examples: track streaming choices by API index

### DIFF
--- a/examples/chat/streaming_multi_choice.rb
+++ b/examples/chat/streaming_multi_choice.rb
@@ -21,7 +21,9 @@ stream.each do |event|
   case event
   when OpenAI::Streaming::ChatChunkEvent
     # Access the full snapshot with all choices:
-    event.snapshot.choices.each_with_index do |choice, index|
+    event.snapshot.choices.each do |choice|
+      index = choice.index
+
       if choice.message.content
         choice_contents[index] = choice.message.content
       end

--- a/test/openai/streaming_multi_choice_example_test.rb
+++ b/test/openai/streaming_multi_choice_example_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "test_helper"
+
+class OpenAI::Test::StreamingMultiChoiceExampleTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  EXAMPLE_PATH = File.expand_path("../../examples/chat/streaming_multi_choice.rb", __dir__)
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def after_all
+    WebMock.allow_net_connect!
+    WebMock.disable!
+    super
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_labels_each_completion_by_choice_index_when_choice_one_finishes_first
+    stdout, stderr, exit_error = run_example(
+      terminal_chunk(index: 1, content: "Second choice"),
+      terminal_chunk(index: 0, content: "First choice")
+    )
+
+    assert_nil(exit_error)
+    assert_empty(stderr)
+    assert_equal(successful_output(first_completion: 1), stdout)
+  end
+
+  def test_labels_each_completion_by_choice_index_when_choice_zero_finishes_first
+    stdout, stderr, exit_error = run_example(
+      terminal_chunk(index: 0, content: "First choice"),
+      terminal_chunk(index: 1, content: "Second choice")
+    )
+
+    assert_nil(exit_error)
+    assert_empty(stderr)
+    assert_equal(successful_output(first_completion: 0), stdout)
+  end
+
+  def test_fails_when_a_choice_never_completes
+    stdout, stderr, exit_error = run_example(
+      terminal_chunk(index: 0, content: "First choice")
+    )
+
+    assert_failure(exit_error, stderr)
+    assert_equal(completion_output(index: 0, content: "First choice"), stdout)
+  end
+
+  def test_fails_when_a_completed_choice_has_empty_content
+    stdout, stderr, exit_error = run_example(
+      terminal_chunk(index: 0, content: ""),
+      terminal_chunk(index: 1, content: "Second choice")
+    )
+
+    assert_failure(exit_error, stderr)
+    assert_equal(
+      completion_output(index: 0, content: "") +
+        completion_output(index: 1, content: "Second choice"),
+      stdout
+    )
+  end
+
+  private
+
+  def run_example(*chunks)
+    wire = chunks.map { |chunk| "data: #{JSON.generate(chunk)}\n\n" }.join + "data: [DONE]\n\n"
+    stub_request(:post, "http://localhost/chat/completions")
+      .with(body: hash_including(model: "gpt-4o-mini", n: 2, stream: true))
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: wire
+      )
+
+    client = OpenAI::Client.new(base_url: "http://localhost", api_key: "fake-key")
+    exit_error = nil
+    stdout, stderr = capture_io do
+      OpenAI::Client.stub(:new, client) do
+        load(EXAMPLE_PATH, true)
+      rescue SystemExit => error
+        exit_error = error
+      end
+    end
+
+    [stdout, stderr, exit_error]
+  end
+
+  def terminal_chunk(index:, content:)
+    {
+      id: "chatcmpl_synthetic",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "test",
+      choices: [
+        {
+          index: index,
+          delta: {role: "assistant", content: content},
+          finish_reason: "stop"
+        }
+      ]
+    }
+  end
+
+  def successful_output(first_completion:)
+    second_completion = 1 - first_completion
+    content_by_index = {0 => "First choice", 1 => "Second choice"}
+
+    completion_output(index: first_completion, content: content_by_index.fetch(first_completion)) +
+      completion_output(index: second_completion, content: content_by_index.fetch(second_completion)) +
+      "------ final choices ------\n" \
+        "[0] First choice\n" \
+        "[1] Second choice\n"
+  end
+
+  def completion_output(index:, content:)
+    "[choice #{index}] complete:\n" \
+      "#{content}\n" \
+      "--- choice #{index} done ---\n\n"
+  end
+
+  def assert_failure(error, stderr)
+    assert_instance_of(SystemExit, error)
+    assert_equal(1, error.status)
+    assert_equal("Expected two completed choices with content; received 1\n", stderr)
+  end
+end


### PR DESCRIPTION
## Summary

Fix `examples/chat/streaming_multi_choice.rb` so its per-choice completion notices use the API's stable `choice.index` instead of the choice's current position in a snapshot array.

This is a finite two-file example fix:

- update the existing multi-choice streaming example;
- add an offline regression that executes the actual example through the public SDK client path.

No SDK stream semantics, public API, parser, generated code, dependencies, or other examples change.

## Trigger and affected callers

The public trigger is running:

```sh
ruby ./examples/chat/streaming_multi_choice.rb
```

The affected callers are developers reading or copying the example's event-handling loop for `n: 2` chat completion streams. If a snapshot's array order differs from the API choice indices—for example, choice 1 is first to arrive and finish—the old loop could print a completion notice under the wrong label even though the SDK's final accumulated choice data was correct.

Potential impact is misleading sample output and copied event-handling code. This is not a model or service failure, and this change makes no claim about live occurrence frequency.

## Root cause and smallest fix

The old example used `each_with_index`, so array position became the key for content, completion state, and labels:

```ruby
event.snapshot.choices.each_with_index do |choice, index|
  # ...
end
```

Snapshot position is not semantic identity. Each choice already exposes its API identity as `choice.index`. The corrected public Ruby loop keeps the existing structure and uses that value:

```ruby
event.snapshot.choices.each do |choice|
  index = choice.index

  if choice.message.content
    choice_contents[index] = choice.message.content
  end

  next unless choice.finish_reason && !choice_finished[index]
  choice_finished[index] = true
  puts("[choice #{index}] complete:")
  puts(choice_contents[index])
  puts("--- choice #{index} done ---")
  puts
end
```

## Deterministic reproduction

The regression uses synthetic WebMock SSE, not a live API call. It sends terminal chunks in this order:

```json
{"choices":[{"index":1,"delta":{"role":"assistant","content":"Second choice"},"finish_reason":"stop"}]}
{"choices":[{"index":0,"delta":{"role":"assistant","content":"First choice"},"finish_reason":"stop"}]}
```

Before:

```text
[choice 0] complete:
Second choice
--- choice 0 done ---

[choice 1] complete:
Second choice
--- choice 1 done ---

------ final choices ------
[0] First choice
[1] Second choice
```

After:

```text
[choice 1] complete:
Second choice
--- choice 1 done ---

[choice 0] complete:
First choice
--- choice 0 done ---

------ final choices ------
[0] First choice
[1] Second choice
```

The before/after distinction matters: the old completion notifications were wrong, while the final SDK data and final summary were already correct.

## Tests

The new serial test loads the actual example, stubs only `OpenAI::Client.new` to return a real client pointed at a local WebMock endpoint, disables network, and verifies:

- choice 1 finishing before choice 0 produces exactly one correctly labeled completion for each choice and the correct final summary;
- ordinary choice-0-first ordering remains correct;
- a missing completion still aborts;
- a completed choice with empty content still aborts.

## Verification

Passed:

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/streaming_multi_choice_example_test.rb`
  - 4 runs, 16 assertions, 0 failures, 0 errors, 0 skips.
- `mise exec ruby@4.0.6 -- bundle exec ruby -w -Itest -e 'require_relative "test/openai/streaming_multi_choice_example_test"; require_relative "test/openai/resources/chat/completions/streaming_test"; require_relative "test/openai/resources/chat/completions/streaming_snapshot_test"'`
  - 41 runs, 196 assertions, 0 failures, 0 errors, 0 skips.
- `mise exec ruby@4.0.6 -- bundle exec rake test:examples:inventory`
  - 24/35 covered examples; 11 explicitly excluded.
- `mise exec ruby@4.0.6 -- bundle exec rubocop --force-exclusion examples/chat/streaming_multi_choice.rb test/openai/streaming_multi_choice_example_test.rb`
  - 2 files inspected, no offenses.
- `mise exec ruby@4.0.6 -- bundle exec ./scripts/rubyfmt --check -- examples/chat/streaming_multi_choice.rb test/openai/streaming_multi_choice_example_test.rb`
  - passed.
- `mise exec ruby@4.0.6 -- bundle exec rake lint`
  - Sorbet no errors; 1,250 RBS files validated; 2,796 files inspected by RuboCop with no offenses; directives validated.
- `git diff --check`
  - passed.
- Public committed-candidate custom-code budget
  - fresh `origin/main` / policy base: `7b880d86007e8640c53de057cae72a22ebe7bb31`;
  - candidate head: `996c69bdf6dafeffdb7c67131bbc82126434a704`;
  - `python3 -I scripts/castiron/custom_code_budget.py check --repo <worktree> --base 7b880d86007e8640c53de057cae72a22ebe7bb31 --head 996c69bdf6dafeffdb7c67131bbc82126434a704 --public --fetch --out <private-temp-dir>`;
  - isolation success; budget success; `+2793 / -270 = 3063` custom lines against limit `4000`, with `937` lines of base-budget headroom;
  - verified generated snapshot: `6ae9f6c5f61f147b7edd2d20439d48cbc21d0739`.

Broad `mise exec ruby@4.0.6 -- bundle exec rake test` ran 1,542 tests with 13,798 assertions and found two unrelated failures:

- a polling deadline assertion exceeded `0.02` by `0.00000000001862645`; the isolated polling helper file immediately passed (42 runs, 230 assertions);
- the known macOS FastFormat `/var` versus `/private/var` baseline reproduced in isolation (2 runs, 5 assertions, 1 failure).

Neither failure touches this two-file scope.

## Compatibility, ownership, and non-goals

The change stays in handwritten example/test paths. It preserves the example's `n: 2` request, expected indices `[0, 1]`, final summary, and completeness guard. It does not sort SDK snapshots, change event types, alter accumulator/parser behavior, handle tool calls, change API parameters, modify output data, touch generated/shared runtime/signatures/dependencies, or redesign any public API.

## Security assessment

This changes only labels and in-memory tracking keys. It adds no payload logging, execution surface, destination, credential behavior, deserialization path, or dependency. Fixtures are synthetic and the test uses a clearly fake key with network disabled. No security-sensitive behavior or finding was identified.
