### PR TITLE
fix: preserve retained Responses stream events

### DIFF
--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -190,12 +190,7 @@ module OpenAI
         def accumulate_event(event:, current_snapshot:)
           if current_snapshot.nil?
             if event.is_a?(OpenAI::Models::Responses::ResponseCreatedEvent)
-              # Use the converter to create a new, isolated copy of the response object.
-              # This ensures proper type validation and prevents shared object references.
-              return OpenAI::Internal::Type::Converter.coerce(
-                OpenAI::Models::Responses::Response,
-                event.response
-              )
+              return isolated_value(event.response)
             end
 
             unless @resumed
@@ -212,12 +207,12 @@ module OpenAI
 
           case event
           when OpenAI::Models::Responses::ResponseOutputItemAddedEvent
-            current_snapshot.output.push(event.item)
+            current_snapshot.output.push(isolated_value(event.item))
 
           when OpenAI::Models::Responses::ResponseContentPartAddedEvent
             output = current_snapshot.output[event.output_index]
             if output && output.type == :message
-              output.content.push(event.part)
+              output.content.push(isolated_value(event.part))
               current_snapshot.output[event.output_index] = output
             end
 
@@ -247,6 +242,16 @@ module OpenAI
         end
 
         private
+
+        # Materialize fresh containers before snapshot accumulation mutates them.
+        # Coercing an already-typed model returns it unchanged, so first use the
+        # model's recursive raw representation. Unknown union fallbacks stay raw.
+        def isolated_value(value)
+          raw = OpenAI::Internal::Type::BaseModel.recursively_to_h(value, convert: false)
+          return raw unless value.is_a?(OpenAI::Internal::Type::BaseModel)
+
+          OpenAI::Internal::Type::Converter.coerce(value.class, raw)
+        end
 
         def assert_type(object, expected_type)
           return if object && object.type == expected_type

--- a/test/openai/helpers/response_stream_isolation_test.rb
+++ b/test/openai/helpers/response_stream_isolation_test.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResponseStreamIsolationTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_retained_wire_events_do_not_change_as_snapshots_accumulate
+    stub_stream(stream_events)
+
+    stream = @client.responses.stream(model: "test", input: "synthetic")
+    events = stream.to_a
+
+    created = events.fetch(0)
+    added_message = events.fetch(1)
+    added_part = events.fetch(2)
+    text_delta = events.fetch(3)
+    added_function = events.fetch(4)
+    arguments_delta = events.fetch(5)
+
+    assert_empty(created.response.output)
+    assert_empty(added_message.item.content)
+    assert_equal("", added_part.part.text)
+    assert_equal("", added_function.item.arguments)
+
+    assert_equal("Hello", text_delta.snapshot)
+    assert_equal("{\"ok\":true}", arguments_delta.snapshot)
+    assert_equal("Hello", stream.get_output_text)
+    assert_equal(:completed, stream.get_final_response.status)
+  ensure
+    stream&.close
+  end
+
+  def test_accumulation_copy_preserves_nested_models_and_unknown_hashes
+    created = coerce_event(
+      type: "response.created",
+      sequence_number: 0,
+      response: response(output: [message_item(content: [part], extension: {nested: ["kept"]})])
+    )
+    state = OpenAI::Helpers::Streaming::ResponseStreamState.new(text_format: nil)
+
+    state.handle_event(created)
+    snapshot = state.instance_variable_get(:@current_snapshot)
+
+    assert_instance_of(OpenAI::Models::Responses::ResponseOutputMessage, snapshot.output.fetch(0))
+    assert_instance_of(OpenAI::Models::Responses::ResponseOutputText, snapshot.output.fetch(0).content.fetch(0))
+    assert_equal({nested: ["kept"]}, snapshot.output.fetch(0)[:extension])
+    refute_same(created.response.output, snapshot.output)
+    refute_same(created.response.output.fetch(0).content, snapshot.output.fetch(0).content)
+    refute_same(created.response.output.fetch(0)[:extension], snapshot.output.fetch(0)[:extension])
+  end
+
+  def test_unknown_union_fallbacks_remain_raw_and_isolated
+    item = {type: "future_tool", id: "item_future", opaque: {items: [1]}}
+    item_event = OpenAI::Models::Responses::ResponseOutputItemAddedEvent.new(
+      item: item,
+      output_index: 1,
+      sequence_number: 1
+    )
+    state = state_after_created(response(output: [message_item]))
+
+    state.handle_event(item_event)
+    snapshot_item = current_snapshot(state).output.fetch(1)
+
+    assert_equal(item, snapshot_item)
+    assert_instance_of(Hash, snapshot_item)
+    refute_same(item_event.item, snapshot_item)
+    refute_same(item_event.item.fetch(:opaque), snapshot_item.fetch(:opaque))
+
+    content = {type: "future_part", opaque: {items: [2]}}
+    content_event = OpenAI::Models::Responses::ResponseContentPartAddedEvent.new(
+      content_index: 0,
+      item_id: "msg_synthetic",
+      output_index: 0,
+      part: content,
+      sequence_number: 1
+    )
+    state = state_after_created(response(output: [message_item]))
+
+    state.handle_event(content_event)
+    snapshot_content = current_snapshot(state).output.fetch(0).content.fetch(0)
+
+    assert_equal(content, snapshot_content)
+    assert_instance_of(Hash, snapshot_content)
+    refute_same(content_event.part, snapshot_content)
+    refute_same(content_event.part.fetch(:opaque), snapshot_content.fetch(:opaque))
+  end
+
+  private
+
+  def coerce_event(event)
+    OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::Responses::ResponseStreamEvent, event)
+  end
+
+  def state_after_created(response)
+    state = OpenAI::Helpers::Streaming::ResponseStreamState.new(text_format: nil)
+    state.handle_event(coerce_event(type: "response.created", sequence_number: 0, response: response))
+    state
+  end
+
+  def current_snapshot(state)
+    state.instance_variable_get(:@current_snapshot)
+  end
+
+  def stub_stream(events)
+    body = events
+      .map do |event|
+        "event: #{event.fetch(:type)}\ndata: #{JSON.generate(event)}\n\n"
+      end
+      .join
+
+    stub_request(:post, "http://localhost/responses").to_return(
+      status: 200,
+      headers: {"Content-Type" => "text/event-stream"},
+      body: body
+    )
+  end
+
+  def stream_events
+    [
+      {type: "response.created", sequence_number: 0, response: response},
+      {type: "response.output_item.added", sequence_number: 1, output_index: 0, item: message_item},
+      {
+        type: "response.content_part.added",
+        sequence_number: 2,
+        item_id: "msg_synthetic",
+        output_index: 0,
+        content_index: 0,
+        part: part
+      },
+      {
+        type: "response.output_text.delta",
+        sequence_number: 3,
+        item_id: "msg_synthetic",
+        output_index: 0,
+        content_index: 0,
+        delta: "Hello"
+      },
+      {type: "response.output_item.added", sequence_number: 4, output_index: 1, item: function_call},
+      {
+        type: "response.function_call_arguments.delta",
+        sequence_number: 5,
+        item_id: "fc_synthetic",
+        output_index: 1,
+        delta: "{\"ok\":true}"
+      },
+      {
+        type: "response.completed",
+        sequence_number: 6,
+        response: response(
+          status: "completed",
+          output: [
+            message_item(status: "completed", content: [part(text: "Hello")]),
+            function_call(arguments: "{\"ok\":true}")
+          ]
+        )
+      }
+    ]
+  end
+
+  def response(status: "in_progress", output: [])
+    {id: "resp_synthetic", object: "response", status: status, model: "test", output: output}
+  end
+
+  def message_item(status: "in_progress", content: [], extension: nil)
+    value = {
+      id: "msg_synthetic",
+      type: "message",
+      role: "assistant",
+      status: status,
+      content: content
+    }
+    value[:extension] = extension if extension
+    value
+  end
+
+  def part(text: "")
+    {type: "output_text", text: text, annotations: [], logprobs: []}
+  end
+
+  def function_call(arguments: "")
+    {
+      id: "fc_synthetic",
+      type: "function_call",
+      name: "synthetic",
+      call_id: "call_synthetic",
+      arguments: arguments
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a Responses streaming helper aliasing bug: events yielded by `client.responses.stream` could later appear to change as subsequent deltas were accumulated. The helper now isolates only values entering its mutable snapshot state, so retained raw events keep their wire values while text/tool-argument snapshots and final response helpers remain correct.

## Trigger and affected callers

This affects callers that retain events from the public Responses helper stream and inspect them after consuming later events. In the deterministic fixture below, the created response starts with no output, an added text part starts empty, and a later delta supplies `Hello`. The comments in this public-API example describe that fixture after the fix, not guaranteed values from a live request:

```ruby
require "openai"

client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
retained = []

stream = client.responses.stream(model: "gpt-4.1", input: "Say hello")
stream.each { |event| retained << event }

created = retained.find { |event| event.type == :"response.created" }
added_part = retained.find { |event| event.type == :"response.content_part.added" }

# These continue to represent the original wire events.
created.response.output # => []
added_part.part.text  # => ""

# Accumulated helper state remains available separately.
stream.get_output_text # => "Hello"
```

The same aliasing affected a retained `response.output_item.added` message's `content` array and a retained added function call's `arguments` string.

## Deterministic reproduction

The regression uses synthetic, network-disabled WebMock SSE fixtures; it is not a live API observation.

Before:

```json
{
  "created_output_count": [0, 2],
  "added_message_content_count": [0, 1],
  "added_part_text": ["", "Hello"],
  "added_function_arguments": ["", "{\"ok\":true}"],
  "final_text": "Hello",
  "text_delta_snapshot": "Hello",
  "argument_delta_snapshot": "{\"ok\":true}"
}
```

After:

```json
{
  "created_output_count": [0, 0],
  "added_message_content_count": [0, 0],
  "added_part_text": ["", ""],
  "added_function_arguments": ["", ""],
  "final_text": "Hello",
  "text_delta_snapshot": "Hello",
  "argument_delta_snapshot": "{\"ok\":true}"
}
```

Potential impact is limited but user-visible: applications that archive, audit, compare, or route retained helper-stream events can observe values belonging to later accumulated state rather than the event originally yielded. No incident frequency, billing impact, or live-service behavior is claimed.

## Root cause and fix

`ResponseStreamState` intended to isolate the created response, but coercing an already-typed model returns that same object. The accumulator also appended `event.item` and `event.part` directly, then later mutated the shared arrays and fields while building delta snapshots.

The fix stays at the helper boundary:

- isolate the created response, added output item, and added content part before they enter mutable snapshot state;
- use the existing recursive raw model representation to create fresh containers;
- re-coerce actual models through their concrete model class;
- preserve unmatched union fallbacks as raw recursively copied Hash/Array values.

This copies only ingress values, not the growing snapshot on every delta. It adds allocations for each created response, added item, and added part while keeping delta accumulation incremental; no payload limit or per-delta full copy is introduced.

## Compatibility, ownership, and non-goals

Only handwritten helper code and one focused test change. No generated models/resources, shared converter/runtime, signatures, dependencies, public API, transport, decoder, structured-output parser, WebSocket, or Realtime code changes.

Raw stream behavior, pass-through events, resume/start-after handling, existing unknown fields/union fallbacks, text and argument delta snapshots, `get_output_text`, and `get_final_response` remain compatible.

Non-goals:

- protecting against arbitrary caller mutations;
- adding immutable events or a copying API;
- changing final-response parsing or stream semantics;
- redesigning generic coercion/cloning;
- adding payload limits or copying the complete snapshot per delta;
- unrelated cleanup or baseline test fixes.

## Verification

- Focused regression: 3 runs, 24 assertions, 0 failures.
- Existing Responses streaming tests: 33 runs, 122 assertions, 0 failures.
- Unknown/resume stream tests: 13 runs, 96 assertions, 0 failures.
- All helper tests: 79 runs, 582 assertions, 0 failures.
- `rake lint`: passed; RuboCop, formatter, directive validation, RBS validation, and Sorbet all green.
- `rake typecheck`: passed.
- `git diff --check`: passed.
- Public committed-candidate custom-code budget: passed against fresh base `7b880d86007e8640c53de057cae72a22ebe7bb31` and candidate `bddaac26c734045d3bf974f665a95aae18469602`; `+2793 / -270 = 3063` custom lines against limit `4000`, with `937` lines of headroom.

The repository-wide `rake test` completed 1,534 runs and 13,750 assertions with two unrelated failures: the known macOS `/var` versus `/private/var` FastFormat baseline mismatch, and a polling-deadline float edge that passed immediately in isolation. Neither affected path overlaps this change.

## Security assessment

This is a narrow in-memory data-isolation correction at an existing deserialization/accumulation boundary. It adds no network, authentication, file, logging, dependency, secret-handling, or dynamic-execution behavior. Synthetic fixtures use fake credentials. Unknown raw fallback payloads are copied without interpretation. No credible vulnerability was identified.

Because the change touches deserialization-boundary behavior, request `@openai/sdks-team` review when publishing.
