### PR TITLE
fix: preserve initial chat stream system fingerprint

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -534,7 +534,7 @@ module OpenAI
               model: data[:model],
               choices: choices,
               usage: data[:usage],
-              system_fingerprint: nil,
+              system_fingerprint: data[:system_fingerprint],
               service_tier: data[:service_tier]
             }
           )

--- a/test/openai/helpers/chat_stream_fingerprint_test.rb
+++ b/test/openai/helpers/chat_stream_fingerprint_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamFingerprintTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_system_fingerprint_accumulates_without_changing_stream_output
+    cases = [
+      ["fp_initial", nil, "fp_initial"],
+      [nil, "fp_later", "fp_later"],
+      ["fp_initial", "fp_later", "fp_later"],
+      [nil, nil, nil]
+    ]
+
+    cases.each do |initial_fingerprint, later_fingerprint, expected_fingerprint|
+      stream = stream_for(initial_fingerprint:, later_fingerprint:)
+      event_types = []
+      raw_fingerprints = []
+      snapshot_fingerprints = []
+      stream.each do |event|
+        event_types << event.type
+        next unless event.type == :chunk
+
+        raw_fingerprints << event.chunk.system_fingerprint
+        snapshot_fingerprints << event.snapshot.system_fingerprint
+      end
+
+      completion = stream.get_final_completion
+
+      assert_equal(
+        [initial_fingerprint, later_fingerprint, nil],
+        raw_fingerprints
+      )
+      assert_equal(
+        [initial_fingerprint, expected_fingerprint, expected_fingerprint],
+        snapshot_fingerprints
+      )
+      if expected_fingerprint.nil?
+        assert_nil(completion.system_fingerprint)
+      else
+        assert_equal(expected_fingerprint, completion.system_fingerprint)
+      end
+
+      assert_equal("Hello world", stream.get_output_text)
+      assert_equal([0], completion.choices.map(&:index))
+      assert_equal("Hello world", completion.choices.first.message.content)
+      assert_equal(2, completion.usage.total_tokens)
+      assert_equal(
+        [:chunk, :"content.delta", :chunk, :"content.delta", :"content.done", :chunk],
+        event_types
+      )
+    end
+  end
+
+  private
+
+  def stream_for(initial_fingerprint:, later_fingerprint:)
+    WebMock.reset!
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: sse(initial_fingerprint:, later_fingerprint:)
+      )
+
+    @client.chat.completions.stream(
+      messages: [{content: "Synthetic", role: :user}],
+      model: "gpt-4o-mini"
+    )
+  end
+
+  def sse(initial_fingerprint:, later_fingerprint:)
+    chunks = [
+      chunk(
+        system_fingerprint: initial_fingerprint,
+        choices: [choice(delta: {role: "assistant", content: "Hello"})]
+      ),
+      chunk(
+        system_fingerprint: later_fingerprint,
+        choices: [choice(delta: {content: " world"}, finish_reason: "stop")]
+      ),
+      chunk(
+        system_fingerprint: nil,
+        choices: [],
+        usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2}
+      )
+    ]
+
+    chunks.map { |payload| "data: #{JSON.generate(payload)}\n\n" }.join + "data: [DONE]\n\n"
+  end
+
+  def chunk(system_fingerprint:, choices:, usage: nil)
+    {
+      id: "chatcmpl-fingerprint",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      system_fingerprint: system_fingerprint,
+      choices: choices,
+      usage: usage
+    }
+  end
+
+  def choice(delta:, finish_reason: nil)
+    {index: 0, delta: delta, finish_reason: finish_reason}
+  end
+end


### PR DESCRIPTION
## Summary

Preserve a `system_fingerprint` supplied on the first Chat Completions streaming chunk in the helper's current snapshot and final completion.

The public streaming helper previously exposed the first fingerprint on the raw chunk but initialized the accumulated completion with `nil`. Users inspecting `event.snapshot.system_fingerprint` or `stream.get_final_completion.system_fingerprint` therefore lost valid server metadata whenever the fingerprint appeared only on the first chunk, which is a normal streamed-response shape.

## Public SDK behavior

```ruby
stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Hello"}]
)

stream.each do |event|
  next unless event.type == :chunk

  puts event.snapshot.system_fingerprint
end

completion = stream.get_final_completion
puts completion.system_fingerprint
```

When the server sends `system_fingerprint: "fp_initial"` on the first chunk and `nil` afterward, both the delivered snapshot progression and final completion now retain `"fp_initial"`.

## Deterministic synthetic evidence

Before:

```text
raw:       ["fp_initial", nil, nil]
snapshots: [nil, nil, nil]
final:     nil
```

After:

```text
raw:       ["fp_initial", nil, nil]
snapshots: ["fp_initial", "fp_initial", "fp_initial"]
final:     "fp_initial"
```

The focused offline regression also verifies that a later non-`nil` fingerprint still replaces the initial value, a later `nil` does not erase a value, and an initial `nil` remains `nil` unless a later chunk supplies a fingerprint. It checks that raw chunk values, text (`"Hello world"`), usage, choice index, and event sequence remain unchanged.

## Root cause and fix

`convert_initial_chunk_into_snapshot` hardcoded `system_fingerprint: nil` while later chunk accumulation already assigned only non-`nil` fingerprints. The fix initializes the existing snapshot field from `data[:system_fingerprint]`, allowing the existing later-chunk rule to preserve or replace it correctly.

## Compatibility and boundaries

This is a backward-compatible bug fix. It does not change the public API, parsing or strictness, tools, event construction, snapshot lifetime/isolation, transport lifecycle, other metadata fields, dependencies, or generated models/resources/signatures. The implementation stays in the handwritten helper boundary and adds one focused synthetic WebMock test.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_fingerprint_test.rb` — 1 run, 32 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_stream_test.rb` — 10 runs, 47 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_initial_finish_test.rb` — 3 runs, 48 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/chat/completions/streaming_test.rb` — 22 runs, 107 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/chat/completions/streaming_snapshot_test.rb` — 15 runs, 73 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake test` — 1,554 runs, 13,943 assertions, 0 failures, 0 errors, 1 existing skip.
- `mise exec ruby@4.0.6 -- bundle exec rake format` — passed.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — passed; 2,800 files inspected with no offenses, plus format, RBS, directive, Sorbet, and type checks.
- Public committed-candidate custom-code budget — passed at 3,311/4,000 lines with 689 lines headroom.

## Limitations

No live API call was made; evidence uses deterministic synthetic SSE chunks through the public client streaming interface. No dedicated security review was required because the change does not touch a security-sensitive surface.
