### PR TITLE
fix: preserve recursive structured output refs

### DIFF
--- a/lib/openai/helpers/structured_output/json_schema_converter.rb
+++ b/lib/openai/helpers/structured_output/json_schema_converter.rb
@@ -23,6 +23,15 @@ module OpenAI
             end
           end
           .freeze
+        # @api private
+        RECURSIVE = Object
+          .new
+          .tap do
+            _1.define_singleton_method(:inspect) do
+              "#<#{OpenAI::Helpers::StructuredOutput::JsonSchemaConverter}::RECURSIVE>"
+            end
+          end
+          .freeze
 
         # rubocop:disable Lint/UnusedMethodArgument
 
@@ -96,6 +105,10 @@ module OpenAI
             defs, path = state.fetch_values(:defs, :path)
             if (stored = defs[type])
               pointers = stored.fetch(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::POINTERS)
+              if pointers.first.fetch(:$ref).empty?
+                stored[OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::RECURSIVE] = true
+              end
+
               pointers.first.except(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::NO_REF).tap do
                 pointers << _1
               end
@@ -130,27 +143,35 @@ module OpenAI
             )
             reused_defs = {}
             defs.each_value do |acc|
-              sch = acc.except(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::POINTERS)
+              recursive = acc.key?(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::RECURSIVE)
+              sch = acc.except(
+                OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::POINTERS,
+                OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::RECURSIVE
+              )
               pointers = acc.fetch(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::POINTERS)
 
               no_refs, refs = pointers.partition do
                 _1.delete(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::NO_REF)
               end
 
-              case refs
-              in [ref]
-                ref.replace(ref.except(:$ref).merge(sch))
-              in [_, ref, *]
-                reused_defs.store(ref.fetch(:$ref), sch)
-                refs.each do
-                  unless (meta = _1.except(:$ref)).empty?
-                    _1.replace(allOf: [_1.slice(:$ref), meta])
-                  end
-                end
+              if recursive
+                reused_defs.store(pointers.first.fetch(:$ref), sch)
               else
+                case refs
+                in [ref]
+                  ref.replace(ref.except(:$ref).merge(sch))
+                in [_, ref, *]
+                  reused_defs.store(ref.fetch(:$ref), sch)
+                  refs.each do
+                    unless (meta = _1.except(:$ref)).empty?
+                      _1.replace(allOf: [_1.slice(:$ref), meta])
+                    end
+                  end
+                else
+                end
               end
 
-              no_refs.each { _1.replace(_1.except(:$ref).merge(sch)) }
+              no_refs.each { _1.replace(_1.except(:$ref).merge(sch)) } unless recursive
             end
 
             xformed = reused_defs.transform_keys do

--- a/test/openai/helpers/structured_output_recursive_refs_test.rb
+++ b/test/openai/helpers/structured_output_recursive_refs_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::StructuredOutputRecursiveRefsTest < Minitest::Test
+  class RecursivePlain < OpenAI::BaseModel
+    required :name, String
+    required :child, -> { RecursivePlain }
+  end
+
+  class RecursiveNilable < OpenAI::BaseModel
+    required :name, String
+    required :child, -> { RecursiveNilable }, nil?: true
+  end
+
+  class RecursiveDocumented < OpenAI::BaseModel
+    required :name, String
+    required :child, -> { RecursiveDocumented }, doc: "Next node"
+  end
+
+  class RecursiveNilableDocumented < OpenAI::BaseModel
+    required :name, String
+    required :child, -> { RecursiveNilableDocumented }, nil?: true, doc: "Optional next node"
+  end
+
+  class MutualLeft < OpenAI::BaseModel
+    required :right, -> { MutualRight }, nil?: true
+  end
+
+  class MutualRight < OpenAI::BaseModel
+    required :left, -> { MutualLeft }, nil?: true
+  end
+
+  def test_recursive_model_references_are_finite_and_resolvable
+    schemas = [
+      RecursivePlain,
+      RecursiveNilable,
+      RecursiveDocumented,
+      RecursiveNilableDocumented
+    ].to_h { [_1, round_trip_schema(_1)] }
+
+    schemas.each_value { assert_resolvable_refs(_1) }
+
+    assert_equal(
+      {"$ref" => "#/$defs/"},
+      schemas.fetch(RecursivePlain).dig("$defs", "", "properties", "child")
+    )
+    assert_equal(
+      [{"$ref" => "#/$defs/"}, {"type" => "null"}],
+      schemas.fetch(RecursiveNilable).dig("$defs", "", "properties", "child", "anyOf")
+    )
+    assert_equal(
+      {"$ref" => "#/$defs/", "description" => "Next node"},
+      schemas.fetch(RecursiveDocumented).dig("$defs", "", "properties", "child")
+    )
+
+    documented_nilable = schemas
+      .fetch(RecursiveNilableDocumented)
+      .dig("$defs", "", "properties", "child")
+    assert_equal("Optional next node", documented_nilable.fetch("description"))
+    assert_equal(
+      [{"$ref" => "#/$defs/"}, {"type" => "null"}],
+      documented_nilable.fetch("anyOf")
+    )
+  end
+
+  def test_mutual_nilable_references_are_finite_and_resolvable
+    schema = round_trip_schema(MutualLeft)
+
+    assert_resolvable_refs(schema)
+    assert_nullable_property(schema, "right")
+    assert_nullable_property(schema, "left")
+  end
+
+  private
+
+  def round_trip_schema(model) = JSON.parse(JSON.generate(model.to_json_schema))
+
+  def assert_resolvable_refs(schema)
+    refs = collect_hashes(schema).filter_map { _1["$ref"] }
+
+    refute_empty(refs)
+    refs.each do |ref|
+      assert_equal("#", ref[0])
+      assert(resolve_local_ref(schema, ref), "Expected #{ref} to resolve")
+    end
+  end
+
+  def assert_nullable_property(schema, property)
+    property_schema = collect_hashes(schema)
+      .filter_map { _1.fetch("properties", {})[property] }
+      .first
+
+    refute_nil(property_schema)
+    assert_includes(property_schema.fetch("anyOf"), {"type" => "null"})
+  end
+
+  def collect_hashes(value)
+    case value
+    in Hash
+      [value, *value.values.flat_map { collect_hashes(_1) }]
+    in Array
+      value.flat_map { collect_hashes(_1) }
+    else
+      []
+    end
+  end
+
+  def resolve_local_ref(schema, ref)
+    pointer = URI::RFC2396_PARSER.unescape(ref.delete_prefix("#/"))
+    pointer.split("/", -1).reduce(schema) do |value, token|
+      value.fetch(token.gsub("~1", "/").gsub("~0", "~"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fix recursive structured-output schemas when a recursive `OpenAI::BaseModel` field is nullable or documented. Previously, `to_json_schema` could construct a cyclic Ruby hash, so serializing the schema raised `JSON::NestingError` before a request could be sent.

Affected users are callers defining recursive structured-output models such as linked lists or mutually recursive trees with `nil?: true` and/or `doc:` metadata.

## Public Ruby example

```ruby
require "json"
require "openai"

class Node < OpenAI::BaseModel
  required :name, String
  required :next, -> { Node }, nil?: true, doc: "Optional next node"
end

schema = Node.to_json_schema
puts JSON.generate(schema)
```

## Deterministic before/after

Before:

```text
JSON::NestingError: nesting of 100 is too deep. Did you try to serialize objects with circular references?
```

After:

```json
{"$defs":{"":{"type":"object","properties":{"name":{"type":"string"},"next":{"anyOf":[{"$ref":"#/$defs/"},{"type":"null"}],"description":"Optional next node"}},"required":["name","next"],"additionalProperties":false}},"$ref":"#/$defs/"}
```

## Root cause and fix

The converter already caches schema definitions and tracks every provisional `$ref`. For nullable or metadata-decorated references, it intentionally marks a pointer as non-reusable so an acyclic definition can be inlined with the local decoration. During recursive construction, that same inlining step inserted the completed definition back into one of its own descendants, producing an object cycle.

The fix marks only cache entries re-entered while their first reference path is still unresolved. Those recursive definitions stay in `$defs`, and their decorated sites remain finite `$ref`-based schemas. Ordinary acyclic reuse continues through the existing materialization path.

## Compatibility and scope

- Preserves plain recursive schemas.
- Preserves nullable and description metadata at recursive field sites.
- Preserves resolvable local `$ref` targets for self-recursive and mutually recursive optional links.
- Does not introduce `allOf` for recursive metadata; `allOf` is unsupported by the Structured Outputs strict subset.
- Does not change `ArrayOf`, `BaseModel`, `UnionOf`, parsers, Sorbet behavior, generated code, signatures, dependencies, or public API shape.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby /Users/jbeckwith/Documents/Codex/2026-08-31/do-this/work/batch2/verify_recursive_schema.rb /Users/jbeckwith/.codex/worktrees/5d25/openai-ruby`
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_recursive_refs_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_api_names_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_nullable_literal_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_constant_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec rake format`
- `mise exec ruby@4.0.6 -- bundle exec rake test` — 1,555 runs, 13,952 assertions, 0 failures, 0 errors, 1 skip
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — 2,800 files inspected, no offenses; Sorbet/RBS/directive checks passed
- Two consecutive adversarial-review rounds, each with two new independent read-only reviewers, found no supported in-scope blockers.
- Trusted committed public custom-code budget: 3,311 / 4,000 lines.

## Limitations

Verification is deterministic and offline; no live API request was made. Sorbet recursive schemas remain intentionally unsupported and are outside this change.
