### PR TITLE
examples: handle structured response output variants

### DIFF
--- a/examples/responses/streaming_previous_response.rb
+++ b/examples/responses/streaming_previous_response.rb
@@ -169,7 +169,9 @@ begin
   parsed_output_received = false
   response
     .output
-    .flat_map { _1.content }
+    .grep(OpenAI::Models::Responses::ResponseOutputMessage)
+    .flat_map(&:content)
+    .grep(OpenAI::Models::Responses::ResponseOutputText)
     .each do |content|
       parsed = content.parsed
       next unless parsed.is_a?(MathResponse)

--- a/examples/responses/streaming_structured_outputs.rb
+++ b/examples/responses/streaming_structured_outputs.rb
@@ -40,7 +40,9 @@ puts("----- parsed outputs from final response -----")
 parsed_output_received = false
 response
   .output
-  .flat_map { _1.content }
+  .grep(OpenAI::Models::Responses::ResponseOutputMessage)
+  .flat_map(&:content)
+  .grep(OpenAI::Models::Responses::ResponseOutputText)
   .each do |content|
     # parsed is an instance of `MathResponse`
     parsed = content.parsed

--- a/examples/structured_outputs_responses.rb
+++ b/examples/structured_outputs_responses.rb
@@ -50,10 +50,13 @@ response = client.responses.create(
 
 response
   .output
-  .flat_map { _1.content }
-  # filter out refusal responses
-  .grep_v(OpenAI::Models::Responses::ResponseOutputRefusal)
+  .grep(OpenAI::Models::Responses::ResponseOutputMessage)
+  .flat_map(&:content)
+  .grep(OpenAI::Models::Responses::ResponseOutputText)
   .each do |content|
     # parsed is an instance of `CalendarEvent`
-    pp(content.parsed)
+    parsed = content.parsed
+    next unless parsed.is_a?(CalendarEvent)
+
+    pp(parsed)
   end

--- a/test/openai/streaming_previous_response_example_test.rb
+++ b/test/openai/streaming_previous_response_example_test.rb
@@ -73,9 +73,8 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
   def test_both_streams_resume_with_captured_ids_and_preserve_structured_output
     structured_stream = Minitest::Mock.new
     final_response = Minitest::Mock.new
-    output_message = Minitest::Mock.new
-    output_content = Minitest::Mock.new
-    @mocks.push(structured_stream, final_response, output_message, output_content)
+    output = []
+    @mocks.push(structured_stream, final_response)
 
     structured_stream.expect(:each, nil) do |&callback|
       callback.call(in_progress_event(sequence_number: 8))
@@ -83,8 +82,7 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
     end
 
     structured_stream.expect(:get_final_response, final_response)
-    final_response.expect(:output, [output_message])
-    output_message.expect(:content, [output_content])
+    final_response.expect(:output, output)
 
     streams = plain_successful_streams +
       [
@@ -96,7 +94,7 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
             assert_equal(7, params.fetch(:starting_after))
 
             math_response = params.fetch(:text).new(steps: [], final_answer: "-29/8")
-            output_content.expect(:parsed, math_response)
+            output << output_message(parsed: math_response)
           end
         }
       ]
@@ -114,9 +112,8 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
   def test_both_streams_resume_after_last_usable_sequence_with_unknown_events
     structured_stream = Minitest::Mock.new
     final_response = Minitest::Mock.new
-    output_message = Minitest::Mock.new
-    output_content = Minitest::Mock.new
-    @mocks.push(structured_stream, final_response, output_message, output_content)
+    output = []
+    @mocks.push(structured_stream, final_response)
 
     structured_stream.expect(:each, nil) do |&callback|
       callback.call(unknown_event)
@@ -125,8 +122,7 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
     end
 
     structured_stream.expect(:get_final_response, final_response)
-    final_response.expect(:output, [output_message])
-    output_message.expect(:content, [output_content])
+    final_response.expect(:output, output)
 
     streams = [
       {
@@ -157,7 +153,7 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
           assert_equal(9, params.fetch(:starting_after))
 
           math_response = params.fetch(:text).new(steps: [], final_answer: "-29/8")
-          output_content.expect(:parsed, math_response)
+          output << output_message(parsed: math_response)
         end
       }
     ]
@@ -244,6 +240,15 @@ class OpenAI::Test::StreamingPreviousResponseExampleTest < Minitest::Test
     data = {type: "future.unmodeled.event"}
     data[:sequence_number] = sequence_number unless sequence_number.nil?
     OpenAI::Streaming::UnknownStreamEvent.new(data: data)
+  end
+
+  def output_message(parsed:)
+    content = OpenAI::Responses::ResponseOutputText.new(text: "{}", annotations: [], parsed: parsed)
+    OpenAI::Responses::ResponseOutputMessage.new(
+      id: "msg_structured",
+      status: :completed,
+      content: [content]
+    )
   end
 
   def assert_failure(error, stderr, message)

--- a/test/openai/structured_response_example_variants_test.rb
+++ b/test/openai/structured_response_example_variants_test.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::StructuredResponseExampleVariantsTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  STREAMING_EXAMPLE_PATH = File.expand_path(
+    "../../examples/responses/streaming_structured_outputs.rb",
+    __dir__
+  )
+  PREVIOUS_RESPONSE_EXAMPLE_PATH = File.expand_path(
+    "../../examples/responses/streaming_previous_response.rb",
+    __dir__
+  )
+  NONSTREAMING_EXAMPLE_PATH = File.expand_path(
+    "../../examples/structured_outputs_responses.rb",
+    __dir__
+  )
+
+  def setup
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+    @previous_api_key = ENV["OPENAI_API_KEY"]
+    ENV["OPENAI_API_KEY"] = "synthetic-test-key"
+    @sleeps = []
+    Thread.current.thread_variable_set(:mock_sleep, @sleeps)
+  end
+
+  def teardown
+    Thread.current.thread_variable_set(:mock_sleep, nil)
+    @previous_api_key ? ENV["OPENAI_API_KEY"] = @previous_api_key : ENV.delete("OPENAI_API_KEY")
+    WebMock.allow_net_connect!
+    WebMock.disable!
+    WebMock.reset!
+    super
+  end
+
+  def test_streaming_example_prints_typed_output_after_reasoning_and_refusal
+    stdout, stderr, error = run_streaming_example(
+      [reasoning_item, message(refusal_content, math_content)]
+    )
+
+    assert_nil(error)
+    assert_empty(stderr)
+    assert_includes(stdout, "MathResponse")
+    assert_includes(stdout, "-29/8")
+  end
+
+  def test_streaming_example_keeps_clear_failure_for_refusal_only_output
+    _stdout, stderr, error = run_streaming_example([message(refusal_content)])
+
+    assert_failure(error, stderr, "The final response did not contain a parsed MathResponse")
+  end
+
+  def test_streaming_example_keeps_clear_failure_for_unparsed_text
+    _stdout, stderr, error = run_streaming_example([message(unparsed_content)])
+
+    assert_failure(error, stderr, "The final response did not contain a parsed MathResponse")
+  end
+
+  def test_previous_response_example_prints_typed_output_after_reasoning_and_refusal
+    stdout, stderr, error = run_previous_response_example(
+      [reasoning_item, message(refusal_content, math_content)]
+    )
+
+    assert_nil(error)
+    assert_empty(stderr)
+    assert_equal([3, 3], @sleeps)
+    assert_includes(stdout, "MathResponse")
+    assert_includes(stdout, "-29/8")
+  end
+
+  def test_previous_response_example_keeps_clear_failure_for_refusal_only_output
+    _stdout, stderr, error = run_previous_response_example([message(refusal_content)])
+
+    assert_failure(error, stderr, "The resumed response did not contain a parsed MathResponse")
+  end
+
+  def test_previous_response_example_keeps_clear_failure_for_unparsed_text
+    _stdout, stderr, error = run_previous_response_example([message(unparsed_content)])
+
+    assert_failure(error, stderr, "The resumed response did not contain a parsed MathResponse")
+  end
+
+  def test_nonstreaming_example_prints_typed_output_after_reasoning_and_refusal
+    stdout, stderr, error = run_nonstreaming_example(
+      [reasoning_item, message(refusal_content, calendar_content)]
+    )
+
+    assert_nil(error)
+    assert_empty(stderr)
+    assert_includes(stdout, "CalendarEvent")
+    assert_includes(stdout, "Science fair")
+  end
+
+  def test_nonstreaming_example_keeps_refusal_only_output_silent
+    stdout, stderr, error = run_nonstreaming_example([message(refusal_content)])
+
+    assert_nil(error)
+    assert_empty(stdout)
+    assert_empty(stderr)
+  end
+
+  def test_nonstreaming_example_keeps_unparsed_text_silent
+    stdout, stderr, error = run_nonstreaming_example([message(unparsed_content)])
+
+    assert_nil(error)
+    assert_empty(stdout)
+    assert_empty(stderr)
+  end
+
+  private
+
+  def run_streaming_example(output)
+    response = response(output)
+    stub_request(:post, "https://api.openai.com/v1/responses")
+      .to_return(sse_response(stream_events(response)))
+
+    load_example(STREAMING_EXAMPLE_PATH)
+  end
+
+  def run_previous_response_example(output)
+    plain_response = response([], id: "resp_plain")
+    structured_response = response(output, id: "resp_structured")
+
+    stub_request(:post, "https://api.openai.com/v1/responses")
+      .to_return(
+        sse_response([created_event(plain_response)]),
+        sse_response([created_event(structured_response)])
+      )
+    stub_request(:get, "https://api.openai.com/v1/responses/resp_plain")
+      .with(query: {"starting_after" => "0", "stream" => "true"})
+      .to_return(sse_response([completed_event(plain_response)]))
+    stub_request(:get, "https://api.openai.com/v1/responses/resp_structured")
+      .with(query: {"starting_after" => "0", "stream" => "true"})
+      .to_return(sse_response([completed_event(structured_response)]))
+
+    load_example(PREVIOUS_RESPONSE_EXAMPLE_PATH)
+  end
+
+  def run_nonstreaming_example(output)
+    stub_request(:post, "https://api.openai.com/v1/responses")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "application/json"},
+        body: JSON.generate(response(output))
+      )
+
+    load_example(NONSTREAMING_EXAMPLE_PATH)
+  end
+
+  def load_example(path)
+    error = nil
+    stdout, stderr = capture_io do
+      load(path, true)
+    rescue SystemExit => exception
+      error = exception
+    end
+
+    [stdout, stderr, error]
+  end
+
+  def response(output, id: "resp_synthetic")
+    {id: id, object: "response", model: "test", status: "completed", output: output}
+  end
+
+  def stream_events(response)
+    [created_event(response), completed_event(response)]
+  end
+
+  def created_event(response)
+    {
+      type: "response.created",
+      sequence_number: 0,
+      response: response.merge(status: "in_progress", output: [])
+    }
+  end
+
+  def completed_event(response)
+    {type: "response.completed", sequence_number: 1, response: response}
+  end
+
+  def sse_response(events)
+    body = events.map { |event| "event: #{event.fetch(:type)}\ndata: #{JSON.generate(event)}\n\n" }.join
+    {status: 200, headers: {"Content-Type" => "text/event-stream"}, body: body}
+  end
+
+  def reasoning_item
+    {id: "reasoning_synthetic", type: "reasoning", summary: []}
+  end
+
+  def message(*content)
+    {
+      id: "msg_synthetic",
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: content
+    }
+  end
+
+  def refusal_content
+    {type: "refusal", refusal: "Synthetic refusal"}
+  end
+
+  def math_content
+    output_text(steps: [], final_answer: "-29/8")
+  end
+
+  def unparsed_content
+    {type: "output_text", text: "null", annotations: [], logprobs: []}
+  end
+
+  def calendar_content
+    output_text(
+      name: "Science fair",
+      date: "2026-09-04",
+      participants: [],
+      optional_participants: nil,
+      is_virtual: false,
+      location: "123 Main St."
+    )
+  end
+
+  def output_text(value)
+    {
+      type: "output_text",
+      text: JSON.generate(value),
+      annotations: [],
+      logprobs: []
+    }
+  end
+
+  def assert_failure(error, stderr, message)
+    assert_instance_of(SystemExit, error)
+    assert_equal(1, error.status)
+    assert_equal("#{message}\n", stderr)
+  end
+end


### PR DESCRIPTION
## Summary

Structured Responses examples assumed every response output item was a message with content and every content part exposed parsed output. Valid Responses API results can place reasoning items or refusal parts before a later typed output-text part, so runnable examples could raise NoMethodError instead of printing the requested MathResponse or CalendarEvent.

This affects users copying:

- examples/responses/streaming_structured_outputs.rb
- examples/responses/streaming_previous_response.rb
- examples/structured_outputs_responses.rb

The examples now narrow output items to ResponseOutputMessage and content parts to ResponseOutputText before reading parsed, then print only the script's expected typed model.

Runnable public SDK shape:

    response = client.responses.create(
      model: "gpt-4o-2024-08-06",
      input: "Extract the event information.",
      text: CalendarEvent
    )

    response
      .output
      .grep(OpenAI::Models::Responses::ResponseOutputMessage)
      .flat_map(&:content)
      .grep(OpenAI::Models::Responses::ResponseOutputText)
      .each do |content|
        parsed = content.parsed
        next unless parsed.is_a?(CalendarEvent)

        pp(parsed)
      end

### Deterministic synthetic before/after

Before:

- output: [reasoning, message(output_text)] raised NoMethodError for nil.parsed.
- output: [message(refusal), message(output_text)] raised NoMethodError for ResponseOutputRefusal#parsed in both streaming examples.
- refusal-only streaming output raised NoMethodError instead of the examples' existing clear abort messages.

After:

- reasoning plus typed text prints an actual MathResponse or CalendarEvent.
- refusal plus typed text, including mixed refusal/output-text message content, prints the later actual typed model.
- refusal-only and JSON-null parsed output preserve script-specific behavior: both streaming examples keep their exact clear aborts, while the non-streaming example remains silent.

### Root cause and minimal fix

The extraction chain called content on every response.output union member and parsed on every message-content union member. The fix uses the SDK's existing concrete Responses union variants at the example boundary; it does not add helpers, duck typing, parser changes, or new exception policy.

### Compatibility and non-goals

This is a handwritten examples/test correction only. It does not change lib/, generated models/resources, signatures, dependencies, transport/stream parsing, public APIs, response creation/retrieval parameters, sequence handling, or output variants. Existing stream event printing, captured response IDs, cursor-zero resumption, and unknown-event behavior remain covered.

### Verification

- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/structured_response_example_variants_test.rb
  - 9 runs, 44 assertions, 0 failures, 0 errors
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/streaming_previous_response_example_test.rb
  - 9 runs, 74 assertions, 0 failures, 0 errors
- Supplied offline public-client/WebMock proofs for all three scripts
  - typed-only, reasoning plus typed, refusal plus typed succeed; refusal-only keeps expected behavior
- mise exec ruby@4.0.6 -- bundle exec rake test:examples:inventory
  - 24/35 exercised, 11 explicitly excluded
- mise exec ruby@4.0.6 -- bundle exec rake test
  - 1564 runs, 13989 assertions, 0 failures, 0 errors, 1 skip
- mise exec ruby@4.0.6 -- bundle exec rake format
- mise exec ruby@4.0.6 -- bundle exec rake lint
  - examples Sorbet, RBS validation, RuboCop: 2802 files inspected, no offenses
- git diff --check
- Adversarial review: four rounds; round 2 found and fixed one WebMock teardown leak; rounds 3 and 4 were consecutive clean rounds
- Public custom-code budget against main 5baeac8131511141491fc41abdb2e4e4c596f3de and candidate e9cdee8ada2cd150a78a123b5a262e0a8c62c7fd
  - 3311 / 4000 custom lines, 689 headroom

### Limitations

No live API request was made; verification uses deterministic synthetic HTTP/SSE fixtures through the public client. This is not a security-sensitive change.
