### PR TITLE
examples: preserve resume cursor across unsequenced stream events

### DIFF
--- a/examples/responses/streaming_previous_response.rb
+++ b/examples/responses/streaming_previous_response.rb
@@ -21,9 +21,11 @@ begin
 
   events = []
   response_id = ""
+  last_sequence_number = nil
 
   stream.each do |event|
     events << event
+    last_sequence_number = event.sequence_number unless event.sequence_number.nil?
     puts("Event from initial stream: #{event.type} (seq: #{event.sequence_number})")
     case event
 
@@ -41,10 +43,11 @@ begin
 
   abort("The initial stream completed without events") if events.empty?
   abort("The initial stream did not include a response ID") if response_id.empty?
+  abort("The initial stream did not include a resumable sequence number") if last_sequence_number.nil?
 
   puts("Collected #{events.length} events")
   puts("Response ID: #{response_id}")
-  puts("Last event sequence number: #{events.last.sequence_number}.\n")
+  puts("Last resumable sequence number: #{last_sequence_number}.\n")
 
   # Give the background response some time to process more events.
   puts("Waiting a moment for the background response to progress...\n")
@@ -52,11 +55,11 @@ begin
 
   # Request 2: Resume the stream using the captured response_id.
   puts
-  puts("Resuming stream from sequence #{events.last.sequence_number}...")
+  puts("Resuming stream from sequence #{last_sequence_number}...")
 
   resumed_stream = client.responses.stream(
     response_id: response_id,
-    starting_after: events.last.sequence_number
+    starting_after: last_sequence_number
   )
 
   resumed_events = []
@@ -77,14 +80,15 @@ begin
   # Show that we properly resumed from where we left off.
   abort("The resumed stream completed without events") if resumed_events.empty?
 
-  first_resumed_event = resumed_events.first
-  last_initial_event = events.last
-  unless first_resumed_event.sequence_number > last_initial_event.sequence_number
+  first_resumed_event = resumed_events.find { |event| !event.sequence_number.nil? }
+  abort("The resumed stream did not include an event with a sequence number") if first_resumed_event.nil?
+
+  unless first_resumed_event.sequence_number > last_sequence_number
     abort("The resumed stream repeated an event from the initial stream")
   end
 
   puts("First resumed event sequence: #{first_resumed_event.sequence_number}")
-  puts("Verified it is greater than the last initial event: #{last_initial_event.sequence_number}")
+  puts("Verified it is greater than the last usable initial sequence: #{last_sequence_number}")
 end
 
 begin
@@ -110,9 +114,11 @@ begin
 
   events = []
   response_id = ""
+  last_sequence_number = nil
 
   stream.each do |event|
     events << event
+    last_sequence_number = event.sequence_number unless event.sequence_number.nil?
 
     case event
     when OpenAI::Models::Responses::ResponseCreatedEvent
@@ -126,16 +132,19 @@ begin
 
   abort("The structured initial stream completed without events") if events.empty?
   abort("The structured initial stream did not include a response ID") if response_id.empty?
+  if last_sequence_number.nil?
+    abort("The structured initial stream did not include a resumable sequence number")
+  end
 
   puts("Waiting for the background response to complete...\n")
   sleep(3)
 
   puts
-  puts("Resuming stream from sequence #{events.last.sequence_number}...")
+  puts("Resuming stream from sequence #{last_sequence_number}...")
 
   resumed_stream = client.responses.stream(
     response_id: response_id,
-    starting_after: events.last.sequence_number,
+    starting_after: last_sequence_number,
     # NOTE: You must pass the structured output format when resuming to access parsed
     # outputs in the resumed stream.
     text: MathResponse

--- a/test/openai/streaming_previous_response_example_test.rb
+++ b/test/openai/streaming_previous_response_example_test.rb
@@ -107,8 +107,84 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
     assert_empty(stderr)
     assert_equal(4, requests.length)
     assert_equal([3, 3], @sleeps)
-    assert_includes(stdout, "Verified it is greater than the last initial event: 1")
+    assert_includes(stdout, "Verified it is greater than the last usable initial sequence: 1")
     assert_includes(stdout, "-29/8")
+  end
+
+  def test_both_streams_resume_after_last_usable_sequence_with_unknown_events
+    structured_stream = Minitest::Mock.new
+    final_response = Minitest::Mock.new
+    output_message = Minitest::Mock.new
+    output_content = Minitest::Mock.new
+    @mocks.push(structured_stream, final_response, output_message, output_content)
+
+    structured_stream.expect(:each, nil) do |&callback|
+      callback.call(unknown_event)
+      callback.call(in_progress_event(sequence_number: 10))
+      true
+    end
+
+    structured_stream.expect(:get_final_response, final_response)
+    final_response.expect(:output, [output_message])
+    output_message.expect(:content, [output_content])
+
+    streams = [
+      {
+        stream: [
+          created_event(id: "resp_plain", sequence_number: 1),
+          unknown_event(sequence_number: 4),
+          unknown_event
+        ]
+      },
+      {
+        stream: [unknown_event, in_progress_event(sequence_number: 5)],
+        check: lambda do |params|
+          assert_equal("resp_plain", params.fetch(:response_id))
+          assert_equal(4, params.fetch(:starting_after))
+        end
+      },
+      {
+        stream: [
+          created_event(id: "resp_structured", sequence_number: 7),
+          unknown_event(sequence_number: 9),
+          unknown_event
+        ]
+      },
+      {
+        stream: structured_stream,
+        check: lambda do |params|
+          assert_equal("resp_structured", params.fetch(:response_id))
+          assert_equal(9, params.fetch(:starting_after))
+
+          math_response = params.fetch(:text).new(steps: [], final_answer: "-29/8")
+          output_content.expect(:parsed, math_response)
+        end
+      }
+    ]
+
+    stdout, stderr, error, requests = run_example(streams)
+
+    assert_nil(error)
+    assert_empty(stderr)
+    assert_equal(4, requests.length)
+    assert_equal([3, 3], @sleeps)
+    assert_includes(stdout, "Event from resumed stream: future.unmodeled.event (seq: )")
+    assert_includes(stdout, "First resumed event sequence: 5")
+    assert_includes(stdout, "Verified it is greater than the last usable initial sequence: 4")
+    assert_includes(stdout, "-29/8")
+  end
+
+  def test_plain_stream_fails_clearly_when_resumed_events_have_no_sequence
+    streams = [
+      {stream: [created_event(id: "resp_plain", sequence_number: 1)]},
+      {stream: [unknown_event]}
+    ]
+
+    _stdout, stderr, error, requests = run_example(streams)
+
+    assert_failure(error, stderr, "The resumed stream did not include an event with a sequence number")
+    assert_equal(2, requests.length)
+    assert_equal([3], @sleeps)
   end
 
   private
@@ -162,6 +238,12 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
 
   def in_progress_event(sequence_number:)
     OpenAI::Models::Responses::ResponseInProgressEvent.new(response: {}, sequence_number: sequence_number)
+  end
+
+  def unknown_event(sequence_number: nil)
+    data = {type: "future.unmodeled.event"}
+    data[:sequence_number] = sequence_number unless sequence_number.nil?
+    OpenAI::Streaming::UnknownStreamEvent.new(data: data)
   end
 
   def assert_failure(error, stderr, message)


### PR DESCRIPTION
## Summary

Fix the Responses streaming resume example so it keeps the last usable sequence number when an otherwise supported unknown stream event does not carry a sequence number.

The SDK intentionally preserves unknown Responses events, including unsequenced ones. The example previously used the final initial event as its cursor and compared the first resumed event directly against it. That made the sample send an empty `starting_after` value when a trailing unknown event was unsequenced, or raise while comparing `nil` when the first resumed event was unsequenced.

## User-visible trigger and impact

This affects users following `examples/responses/streaming_previous_response.rb` when the stream contains a future, unmodeled event without `sequence_number`:

```sh
bundle exec ruby examples/responses/streaming_previous_response.rb
```

The arrays below are synthetic fixture data illustrating the trigger; they are not helper APIs exposed by the SDK:

```ruby
initial_events = [
  response_created(sequence_number: 1),
  unknown_event(sequence_number: 4),
  unknown_event(sequence_number: nil)
]
```

Before this change, the sample used `events.last.sequence_number`, so the resume request could effectively become:

```ruby
client.responses.stream(response_id: response_id, starting_after: nil)
```

The same issue appeared during plain-stream verification if the resumed stream began with an observable unsequenced unknown event:

```ruby
resumed_events = [
  unknown_event(sequence_number: nil),
  response_in_progress(sequence_number: 5)
]
```

The example tried to compare `nil > 4` instead of validating the first resumed event with a usable sequence.

## Fix

Track the last non-`nil` sequence number while collecting each initial stream, in both the plain and structured-output sections:

```ruby
last_sequence_number = nil

stream.each do |event|
  last_sequence_number = event.sequence_number unless event.sequence_number.nil?
end

abort("The initial stream did not include a resumable sequence number") if last_sequence_number.nil?

resumed_stream = client.responses.stream(
  response_id: response_id,
  starting_after: last_sequence_number
)
```

The essential retained-cursor update is:

```ruby
last_sequence_number = event.sequence_number unless event.sequence_number.nil?
```

Use that retained cursor for `starting_after`, and fail clearly before resuming if no usable cursor exists. In the plain section, keep all resumed events observable but compare the first resumed event whose `sequence_number` is present; fail clearly if the bounded resumed collection has no such event.

The output now calls this value the “last resumable sequence number” and verifies it against the “last usable initial sequence,” matching the repaired behavior.

## Why this is the smallest fix

This is a consumer-example correction at the point where the example chooses and validates its cursor. It does not change SDK decoding, helper filtering, unknown-event passthrough, resource behavior, public APIs, or sequence coercion. Sequenced unknown events remain eligible cursors; unsequenced unknown events remain observable.

## Regression coverage

The focused test loads and executes the actual example with deterministic synthetic streams:

- Plain initial stream includes a sequenced unknown event followed by an unsequenced unknown event and verifies resume uses the earlier usable cursor.
- Plain resumed stream begins with an unsequenced unknown event, verifies that exact resumed event is printed, then verifies comparison uses the next sequenced event.
- Structured initial stream independently exercises the same sequenced-then-unsequenced unknown-event cursor behavior and preserves final parsed `MathResponse` output.
- A no-sequenced-resumed-event case now fails with a clear message instead of calling `>` on `nil`.
- Existing empty-stream, missing/empty response ID, ordinary resume, and parsed structured-output checks remain in place. The example's existing collection bounds are unchanged.

## Synthetic before/after evidence

Before:

- Trailing unsequenced initial unknown event sent an empty `starting_after`, then raised `ArgumentError` comparing an integer with `nil`.
- Leading unsequenced resumed unknown event kept the cursor but raised `NoMethodError` for `nil.>`.

After:

- The same trailing initial case resumes with the last usable cursor (`3` in the synthetic proof).
- The same leading resumed case retains cursor `4` and compares the later usable resumed sequence.
- The focused actual-example test passes with 9 runs and 74 assertions.

## Compatibility and non-goals

No public API or SDK runtime behavior changes. This does not alter parser/decoder/helper/transport/resource/model behavior, unknown-event filtering, replay guarantees, ordering semantics, generated code, dependencies, or other examples. It does not claim unknown-event handling in the SDK is broken; the SDK’s passthrough behavior is intentional.

## Verification

```
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/streaming_previous_response_example_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/unknown_response_stream_event_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/responses/streaming_test.rb
mise exec ruby@4.0.6 -- bundle exec rake test:examples:inventory
mise exec ruby@4.0.6 -- bundle exec rake lint
mise exec ruby@4.0.6 -- bundle exec rake format
git diff --check
```

Results:

- Focused example test: 9 runs, 74 assertions, all passing.
- Unknown Responses stream events: 13 runs, 96 assertions, all passing.
- Responses streaming: 33 runs, 122 assertions, all passing.
- Example inventory: 24/35 exercised, 11 explicitly excluded.
- Lint/type/format checks on the final rebased head: RBS validation, directive validation, Sorbet examples typecheck, rubyfmt, and RuboCop over 2,798 files all passing.
- Full `rake test` on the final rebased head: 1,550 runs, 13,863 assertions, 0 failures, 0 errors, 1 existing skip. An earlier pre-rebase run had an unrelated macOS formatter failure and a transient mTLS timeout; neither reproduced in the final full run. No live API example suite was run.
- Hosted CI on the final head passed, including Ruby 3.3/3.4/4.0, Bedrock Ruby 4.0, package, lint, type checks, CodeQL, and Castiron baseline/budget checks.
