### PR TITLE
fix: raise finish errors for initial chat stream chunks

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -133,6 +133,12 @@ module OpenAI
               index_choice_snapshot!(choice_snapshot)
             end
 
+            @current_completion_snapshot = completion_snapshot
+
+            chunk.choices.each do |choice|
+              handle_finish_reason(choice.finish_reason, completion_snapshot) if choice.finish_reason
+            end
+
             return completion_snapshot
           end
 

--- a/test/openai/helpers/chat_stream_initial_finish_test.rb
+++ b/test/openai/helpers/chat_stream_initial_finish_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamInitialFinishTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class StructuredResult < OpenAI::BaseModel
+    required :value, Integer
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_parseable_initial_terminal_chunks_raise_the_existing_finish_errors
+    parseable_options.each do |options|
+      finish_errors.each do |finish_reason, error_class|
+        [false, true].each do |prefix|
+          stream = stream_for(
+            chunks: terminal_chunks(finish_reason, prefix: prefix),
+            **options
+          )
+
+          error = assert_raises(error_class) { stream.to_a }
+          snapshot = stream.current_completion_snapshot
+
+          assert_equal(finish_reason, snapshot.choices.first.finish_reason)
+          assert_raises(error_class) { stream.get_final_completion }
+
+          next unless finish_reason == :length
+
+          assert_same(error.completion, snapshot)
+          choice = error.completion.choices.first
+          assert_equal(:length, choice.finish_reason)
+          assert_equal(:assistant, choice.message.role)
+          assert_equal("{\"value\":", choice.message.content)
+        end
+      end
+    end
+  end
+
+  def test_plain_chat_terminal_chunks_keep_existing_non_raising_behavior
+    finish_errors.each_key do |finish_reason|
+      [false, true].each do |prefix|
+        stream = stream_for(chunks: terminal_chunks(finish_reason, prefix: prefix))
+
+        stream.to_a
+
+        assert_equal(finish_reason, stream.get_final_completion.choices.first.finish_reason)
+      end
+    end
+  end
+
+  def test_successful_initial_and_prefixed_structured_streams_still_parse
+    [false, true].each do |prefix|
+      chunks = []
+      chunks << choice(delta: {role: "assistant"}) if prefix
+      chunks <<
+        choice(
+          delta: {role: "assistant", content: "{\"value\":1}"},
+          finish_reason: "stop"
+        )
+      stream = stream_for(chunks: chunks, response_format: StructuredResult)
+
+      stream.to_a
+      completion = stream.get_final_completion
+
+      assert_equal("{\"value\":1}", completion.choices.first.message.content)
+      assert_equal(1, completion.choices.first.message.parsed.value)
+    end
+  end
+
+  private
+
+  def parseable_options
+    [
+      {response_format: StructuredResult},
+      {
+        tools: [
+          {
+            type: :function,
+            function: {
+              name: "synthetic",
+              strict: false,
+              parameters: {type: :object, properties: {}}
+            }
+          }
+        ]
+      }
+    ]
+  end
+
+  def finish_errors
+    {
+      length: OpenAI::LengthFinishReasonError,
+      content_filter: OpenAI::ContentFilterFinishReasonError
+    }
+  end
+
+  def terminal_chunks(finish_reason, prefix:)
+    chunks = []
+    chunks << choice(delta: {role: "assistant"}) if prefix
+    chunks <<
+      choice(
+        delta: {role: "assistant", content: "{\"value\":"},
+        finish_reason: finish_reason.to_s
+      )
+    chunks
+  end
+
+  def stream_for(chunks:, **options)
+    WebMock.reset!
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: sse(chunks)
+      )
+
+    @client.chat.completions.stream(
+      messages: [{content: "Synthetic", role: :user}],
+      model: "gpt-4o-mini",
+      **options
+    )
+  end
+
+  def sse(choices)
+    chunks = choices.map do |choice|
+      payload = {
+        id: "chatcmpl-initial-finish",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt-4o-mini",
+        choices: [choice]
+      }
+      "data: #{JSON.generate(payload)}\n\n"
+    end
+
+    chunks.join + "data: [DONE]\n\n"
+  end
+
+  def choice(delta:, finish_reason: nil)
+    {index: 0, delta: delta, finish_reason: finish_reason}
+  end
+end


### PR DESCRIPTION
## Summary

Fix `client.chat.completions.stream` so a structured-output or tool-enabled chat stream raises the existing finish-reason errors when its first SSE chunk is already terminal.

Previously, an initial chunk with `finish_reason: "length"` or `"content_filter"` could be yielded without raising, while the equivalent terminal chunk after a role-only prefix raised `OpenAI::LengthFinishReasonError` or `OpenAI::ContentFilterFinishReasonError`. The behavior depended on chunk framing rather than the completion result.

## Problem and affected users

Applications using the public chat streaming helper with a structured `response_format` or any supplied tool could miss an incomplete or filtered completion when the provider emitted the terminal choice in the first chunk. Event-only consumers could miss the helper's established termination signal because iteration completed without the exception. Callers that always invoke `get_final_completion` retained the existing finalization-time check. The same logical result already raised during iteration if a role-only chunk preceded it.

This is a deterministic helper inconsistency, not a claim about how frequently providers emit either chunk shape.

## Public API usage illustration

```ruby
# frozen_string_literal: true

require "openai"

class Result < OpenAI::BaseModel
  required :value, Integer
end

client = OpenAI::Client.new
stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Return structured JSON"}],
  response_format: Result
)

stream.each { |_event| nil }
```

## Synthetic deterministic fixture shape

The focused regression stubs `POST /chat/completions` with WebMock and a synthetic SSE stream whose first choice is terminal:

```ruby
{
  index: 0,
  delta: {role: "assistant", content: '{"value":'},
  finish_reason: "length"
}
```

Run it with:

```sh
mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/helpers/chat_stream_initial_finish_test.rb
```

Before this change, that synthetic initial-terminal stream produced no iteration error. Adding a preceding role-only chunk produced `OpenAI::LengthFinishReasonError`. The same mismatch occurred for `content_filter` and for supplied non-strict tools.

After this change, both initial and role-prefixed terminal chunks raise the same existing error. Plain chat without a response format or tools remains non-raising.

## Root cause and fix

The initial-snapshot branch in `ChatCompletionStreamState#accumulate_chunk` returned before the existing `handle_finish_reason` path used by later chunks. The fix retains the already-built initial snapshot and routes the initial choices through that canonical handler before returning.

This preserves the exact existing `parseable_input?` contract:

```ruby
@response_format || @input_tools.any?
```

It also preserves `LengthFinishReasonError#completion` and the stream's current completion snapshot when the initial chunk raises.

## Compatibility and non-goals

No public API, exception class, strictness policy, parser, JSON handling, tool-argument parsing, tool done-event ordering, metadata accumulation, index handling, transport, stream lifecycle, or raw streaming behavior changes. Successful streams and plain chat behavior remain unchanged.

The production edit is in the handwritten helpers boundary; generated resources, models, runtime files, and signatures are untouched.

## Regression coverage

The new public-entrypoint WebMock SSE regression covers:

- Initial and role-prefixed terminal chunks.
- `length` and `content_filter`.
- Structured `response_format`.
- Supplied tools with `strict: false`, preserving the existing any-tool gate.
- Plain chat without response format or tools.
- Successful initial and prefixed structured streams.
- Retained snapshot and `LengthFinishReasonError#completion` data.

## Verification

- Focused regression: 3 runs, 48 assertions, 0 failures, 0 errors.
- Adjacent chat stream/parser/isolation suites: 25 runs, 210 assertions, 0 failures, 0 errors.
- Full non-Bedrock suite: 1,551 runs, 13,889 assertions, 0 failures, 0 errors, 1 skip.
- Full lint/type/format gate: RuboCop inspected 2,799 files with no offenses; Sorbet and RBS validation passed.
- `git diff --check` passed.

Tests use synthetic SSE, WebMock, and fake credentials; no live API request is required.
