### PR TITLE
fix: respect StringIO cursor in FilePart serialization

### DIFF
--- a/lib/openai/file_part.rb
+++ b/lib/openai/file_part.rb
@@ -85,7 +85,7 @@ module OpenAI
       in Pathname
         content.read(binmode: true)
       in StringIO
-        content.string
+        content.string.byteslice(content.pos..) || ""
       in IO
         content.read
       in String

--- a/test/openai/file_part_serialization_cursor_test.rb
+++ b/test/openai/file_part_serialization_cursor_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::FilePartSerializationCursorTest < Minitest::Test
+  def test_string_io_serializers_use_bytes_remaining_at_current_cursor
+    [
+      [0, "abcdef"],
+      [3, "def"],
+      [6, ""],
+      [10, ""]
+    ].each do |position, expected|
+      content = StringIO.new("abcdef")
+      content.pos = position
+      file = OpenAI::FilePart.new(content)
+
+      assert_equal(expected, JSON.parse(file.to_json), "JSON at byte position #{position}")
+      assert_equal(expected, YAML.safe_load(file.to_yaml), "YAML at byte position #{position}")
+      assert_equal(position, content.pos)
+      refute_predicate(content, :closed?)
+    end
+  end
+
+  def test_string_io_serializers_slice_at_utf8_byte_boundaries_without_consuming
+    content = StringIO.new("éx")
+    content.pos = "é".bytesize
+    file = OpenAI::FilePart.new(content)
+
+    2.times do
+      assert_equal("x", JSON.parse(file.to_json))
+      assert_equal("x", YAML.safe_load(file.to_yaml))
+      assert_equal("é".bytesize, content.pos)
+      refute_predicate(content, :closed?)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`OpenAI::FilePart.new(string_io).to_json` and `.to_yaml` serialized the entire backing string even when the caller had already advanced `StringIO#pos`. File-backed IO already serialized from its current position, and multipart/vector-store StringIO paths already use remaining-byte semantics.

## User impact

A caller serializing a `FilePart` after consuming part of a `StringIO` now gets only the bytes remaining at the current cursor. At position 3 in synthetic `abcdef`, JSON and YAML now serialize `def` instead of `abcdef`; at or beyond EOF they serialize an empty string. Position 0 remains unchanged.

## Fix

The private `FilePart#read` StringIO branch now uses `content.string.byteslice(content.pos..) || ""`, matching established SDK multipart behavior. This slices by byte offset without reading, rewinding, closing, or moving the caller stream.

## Compatibility and scope

The public constructor and metadata behavior are unchanged. Plain String, Pathname, and ordinary IO branches are untouched. This PR does not change multipart encoding, uploaders, NetHTTPClient, global serialization, generated code, dependencies, signatures, closed-input policy, or payload limits.

This is ordinary file-content correctness, not a security vulnerability claim. A focused file/serialization security assessment found no new logging, path, transport, deserialization, dependency, or limit surface.

## Verification

- Red regression before fix: 2 runs, 7 assertions, 2 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/file_part_serialization_cursor_test.rb` — 2 runs, 30 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/file_part_test.rb` — 19 runs, 368 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/net_http_client_stringio_length_test.rb` — 3 runs, 38 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/util_test.rb` — 62 runs, 286 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/multipart_content_type_test.rb` — 6 runs, 306 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/vector_store_file_uploader_test.rb` — 22 runs, 142 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — passed; 2,805 files inspected, no offenses, RBS and Sorbet checks clean.
- `mise exec ruby@4.0.6 -- bundle exec rake test` — 1,567 runs, 14,133 assertions, 0 failures, 0 errors, 1 skip.
- Root proof script confirms position 0, mid-buffer, EOF, past EOF, and ordinary file-backed IO behavior.
- Trusted public custom-code budget check on committed candidate `b6744c42bebce34cc59d32e4eda6072ed93bb789` against current main `0daedb2878373da899dac8b029fdb0523a26c6ef` — passed, 3,311 / 4,000 custom lines.
- Required adversarial review converged after two consecutive clean rounds, each with two fresh independent read-only reviewers; no in-scope findings required repairs.

## Limitations

No live API examples were run; verification is offline with synthetic content.