### PR TITLE
ci: tolerate polling deadline float noise

### DIFF
--- a/test/openai/resources/polling_helpers_test.rb
+++ b/test/openai/resources/polling_helpers_test.rb
@@ -391,9 +391,11 @@ class OpenAI::Test::Resources::PollingHelpersTest < Minitest::Test
   end
 
   def test_files_wait_for_processing_bounds_retrieval_by_polling_deadline
+    # Allow only Float subtraction noise around the deadline.
+    timeout_arithmetic_tolerance = 0.000001
     transport = scripted_transport do |request|
       assert_operator(request.timeout, :positive?)
-      assert_operator(request.timeout, :<=, 0.02)
+      assert_operator(request.timeout, :<=, 0.02 + timeout_arithmetic_tolerance)
       sleep(request.timeout + 0.01)
       raise OpenAI::Errors::APITimeoutError.new(url: URI("http://example.test/v1/files/file_123"))
     end


### PR DESCRIPTION
## Summary\n\nFix a false CI failure in test_files_wait_for_processing_bounds_retrieval_by_polling_deadline caused only by Float subtraction noise at the polling-deadline boundary.\n\nProblem and trigger: with a monotonic clock value such as 262144.0, Ruby evaluates (262144.0 + 0.02) - 262144.0 as 0.02000000001862645. The existing strict <= 0.02 assertion can therefore fail even though the SDK bounded the retrieval request to the configured deadline.\n\nAffected users: contributors and CI runs exercising the polling helper suite. Shipped gem behavior is unchanged.\n\nRunnable reproduction:\n\nruby -e "value = (262144.0 + 0.02) - 262144.0; abort(value.inspect) unless value > 0.02"\n\nDeterministic synthetic before:\n- Computed interval: 0.02000000001862645\n- Existing assertion: expected <= 0.02\n- Result: 1 run, 4 assertions, 1 failure\n\nDeterministic synthetic after:\n- Same computed interval: 0.02000000001862645\n- Assertion permits only 0.000001 seconds of Float arithmetic tolerance\n- Result: 1 run, 7 assertions, 0 failures\n\nPreserved negative control:\n- Injected interval: 0.03\n- Upper bound: <= 0.020001\n- Result: 1 run, 4 assertions, 1 expected failure\n\n## Root cause and fix\n\nThe test compared a deadline-derived Float with an exact decimal boundary. Binary Float subtraction can produce a negligible positive residue. The minimal fix adds a named one-microsecond local tolerance with a nearby explanation and applies it only to that one upper-bound assertion.\n\nThe test still configures timeout 0.02, requires a positive request timeout, deliberately waits past the deadline, expects PollingTimeoutError, verifies nil last resource, and asserts exactly one request.\n\n## Compatibility and non-goals\n\nThis is test-only. It changes no SDK behavior, public API, production timeout logic, transport behavior, dependencies, generated files, CI harness, or other tests. It does not loosen coverage beyond one microsecond of arithmetic noise.\n\n## Verification\n\n- Deterministic private proof on unchanged source: 1 run, 4 assertions, 1 failure at <= 0.02\n- Deterministic proof after fix: 1 run, 7 assertions, 0 failures\n- Oversized 0.03 negative control: expected failure at <= 0.020001\n- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/polling_helpers_test.rb: 42 runs, 230 assertions, 0 failures\n- mise exec ruby@4.0.6 -- bundle exec rubocop test/openai/resources/polling_helpers_test.rb: no offenses\n- mise exec ruby@4.0.6 -- bundle exec rake lint: passed\n- mise exec ruby@4.0.6 -- bundle exec rake format: passed with no additional diff\n- mise exec ruby@4.0.6 -- bundle exec rake test: 1562 runs, 14089 assertions, 0 failures, 0 errors, 1 skip\n- Public custom-code budget: 3311 / 4000, 689 lines headroom\n- Adversarial review: two consecutive clean rounds, two fresh independent read-only reviewers per round\n\n## Limitations\n\nThe private custom-code diagnostic could not resolve its private checkpoint object in this public clone. The required public committed-candidate gate passed against freshly fetched main.