### PR TITLE
fix: correct StringIO request content length

### DIFF
--- a/lib/openai/net_http_client.rb
+++ b/lib/openai/net_http_client.rb
@@ -118,7 +118,7 @@ module OpenAI
         req["content-length"] ||= body.bytesize.to_s unless req["transfer-encoding"]
         req.body_stream = OpenAI::Internal::Util::ReadIOAdapter.new(body, &blk)
       in StringIO
-        req["content-length"] ||= body.size.to_s unless req["transfer-encoding"]
+        req["content-length"] ||= [body.size - body.pos, 0].max.to_s unless req["transfer-encoding"]
         req.body_stream = OpenAI::Internal::Util::ReadIOAdapter.new(body, &blk)
       in Pathname | IO | Enumerator
         req["transfer-encoding"] ||= "chunked" unless req["content-length"]

--- a/test/openai/net_http_client_stringio_length_test.rb
+++ b/test/openai/net_http_client_stringio_length_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::NetHTTPClientStringIOLengthTest < Minitest::Test
+  include WebMock::API
+
+  REQUEST_URL = "https://example.test/probe"
+
+  def setup
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def teardown
+    WebMock.reset!
+    WebMock.disable!
+    super
+  end
+
+  def test_automatic_content_length_matches_bytes_remaining_at_current_cursor
+    observations = [
+      [0, "6", "abcdef"],
+      [3, "3", "def"],
+      [6, "0", ""],
+      [10, "0", ""]
+    ].map do |position, expected_length, expected_body|
+      source = StringIO.new("abcdef")
+      source.pos = position
+
+      observation = execute(source)
+
+      assert_equal(expected_length, observation.fetch(:content_length))
+      assert_equal(expected_body, observation.fetch(:body))
+      refute_predicate(source, :closed?)
+      observation
+    end
+
+    assert_equal(%w[6 3 0 0], observations.map { _1.fetch(:content_length) })
+  end
+
+  def test_automatic_content_length_counts_remaining_multibyte_bytes
+    source = StringIO.new("éx")
+    source.pos = "é".bytesize
+
+    observation = execute(source)
+
+    assert_equal("1", observation.fetch(:content_length))
+    assert_equal("x", observation.fetch(:body))
+    refute_predicate(source, :closed?)
+  end
+
+  def test_explicit_framing_headers_remain_caller_owned
+    content_length_source = StringIO.new("abcdef").tap { _1.pos = 3 }
+    transfer_encoding_source = StringIO.new("abcdef").tap { _1.pos = 3 }
+    content_length = execute(content_length_source, headers: {"Content-Length" => "6"})
+    transfer_encoding = execute(
+      transfer_encoding_source,
+      headers: {"Transfer-Encoding" => "chunked"}
+    )
+
+    assert_equal("6", content_length.fetch(:content_length))
+    assert_nil(content_length.fetch(:transfer_encoding))
+    assert_equal("def", content_length.fetch(:body))
+    assert_nil(transfer_encoding.fetch(:content_length))
+    assert_equal("chunked", transfer_encoding.fetch(:transfer_encoding))
+    assert_equal("def", transfer_encoding.fetch(:body))
+    refute_predicate(content_length_source, :closed?)
+    refute_predicate(transfer_encoding_source, :closed?)
+  end
+
+  private def execute(source, headers: {})
+    observed = nil
+    stub_request(:post, REQUEST_URL).to_return do |request|
+      observed = {
+        content_length: request.headers["Content-Length"],
+        transfer_encoding: request.headers["Transfer-Encoding"],
+        body: request.body
+      }
+      {status: 200, body: "ok"}
+    end
+
+    client = OpenAI::NetHTTPClient.new
+    request = OpenAI::HTTPClient::Request.new(
+      method: :post,
+      url: URI(REQUEST_URL),
+      headers: headers,
+      body: source,
+      timeout: 1
+    )
+
+    response = client.execute(request)
+    assert_equal("ok", response.body.to_a.join)
+    observed
+  ensure
+    client&.close
+  end
+end


### PR DESCRIPTION
Summary

Fix automatic request framing for an already-supported `StringIO` body passed directly to `OpenAI::NetHTTPClient#execute` after the caller has advanced its cursor.

When a caller supplied `StringIO.new("abcdef")` at position `3`, the transport previously advertised `Content-Length: 6` but its existing `ReadIOAdapter` streamed only `"def"` (3 bytes). At EOF or beyond EOF it advertised 6 while streaming 0. This affected callers using the public native transport boundary directly with partially consumed in-memory bodies; it is not a claim about ordinary multipart or higher-level `client.request` encoding paths.

The fix keeps the existing handwritten `StringIO` branch and computes the automatic header as the remaining byte count, clamped at zero. `StringIO#size` and `#pos` are byte-based, so multibyte content is framed by bytes rather than characters. The adapter remains unchanged and the caller's source is neither rewound nor closed.

Deterministic synthetic evidence

Before:

```text
StringIO("abcdef"), pos 0  -> Content-Length 6, sends "abcdef" (6 bytes)
StringIO("abcdef"), pos 3  -> Content-Length 6, sends "def"    (3 bytes)
StringIO("abcdef"), pos 6  -> Content-Length 6, sends ""       (0 bytes)
StringIO("abcdef"), pos 10 -> Content-Length 6, sends ""       (0 bytes)
```

After:

```text
StringIO("abcdef"), pos 0  -> Content-Length 6, sends "abcdef" (6 bytes)
StringIO("abcdef"), pos 3  -> Content-Length 3, sends "def"    (3 bytes)
StringIO("abcdef"), pos 6  -> Content-Length 0, sends ""       (0 bytes)
StringIO("abcdef"), pos 10 -> Content-Length 0, sends ""       (0 bytes)
StringIO("éx"), pos 2      -> Content-Length 1, sends "x"      (1 byte)
```

The regression test uses a real `OpenAI::HTTPClient::Request` through `OpenAI::NetHTTPClient#execute` with offline WebMock, and verifies cursor 0/middle/EOF/beyond EOF, multibyte byte accounting, transmitted body bytes, caller-owned source lifetime, and unchanged explicit `Content-Length` / `Transfer-Encoding` ownership.

Compatibility and scope

- No public API or signature changes.
- Explicit `Content-Length` and `Transfer-Encoding` remain caller-owned and unchanged.
- Existing String, IO, Pathname, and Enumerator branches are untouched.
- No generated files, dependencies, pooling, authentication, TLS, retries, generic body support, multipart behavior, or transport redesign.

Verification

```sh
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/net_http_client_stringio_length_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/http_client_test.rb
mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/x509_transport_security_test.rb
mise exec ruby@4.0.6 -- bundle exec rake format
mise exec ruby@4.0.6 -- bundle exec rake lint
mise exec ruby@4.0.6 -- bundle exec rake test
```

Results: focused regression `3 runs, 38 assertions`; neighboring HTTP client `36 runs, 158 assertions`; transport security `6 runs, 216 assertions`; format/lint exit 0; full suite `1556 runs, 13949 assertions, 0 failures, 0 errors, 1 skip`.

Security review

HTTP framing is security-sensitive. Two independent dedicated correctness/security reviews found the correction removes the previous automatic length/body desynchronization risk and introduces no new request-smuggling path. No secrets, logging, dependencies, authentication, TLS, file paths, or deserialization behavior changed.

Custom-code budget

Committed public gate passed against current main and candidate `0f16968fc81473c61bcc90afbd2706e2b1130e57`: `+3002 / -309 = 3311` custom lines under the `4000` limit, with `689` lines of headroom and verified public generated snapshot `6ae9f6c5f61f147b7edd2d20439d48cbc21d0739`.

Limitations

The separate private diagnostic cannot resolve the private Castiron checkpoint object from this public clone; the required public committed-candidate gate passed. No live API request was needed because the public transport behavior is covered deterministically offline.

