### PR TITLE
fix: short-circuit Bedrock profile credentials

### DIFF
--- a/lib/openai/providers/bedrock.rb
+++ b/lib/openai/providers/bedrock.rb
@@ -229,33 +229,41 @@ module OpenAI
 
         private def resolve
           config = Aws.shared_config
-          providers = []
           if config.config_enabled?
-            providers <<
-              config.assume_role_web_identity_credentials_from_config(
-                profile: @profile,
-                region: @region
-              )
-            providers << config.sso_credentials_from_config(profile: @profile)
-            providers << config.assume_role_credentials_from_config(profile: @profile, region: @region)
+            provider = config.assume_role_web_identity_credentials_from_config(
+              profile: @profile,
+              region: @region
+            )
+            return provider if provider&.set?
+
+            provider = config.sso_credentials_from_config(profile: @profile)
+            return provider if provider&.set?
+
+            provider = config.assume_role_credentials_from_config(profile: @profile, region: @region)
+            return provider if provider&.set?
           end
 
           begin
-            providers << Aws::SharedCredentials.new(profile_name: @profile)
+            provider = Aws::SharedCredentials.new(profile_name: @profile)
+            return provider if provider.set?
           rescue Aws::Errors::NoSuchProfileError
             nil
           end
 
           if config.config_enabled?
             if config.respond_to?(:login_credentials_from_config)
-              providers << config.login_credentials_from_config(profile: @profile, region: @region)
+              provider = config.login_credentials_from_config(profile: @profile, region: @region)
+              return provider if provider&.set?
             end
 
             process = config.credential_process(profile: @profile)
-            providers << Aws::ProcessCredentials.new([process]) if process
+            if process
+              provider = Aws::ProcessCredentials.new([process])
+              return provider if provider.set?
+            end
           end
 
-          providers.compact.find(&:set?) || raise(OpenAI::Errors::Error, CREDENTIAL_RESOLUTION_MESSAGE)
+          raise OpenAI::Errors::Error, CREDENTIAL_RESOLUTION_MESSAGE
         end
       end
 

--- a/test/openai/providers/bedrock_test.rb
+++ b/test/openai/providers/bedrock_test.rb
@@ -146,6 +146,102 @@ class OpenAI::Test::BedrockProviderTest < Minitest::Test
     end
   end
 
+  def test_named_profile_does_not_construct_unused_process_credentials
+    File.write(
+      ENV.fetch("AWS_SHARED_CREDENTIALS_FILE"),
+      <<~INI
+        [engineering]
+        aws_access_key_id = profile-access-key
+        aws_secret_access_key = profile-secret-key
+      INI
+    )
+    File.write(
+      ENV.fetch("AWS_CONFIG_FILE"),
+      <<~INI
+        [profile engineering]
+        credential_process = unused-process
+      INI
+    )
+    reset_shared_config
+    url = "https://bedrock-mantle.us-east-1.api.aws/v1/models"
+    stub_request(:get, url).to_return_json(status: 200, body: {})
+    process_calls = 0
+    process_constructor = lambda do |_command|
+      process_calls += 1
+      raise "unused process credentials must not be constructed"
+    end
+
+    Aws::ProcessCredentials.stub(:new, process_constructor) do
+      client = OpenAI::Client.new(
+        provider: OpenAI::Providers.bedrock(region: "us-east-1", profile: "engineering")
+      )
+      client.request({method: :get, path: "models"})
+    end
+
+    assert_equal(0, process_calls)
+    assert_requested(:get, url) do |request|
+      assert_includes(request.headers.fetch("Authorization"), "Credential=profile-access-key/")
+    end
+  end
+
+  def test_named_profile_continues_to_process_credentials_after_unset_candidates
+    File.write(
+      ENV.fetch("AWS_CONFIG_FILE"),
+      <<~INI
+        [profile engineering]
+        credential_process = selected-process
+      INI
+    )
+    reset_shared_config
+    url = "https://bedrock-mantle.us-east-1.api.aws/v1/models"
+    stub_request(:get, url).to_return_json(status: 200, body: {})
+    process_calls = 0
+    process_constructor = lambda do |_command|
+      process_calls += 1
+      Aws::Credentials.new("process-access-key", "process-secret-key")
+    end
+
+    Aws::ProcessCredentials.stub(:new, process_constructor) do
+      client = OpenAI::Client.new(
+        provider: OpenAI::Providers.bedrock(region: "us-east-1", profile: "engineering")
+      )
+      client.request({method: :get, path: "models"})
+    end
+
+    assert_equal(1, process_calls)
+    assert_requested(:get, url) do |request|
+      assert_includes(request.headers.fetch("Authorization"), "Credential=process-access-key/")
+    end
+  end
+
+  def test_named_profile_does_not_downgrade_after_higher_priority_provider_error
+    File.write(
+      ENV.fetch("AWS_SHARED_CREDENTIALS_FILE"),
+      <<~INI
+        [engineering]
+        aws_access_key_id = profile-access-key
+        aws_secret_access_key = profile-secret-key
+      INI
+    )
+    reset_shared_config
+    config = Aws.shared_config
+    failing_web_identity = lambda do |**_options|
+      raise "higher priority provider failed"
+    end
+
+    error = config.stub(:assume_role_web_identity_credentials_from_config, failing_web_identity) do
+      runtime = OpenAI::Internal::Provider.configure(
+        OpenAI::Providers.bedrock(region: "us-east-1", profile: "engineering")
+      )
+      assert_raises(OpenAI::Errors::Error) do
+        runtime.prepare_request.call(bedrock_request)
+      end
+    end
+
+    assert_equal(OpenAI::Providers::Bedrock::CREDENTIAL_RESOLUTION_MESSAGE, error.message)
+    assert_equal("higher priority provider failed", error.cause.message)
+  end
+
   def test_named_profile_reads_shared_credentials_when_config_is_disabled
     ENV["AWS_SDK_CONFIG_OPT_OUT"] = "true"
     File.write(


### PR DESCRIPTION
## Summary

Explicit Bedrock profiles could fail even when an earlier credential source was already valid. When a named profile contained valid shared static credentials plus a lower-priority `credential_process`, the SDK eagerly constructed every profile provider before selecting the first `set?` provider. Applications using `OpenAI::Providers.bedrock(profile: ..., region: ...)` could therefore execute or fail inside an unused fallback.

```ruby
client = OpenAI::Client.new(
  provider: OpenAI::Providers.bedrock(profile: "production", region: "us-east-1")
)
client.models.list
```

Deterministic synthetic behavior:

- Before: a fake profile with valid shared credentials and an intentionally failing unused process constructor raised `OpenAI::Errors::Error` with the process-constructor error as its cause; constructor calls: 1.
- After: the same public client request signs with the shared profile credentials; unused process-constructor calls: 0.

This restores AWS-style first-valid-provider behavior for explicit profiles and avoids availability failures or unintended side effects from lower-priority providers that should never be selected.

## Root cause and fix

`ProfileCredentialsProvider#resolve` appended all candidate providers to an array and only then called `find(&:set?)`. The fix checks each existing candidate immediately, in the same declared order, and returns as soon as one is set. It still continues through nil or unset candidates and still lets errors from a higher-priority candidate fail through the existing credential-resolution wrapper instead of silently downgrading.

## Compatibility and scope

- Preserves web identity → SSO → assume role → shared credentials → optional login → process ordering.
- Preserves the optional login capability guard, config-disabled behavior, explicit profile/region selection, provider caching/refresh, error wrapping, and Mantle/Runtime SigV4 signing.
- No public API/signature changes, dependency or lockfile changes, generated-code changes, default-chain changes, credential logging, endpoint changes, or authentication redesign.
- This is an ordinary credential-precedence/availability fix; no vulnerability was identified.

## Verification

- `BUNDLE_GEMFILE=gemfiles/bedrock.gemfile mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/providers/bedrock_test.rb` — 29 runs, 177 assertions, 0 failures, 0 errors, 0 skips.
- `BUNDLE_GEMFILE=gemfiles/bedrock.gemfile mise exec ruby@4.0.6 -- bundle exec rake test:bedrock` — 41 runs, 386 assertions, 0 failures, 0 errors, 1 skip.
- `mise exec ruby@4.0.6 -- bundle exec rake test` — 1560 runs, 14046 assertions, 0 failures, 0 errors, 1 skip.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RBS, Sorbet, RuboCop directives, and RuboCop passed.
- `mise exec ruby@4.0.6 -- bundle exec rake format` — passed with no additional changes.
- `git diff --check 5baeac8131511141491fc41abdb2e4e4c596f3de..HEAD` — passed.
- Trusted public custom-code budget against `origin/main` `2ded21565f969d026c93027d1d7264a8081d6242` and candidate `d22b406fc3d6ee02333fed9d5be9ff9c12a35e20` — 3311 / 4000 custom lines, 689 lines headroom.
- Adversarial review — two consecutive clean rounds, each with two fresh independent read-only reviewers.

## Limitations

The regression is fully offline and synthetic; it does not execute a real `credential_process`, contact AWS, or use live credentials.
