### PR TITLE
fix: preserve nested array schema definitions

### DIFF
--- a/lib/openai/helpers/structured_output/array_of.rb
+++ b/lib/openai/helpers/structured_output/array_of.rb
@@ -24,10 +24,10 @@ module OpenAI
         # @return [Hash{Symbol=>Object}]
         def to_json_schema_inner(state:)
           OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.cache_def!(state, type: self) do
-            state.fetch(:path) << "[]"
+            new_state = {**state, path: [*state.fetch(:path), "[]"]}
             items = OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.to_json_schema_inner(
               item_type,
-              state: state
+              state: new_state
             )
             items = OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.to_nilable(items) if nilable?
             OpenAI::Helpers::StructuredOutput::JsonSchemaConverter.assoc_meta!(items, meta: @meta)

--- a/test/openai/helpers/structured_output_nested_array_refs_test.rb
+++ b/test/openai/helpers/structured_output_nested_array_refs_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::StructuredOutputNestedArrayRefsTest < Minitest::Test
+  Inner = OpenAI::ArrayOf[Integer]
+  Outer = OpenAI::ArrayOf[Inner]
+
+  class ReusedArrays < OpenAI::BaseModel
+    required :nested_one, Outer
+    required :nested_two, Outer
+    required :flat, Inner
+  end
+
+  def test_reused_nested_and_flat_arrays_keep_distinct_schema_dimensions
+    expected = {
+      :$defs => {
+        ".nested_one" => {
+          type: "array",
+          items: {:$ref => "#/$defs/.nested_one~1%5B%5D"}
+        },
+        ".nested_one/[]" => {
+          type: "array",
+          items: {type: "integer"}
+        }
+      },
+      :type => "object",
+      :properties => {
+        nested_one: {:$ref => "#/$defs/.nested_one"},
+        nested_two: {:$ref => "#/$defs/.nested_one"},
+        flat: {:$ref => "#/$defs/.nested_one~1%5B%5D"}
+      },
+      :required => %w[nested_one nested_two flat],
+      :additionalProperties => false
+    }
+
+    assert_equal(expected, ReusedArrays.to_json_schema)
+    assert_equal(expected, ReusedArrays.to_json_schema)
+  end
+end


### PR DESCRIPTION
## Summary

Fix structured-output JSON Schema generation when the same nested and flat `OpenAI::ArrayOf` instances are reused in one `OpenAI::BaseModel`.

Affected users are SDK callers who compose reusable array types for structured outputs, for example:

```ruby
class Payload < OpenAI::BaseModel
  Inner = OpenAI::ArrayOf[Integer]
  Outer = OpenAI::ArrayOf[Inner]

  required :nested_one, Outer
  required :nested_two, Outer
  required :flat, Inner
end

Payload.to_json_schema
```

Before this change, schema generation could give all three properties the same `$ref` and emit only one flat integer-array definition. That loses the nested dimension for `nested_one` and `nested_two`, so the schema no longer describes the Ruby model accurately.

The root cause was `ArrayOf#to_json_schema_inner` appending `"[]"` directly to the shared traversal `state[:path]`. When an outer array converted its inner array, the mutation leaked back into enclosing and sibling cache frames, allowing distinct reusable types to resolve under the same definition name.

The fix is intentionally narrow: `ArrayOf` now passes item conversion a copied state with a copied path containing the new `"[]"` segment. The existing shared definitions cache is preserved, while each array cache frame keeps the path that belongs to its own dimension.

## Deterministic synthetic before/after evidence

Before, the relevant schematic schema excerpt was:

```ruby
properties: {
  nested_one: {"$ref" => "#/$defs/.nested_one~1%5B%5D~1%5B%5D"},
  nested_two: {"$ref" => "#/$defs/.nested_one~1%5B%5D~1%5B%5D"},
  flat: {"$ref" => "#/$defs/.nested_one~1%5B%5D~1%5B%5D"}
},
"$defs" => {
  ".nested_one/[]/[]" => {type: "array", items: {type: "integer"}}
}
```

After, the same deterministic in-memory model produces this schematic schema excerpt:

```ruby
properties: {
  nested_one: {"$ref" => "#/$defs/.nested_one"},
  nested_two: {"$ref" => "#/$defs/.nested_one"},
  flat: {"$ref" => "#/$defs/.nested_one~1%5B%5D"}
},
"$defs" => {
  ".nested_one" => {
    type: "array",
    items: {"$ref" => "#/$defs/.nested_one~1%5B%5D"}
  },
  ".nested_one/[]" => {type: "array", items: {type: "integer"}}
}
```

This restores the concrete user impact: nested fields remain arrays of arrays, the flat field remains an array of integers, and all references resolve to definitions with the correct dimensions.

## Compatibility and boundaries

This is a backward-compatible bug fix. It does not change public API names, pointer encoding, nilability, metadata handling, primitive-array behavior, response parsing, Sorbet paths, generated code, dependencies, or schema limits. It does not redesign `JsonSchemaConverter`, `BaseModel`, `UnionOf`, or the cache algorithm.

## Verification

- Focused regression: `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_nested_array_refs_test.rb` — `1 runs, 2 assertions, 0 failures, 0 errors`.
- Existing structured-output suite: `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_test.rb` — `8 runs, 60 assertions, 0 failures, 0 errors`.
- Structured-output controls: constant and nullable-literal tests — `3 runs, 19 assertions` and `2 runs, 6 assertions`, both green.
- Packaging rerun: `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/gem_packaging_test.rb` — `2 runs, 34 assertions`, green.
- Polling rerun after an unrelated timing flake: `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/polling_helpers_test.rb` — `42 runs, 230 assertions`, green.
- Full suite: `mise exec ruby@4.0.6 -- bundle exec rake test` — `1554 runs, 13913 assertions, 0 failures, 0 errors, 1 skips`.
- Formatter: `mise exec ruby@4.0.6 -- bundle exec rake format` — green.
- Lint and typecheck: `mise exec ruby@4.0.6 -- bundle exec rake lint` — green; Sorbet, RBS validation, RuboCop, directives, and rubyfmt checks passed.
- Public committed-candidate custom-code budget: `3311 / 4000` custom lines, `689` lines headroom, green.

## Limitations

The full suite retains its existing single skipped test. During verification, one initial broad run saw a transient packaging error and the first fresh full-suite run saw an unrelated polling timing assertion exceed its threshold by `0.00000000001862645` seconds; the focused reruns and final serial full suite passed without code changes.
