### PR TITLE
fix: isolate chat stream logprob chunks

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -339,8 +339,8 @@ module OpenAI
 
           if choice_snapshot.logprobs.nil?
             choice_snapshot.logprobs = OpenAI::Chat::ChatCompletionChunk::Choice::Logprobs.new(
-              content: choice_logprobs.content,
-              refusal: choice_logprobs.refusal
+              content: choice_logprobs.content&.dup,
+              refusal: choice_logprobs.refusal&.dup
             )
           else
             if choice_logprobs.content

--- a/test/openai/helpers/chat_stream_logprob_isolation_test.rb
+++ b/test/openai/helpers/chat_stream_logprob_isolation_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamLogprobIsolationTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_raw_chunk_logprobs_stay_isolated_when_they_start_after_the_initial_chunk
+    [:content, :refusal].each do |kind|
+      stream = stream_for(kind, initial_logprobs: false)
+      chunks, observed = collect_raw_logprobs(stream, kind)
+
+      assert_equal([nil, ["A"], ["B"], nil], observed)
+      assert_equal([nil, ["A"], ["B"], nil], retained_logprobs(chunks, kind))
+      assert_equal(["A", "B"], final_logprobs(stream, kind))
+    end
+  end
+
+  def test_raw_chunk_logprobs_stay_isolated_when_the_initial_chunk_has_logprobs
+    [:content, :refusal].each do |kind|
+      stream = stream_for(kind, initial_logprobs: true)
+      chunks, observed = collect_raw_logprobs(stream, kind)
+
+      assert_equal([["A"], ["B"], nil], observed)
+      assert_equal([["A"], ["B"], nil], retained_logprobs(chunks, kind))
+      assert_equal(["A", "B"], final_logprobs(stream, kind))
+    end
+  end
+
+  def test_late_choice_logprobs_still_accumulate_once_per_chunk
+    stream = stream_for(:content, initial_logprobs: false, choice_index: 1, tokens: ["A", "A"])
+    chunks, = collect_raw_logprobs(stream, :content)
+
+    assert_equal([nil, ["A"], ["A"], nil], retained_logprobs(chunks, :content))
+    assert_equal(["A", "A"], final_logprobs(stream, :content, choice_index: 1))
+  end
+
+  private
+
+  def stream_for(kind, initial_logprobs:, choice_index: 0, tokens: ["A", "B"])
+    WebMock.reset!
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: sse(kind:, initial_logprobs:, choice_index:, tokens:)
+      )
+
+    @client.chat.completions.stream(
+      messages: [{content: "Synthetic", role: :user}],
+      model: "gpt-4o-mini",
+      logprobs: true
+    )
+  end
+
+  def sse(kind:, initial_logprobs:, choice_index:, tokens:)
+    choices = [
+      choice(choice_index.zero? ? choice_index : 0, delta: {role: "assistant"}),
+      choice(choice_index, delta: {kind => tokens.first}, logprobs: {kind => [logprob(tokens.first)]}),
+      choice(choice_index, delta: {kind => tokens.last}, logprobs: {kind => [logprob(tokens.last)]}),
+      choice(choice_index, delta: {}, finish_reason: "stop")
+    ]
+    choices.shift if initial_logprobs
+
+    chunks = choices.map { |item| chunk(item) }
+    chunks.map { |payload| "data: #{JSON.generate(payload)}\n\n" }.join + "data: [DONE]\n\n"
+  end
+
+  def chunk(choice)
+    {
+      id: "chatcmpl-logprob-isolation",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      choices: [choice]
+    }
+  end
+
+  def choice(index, delta:, logprobs: nil, finish_reason: nil)
+    {index:, delta:, logprobs:, finish_reason:}
+  end
+
+  def logprob(token)
+    {token:, logprob: -0.1, bytes: token.bytes, top_logprobs: []}
+  end
+
+  def collect_raw_logprobs(stream, kind)
+    chunks = []
+    observed = []
+
+    stream.each do |event|
+      next unless event.type == :chunk
+
+      chunks << event.chunk
+      observed << logprob_tokens(event.chunk, kind)
+    end
+
+    [chunks, observed]
+  end
+
+  def retained_logprobs(chunks, kind)
+    chunks.map { |chunk| logprob_tokens(chunk, kind) }
+  end
+
+  def logprob_tokens(chunk, kind)
+    logprobs = chunk.choices.first.logprobs
+    values = kind == :content ? logprobs&.content : logprobs&.refusal
+    values&.map(&:token)
+  end
+
+  def final_logprobs(stream, kind, choice_index: 0)
+    choice = stream.get_final_completion.choices.find { |item| item.index == choice_index }
+    values = kind == :content ? choice.logprobs.content : choice.logprobs.refusal
+    values.map(&:token)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes Chat Completions streaming logprob retention when a choice's first logprobs arrive after an earlier role-only chunk. Previously, the accumulator adopted the raw chunk's mutable content or refusal array; appending a later token then mutated the already-delivered raw chunk payload. Users that retain chunk events could observe historical raw data change after delivery.

```ruby
stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Say two tokens"}],
  logprobs: true
)

raw_chunks = stream.select { |event| event.type == :chunk }.map(&:chunk)
# Each raw chunk's logprobs now remain exactly as delivered.
```

### Deterministic synthetic behavior

- Before: role-only → token A → token B caused the retained raw token-A chunk to change from `["A"]` at delivery to `["A", "B"]` after stream completion.
- After: retained raw chunks stay `[nil, ["A"], ["B"], nil]` for both content and refusal logprobs, while the final accumulated completion remains `["A", "B"]`.
- Control: when logprobs are already present on the initial chunk, raw retention remains unchanged.
- Compatibility: a genuinely late choice with repeated A / A tokens still accumulates `["A", "A"]`, preserving legitimate repeated tokens exactly once per chunk.

### Root cause and fix

`accumulate_logprobs!` seeded an existing choice snapshot with the raw chunk's mutable logprob arrays. Later `concat` calls therefore mutated both the snapshot and the earlier raw chunk. The fix shallow-copies only the first non-nil content and refusal arrays at that ownership boundary. Token objects, live snapshot behavior, emitted events, and final accumulation semantics remain unchanged.

### Scope and compatibility

- Handwritten helper only: `lib/openai/helpers/streaming/chat_completion_stream.rb`.
- Adds one deterministic public-client SSE regression: `test/openai/helpers/chat_stream_logprob_isolation_test.rb`.
- No generated code, dependencies, transport, schemas, signatures, parser behavior, tool-call handling, fingerprint/service metadata, public API, or current snapshot API changes.
- Security assessment: in-memory array ownership only; no credentials, transport, deserialization, files, logging, or dependency surface changed.

### Verification

- Red pinned-base proof (`a31c1cef9ee8e1fc5ed7a9b29f23171260a101e4`): content and refusal raw token-A chunks changed to `["A", "B"]` after completion; initial-logprobs controls stayed correct.
- Green proof after fix: retained raw chunks stay isolated and final tokens remain `["A", "B"]` for content and refusal.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_logprob_isolation_test.rb` → 3 runs, 14 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_stream_test.rb test/openai/helpers/chat_stream_fingerprint_test.rb test/openai/helpers/chat_stream_initial_finish_test.rb` → 10 runs, 47 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake format` → passed; no additional changes.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` → passed, including RuboCop, rubyfmt/RBS checks, Sorbet, and RBS validation.
- `mise exec ruby@4.0.6 -- bundle exec rake test` → 1557 runs, 13954 assertions, 1 unrelated timing-boundary failure in PollingHelpersTest (`0.02000000001862645 <= 0.02`); isolated rerun of `test/openai/resources/polling_helpers_test.rb` passed with 42 runs, 230 assertions.
- Trusted current-main public custom-code budget check against `bbfbe29f53018b4a3a1c61edab355ad901bb0239` and committed candidate `6a86d247aa8b72a5d45a789d3793d723bcc98144` → success, 3311 / 4000 custom lines, 689 headroom, verified generated snapshot `6ae9f6c5f61f147b7edd2d20439d48cbc21d0739`.

### Review

Required adversarial review converged after three rounds with exactly two fresh read-only reviewers each round. Round 1 found and fixed one narrowly necessary test gap for legitimate repeated late-choice tokens; rounds 2 and 3 were clean on unchanged source/tests.
