### PR TITLE
ci: serialize auth tests with global stubs

### DIFF
--- a/test/openai/auth/x509_contract_test.rb
+++ b/test/openai/auth/x509_contract_test.rb
@@ -3,6 +3,9 @@
 require_relative "../test_helper"
 
 class OpenAI::Test::X509ContractTest < Minitest::Test
+  # These tests stub the process-wide monotonic clock.
+  extend Minitest::Serial
+
   def setup
     super
     @native = OpenAI::NetHTTPClient.new

--- a/test/openai/auth/x509_token_exchange_test.rb
+++ b/test/openai/auth/x509_token_exchange_test.rb
@@ -3,6 +3,9 @@
 require_relative "../test_helper"
 
 class OpenAI::Test::X509TokenExchangeTest < Minitest::Test
+  # These tests stub process-wide clock and JSON helpers.
+  extend Minitest::Serial
+
   ISSUED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
 
   def setup

--- a/test/openai/realtime/auth_retry_test.rb
+++ b/test/openai/realtime/auth_retry_test.rb
@@ -3,6 +3,9 @@
 require_relative "../test_helper"
 
 class OpenAI::Test::RealtimeAuthRetryTest < Minitest::Test
+  # These tests stub the process-wide monotonic clock.
+  extend Minitest::Serial
+
   class Socket
     def closed? = @closed == true
     def close(code: 1000, reason: "")


### PR DESCRIPTION
## Summary

Three handwritten authentication test classes inherited `parallelize_me!` while stubbing process-wide methods. When Minitest scheduled them together, one suite could replace or restore `OpenAI::Internal::Util.monotonic_secs` while another still depended on its stub, producing a wrong X.509 token assertion and a stub-restoration `NameError`. This affects contributors and CI reliability; shipped gem behavior is unchanged.

### Runnable public SDK example

```ruby
require "openai"

client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
response = client.responses.create(model: "gpt-4.1", input: "Say hello")
puts response.output_text
```

### Deterministic synthetic reproduction

- Before (pinned base `5baeac8131511141491fc41abdb2e4e4c596f3de`):
  `mise exec ruby@4.0.6 -- bundle exec ruby /Users/jbeckwith/Documents/Codex/2026-08-31/do-this/work/batch2/verify_clock_stub_runner.rb "$PWD"`
  produced `2 runs, 3 assertions, 1 failure, 1 error`; the failure expected `fake-rotated-token` but saw `fake-first-token`, and the error was `NameError: undefined method '__minitest_stub__monotonic_secs'`.
- After: the same real Minitest 6.0.6 runner, without its serial-control argument, produced `2 runs, 12 assertions, 0 failures, 0 errors`.

### Root cause and fix

The three classes stub global clock state (and the token-exchange class also stubs `JSON.parse`) but were eligible for parallel suite dispatch. Each now extends the repository's existing `Minitest::Serial` module. Minitest 6.0.6 runs non-parallel suites before parallel suites, and the module delegates to `Minitest::Runnable.run`, so these stubs are restored before parallel suites begin.

### Compatibility and boundaries

This is a test-only scheduling change: no production code, generated files, public API, dependencies, assertions, request deadlines, sleep thresholds, or dedicated concurrency scenarios changed. It does not claim to fix the separate polling Float boundary flake.

### Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby /Users/jbeckwith/Documents/Codex/2026-08-31/do-this/work/batch2/verify_clock_stub_runner.rb "$PWD"` — green after fix: 2 runs, 12 assertions.
- Focused suites: X509 contract `19 runs, 116 assertions`; X509 token exchange `22 runs, 357 assertions`; Realtime auth retry `8 runs, 44 assertions` — all green.
- Existing Minitest compatibility and async concurrency tests — green.
- `mise exec ruby@4.0.6 -- bundle exec rake lint`, `rake typecheck`, and `rake format` — exit 0; formatting left the diff unchanged.
- `git diff --check` — green.
- Trusted committed public custom-code budget against current main `2ded21565f969d026c93027d1d7264a8081d6242` and candidate `94d20fb6989909f74c00d180022aeed6fec8f3ef` — success, 3311/4000 custom lines, 689 headroom.
- Full `rake test` was run twice unchanged and both runs hit only the known unrelated `PollingHelpersTest#test_files_wait_for_processing_bounds_retrieval_by_polling_deadline` Float boundary (`0.02000000001862645 <= 0.02`); each run otherwise reported 1560 runs, 14043 assertions, 1 failure, 0 errors, 1 skip. No auth-test failure occurred.

### Review and security

Two consecutive adversarial-review rounds, each with two fresh independent read-only reviewers, found no in-scope blockers. Security assessment: test scheduling only; authentication/runtime behavior and coverage are unchanged.
