### PR TITLE
fix: preserve string-tagged structured output models

### DIFF
--- a/lib/openai/helpers/structured_output/chat_completion_parser.rb
+++ b/lib/openai/helpers/structured_output/chat_completion_parser.rb
@@ -67,7 +67,10 @@ module OpenAI
               }
             )
           in {
-              response_format: {type: :json_schema, json_schema: OpenAI::StructuredOutput::JsonSchemaConverter => model}
+              response_format: {
+                  type: :json_schema | "json_schema",
+                  json_schema: OpenAI::StructuredOutput::JsonSchemaConverter => model
+                }
             }
             parsed.fetch(:response_format).update(
               json_schema: {
@@ -78,7 +81,7 @@ module OpenAI
             )
           in {
               response_format: {
-                  type: :json_schema,
+                  type: :json_schema | "json_schema",
                   json_schema: {schema: OpenAI::StructuredOutput::JsonSchemaConverter => model}
                 }
             }
@@ -124,7 +127,7 @@ module OpenAI
           return [] if tools.nil?
 
           tools.map do |tool|
-            next tool unless tool[:type] == :function
+            next tool unless [:function, "function"].include?(tool[:type])
 
             function_name = tool.dig(:function, :name)
             model = tool_models[function_name]

--- a/test/openai/helpers/chat_completion_parser_test.rb
+++ b/test/openai/helpers/chat_completion_parser_test.rb
@@ -18,17 +18,18 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
   class RecordingTransport < OpenAI::HTTPClient
     attr_reader :request
 
-    def initialize(response)
+    def initialize(response = nil, headers: {"content-type" => "application/json"}, **response_keywords)
       super()
-      @response = response
+      @response = response || response_keywords
+      @headers = headers
     end
 
     def execute(request)
       @request = request
       OpenAI::HTTPClient::Response.new(
         status: 200,
-        headers: {"content-type" => "application/json"},
-        body: JSON.generate(@response)
+        headers: @headers,
+        body: @response.is_a?(String) ? @response : JSON.generate(@response)
       )
     end
   end
@@ -44,6 +45,13 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
       {
         response_format: {
           type: :json_schema,
+          json_schema: {name: "explicit", strict: false, schema: TextModel}
+        }
+      },
+      {response_format: {type: "json_schema", json_schema: TextModel}},
+      {
+        response_format: {
+          type: "json_schema",
           json_schema: {name: "explicit", strict: false, schema: TextModel}
         }
       }
@@ -146,6 +154,121 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
     end
   end
 
+  def test_public_create_treats_string_json_schema_type_like_symbol
+    forms = [
+      [TextModel, "TextModel", true],
+      [{name: "result", strict: false, schema: TextModel}, "result", false]
+    ]
+
+    [:json_schema, "json_schema"].product(forms).each do |type, (json_schema, name, strict)|
+      transport = RecordingTransport.new(
+        id: "chatcmpl_test",
+        object: "chat.completion",
+        created: 0,
+        model: "test",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: {role: "assistant", content: JSON.generate(value: "hello")}
+          }
+        ]
+      )
+      client = OpenAI::Client.new(
+        api_key: "fake-key",
+        base_url: "http://example.test",
+        http_client: transport
+      )
+
+      completion = client.chat.completions.create(
+        model: "test",
+        messages: [{role: "user", content: "hi"}],
+        response_format: {
+          type: type,
+          json_schema: json_schema
+        }
+      )
+
+      request = JSON.parse(transport.request.body)
+      assert_equal("json_schema", request.dig("response_format", "type"))
+      assert_equal(name, request.dig("response_format", "json_schema", "name"))
+      assert_equal(strict, request.dig("response_format", "json_schema", "strict"))
+      assert_equal("object", request.dig("response_format", "json_schema", "schema", "type"))
+      assert_instance_of(TextModel, completion.choices.first.message.parsed)
+    end
+  end
+
+  def test_public_stream_treats_string_function_type_like_symbol
+    chunks = [
+      {
+        id: "chatcmpl_test",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "test",
+        choices: [{index: 0, delta: {role: "assistant"}, finish_reason: nil}]
+      },
+      {
+        id: "chatcmpl_test",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_test",
+                  type: "function",
+                  function: {name: "lookup", arguments: JSON.generate(argument: 7)}
+                }
+              ]
+            },
+            finish_reason: nil
+          }
+        ]
+      },
+      {
+        id: "chatcmpl_test",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "test",
+        choices: [{index: 0, delta: {}, finish_reason: "tool_calls"}]
+      }
+    ]
+    body = chunks.map { |chunk| "data: #{JSON.generate(chunk)}\n\n" }.join + "data: [DONE]\n\n"
+
+    [:function, "function"].each do |type|
+      transport = RecordingTransport.new(body, headers: {"content-type" => "text/event-stream"})
+      client = OpenAI::Client.new(
+        api_key: "fake-key",
+        base_url: "http://example.test",
+        http_client: transport
+      )
+      stream = client.chat.completions.stream(
+        model: "test",
+        messages: [{role: "user", content: "hi"}],
+        tools: [{type: type, function: {name: "lookup", strict: true, parameters: ToolModel}}]
+      )
+
+      request = JSON.parse(transport.request.body)
+      assert_equal("function", request.dig("tools", 0, "type"))
+      assert_equal("lookup", request.dig("tools", 0, "function", "name"))
+      assert_equal(true, request.dig("tools", 0, "function", "strict"))
+      assert_equal("object", request.dig("tools", 0, "function", "parameters", "type"))
+      done = stream.find do |event|
+        event.is_a?(OpenAI::Helpers::Streaming::ChatFunctionToolCallArgumentsDoneEvent)
+      end
+
+      assert_instance_of(ToolModel, done.parsed)
+      assert_equal(7, done.parsed.argument)
+      arguments = stream.get_final_completion.choices.first.message.tool_calls.first.function.parsed
+      assert_instance_of(ToolModel, arguments)
+      assert_equal(7, arguments.argument)
+    end
+  end
+
   def test_tool_conversion_preserves_names_and_input_identity
     [nil, "explicit"].each do |name|
       function = {parameters: ToolModel}
@@ -178,7 +301,7 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
     end
   end
 
-  def test_build_tools_only_copies_matching_symbol_function_tools
+  def test_build_tools_only_copies_matching_function_tools
     resource = OpenAI::Resources::Chat::Completions.allocate
     known = {type: :function, function: {name: "known"}}
     unknown = {type: :function, function: {name: "unknown"}}
@@ -193,9 +316,11 @@ class OpenAI::Test::ChatCompletionParserTest < Minitest::Test
     refute_same(known, mapped.first)
     assert_equal(known.merge(model: ToolModel), mapped.first)
     refute(known.key?(:model))
-    [unknown, string_type, other].each_with_index do |tool, index|
-      assert_same(tool, mapped[index + 1])
-    end
+    assert_same(unknown, mapped[1])
+    refute_same(string_type, mapped[2])
+    assert_equal(string_type.merge(model: ToolModel), mapped[2])
+    refute(string_type.key?(:model))
+    assert_same(other, mapped[3])
   end
 
   def test_create_preserves_request_shape_and_unwrap_contract


### PR DESCRIPTION
Summary

Fix Chat Completions structured-output handling so supported string discriminators behave like their symbol counterparts. A nested `response_format` tagged with `"json_schema"` now serializes the model's JSON Schema object and hydrates the parsed message model; a streamed tool tagged with `"function"` now retains its typed argument model for both done events and the final completion.

Bug and impact

Users can pass SDK parameters with either Ruby symbols or JSON-style strings. Before this fix, replacing only `:json_schema` with `"json_schema"` in a converter-bearing Chat Completions response format sent the model class name as the wire `schema` value instead of its object schema, and the returned message had no typed `parsed` model. Replacing only `:function` with `"function"` for a streamed converter-bearing tool left done/final arguments as raw hashes instead of the requested model.

The failure is deterministic and offline:

- Before: `type: :json_schema` sent an object schema and returned `DiscriminatorText`; `type: "json_schema"` sent `"DiscriminatorText"` as `schema` and returned `NilClass`.
- Before: `type: :function` produced `DiscriminatorTool` for streamed done/final arguments; `type: "function"` produced `Hash`.
- After: both discriminator spellings send the same object schema/parameters and return the same typed models.

Root cause and minimal fix

The structured-output parser matched only the symbol `:json_schema` in its two nested response-format converter patterns, so string-tagged forms bypassed schema conversion and model capture. The stream input-tool binder similarly copied captured models only when `tool[:type] == :function`.

The fix broadens those exact checks only:

- the two existing converter-bearing response-format patterns accept `:json_schema | "json_schema"`;
- stream model binding accepts `:function` or `"function"`.

This uses the existing Chat Completions helper boundary and existing model conversion path; it does not add a new coercion framework or normalize arbitrary hashes.

Compatibility and scope

Explicit `name` and `strict` values remain intact. Direct converter forms, symbol controls, ordinary raw schema hashes, unknown tools, and custom/unrelated tool tags retain their existing behavior. The change is confined to the handwritten Chat Completions structured-output helper and its focused tests; generated code, transports, streaming helpers, signatures, dependencies, and public APIs are unchanged.

Verification

- Focused regression: `bundle exec ruby -Itest test/openai/helpers/chat_completion_parser_test.rb` — 11 runs, 186 assertions, 0 failures, 0 errors.
- Offline proof: symbol and string response formats both sent object schemas and hydrated `DiscriminatorText`; symbol and string streamed tools both produced `DiscriminatorTool` for done/final arguments.
- `bundle exec rake format` — passed and idempotent.
- `bundle exec rake lint` — passed; Sorbet clean, RuboCop directives valid, 1,250 RBS files valid, 2,799 files inspected with no offenses.
- `bundle exec rake test` — 1,555 runs, 13,974 assertions, 0 failures, 0 errors, 1 skip.
- `git diff --check` — clean.
- Two consecutive fresh adversarial review rounds, each with independent correctness/security and architecture/simplicity reviewers — clean.
- Committed public custom-code gate — passed: 3,311 / 4,000 custom lines, 689 lines headroom.

Security and limitations

The serialization/deserialization boundary was reviewed explicitly. This recognizes only two exact existing enum strings and adds no transport, authentication, logging, secret, dependency, file, or generated-code behavior. Tests use fake offline payloads; no live API request was made. The full suite retains one existing skip and existing Ruby/async warnings.
