### PR TITLE
fix: parse initial streamed tool arguments

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -137,6 +137,9 @@ module OpenAI
 
             chunk.choices.each do |choice|
               handle_finish_reason(choice.finish_reason, completion_snapshot) if choice.finish_reason
+
+              tool_calls_by_index = @tool_call_snapshots_by_choice_index.fetch(choice.index)
+              parse_tool_calls!(choice.delta.tool_calls, tool_calls_by_index)
             end
 
             return completion_snapshot
@@ -511,7 +514,7 @@ module OpenAI
           choices = []
           chunk.choices.each do |choice|
             choice_hash = choice.to_h
-            delta_hash = choice.delta.to_h
+            delta_hash = model_dump(choice.delta)
 
             message_data = delta_hash.dup
             message_data[:role] ||= :assistant

--- a/test/openai/helpers/chat_stream_initial_tool_parsing_test.rb
+++ b/test/openai/helpers/chat_stream_initial_tool_parsing_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamInitialToolParsingTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class TypedArguments < OpenAI::BaseModel
+    required :x, Integer
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_complete_initial_strict_arguments_match_role_prefixed_deltas
+    [hash_tool, typed_tool].each do |tool|
+      initial = stream_result([tool_choice(arguments: "{\"x\":1}"), finish_choice], tool)
+      prefixed = stream_result([role_choice, tool_choice(arguments: "{\"x\":1}"), finish_choice], tool)
+
+      assert_equal({x: 1}, initial.fetch(:delta).parsed)
+      assert_equal(prefixed.fetch(:delta).parsed, initial.fetch(:delta).parsed)
+      assert_equal({x: 1}, initial.fetch(:delta).parsed)
+
+      if tool == typed_tool
+        assert_instance_of(TypedArguments, initial.fetch(:done).parsed)
+        assert_instance_of(TypedArguments, initial.fetch(:final).function.parsed)
+      else
+        assert_equal({x: 1}, initial.fetch(:done).parsed)
+        assert_equal({x: 1}, initial.fetch(:final).function.parsed)
+      end
+    end
+  end
+
+  def test_initial_non_strict_and_incomplete_arguments_keep_existing_unparsed_deltas
+    non_strict = stream_result([tool_choice(arguments: "{\"x\":1}"), finish_choice], non_strict_tool)
+    incomplete = stream_result([tool_choice(arguments: "{\"x\":"), finish_choice], hash_tool)
+
+    assert_nil(non_strict.fetch(:delta).parsed)
+    assert_nil(non_strict.fetch(:done).parsed)
+    assert_nil(incomplete.fetch(:delta).parsed)
+    assert_nil(incomplete.fetch(:done).parsed)
+  end
+
+  private
+
+  def stream_result(choices, tool)
+    WebMock.reset!
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: sse(choices)
+      )
+
+    stream = @client.chat.completions.stream(
+      messages: [{content: "Synthetic", role: :user}],
+      model: "gpt-4o-mini",
+      tools: [tool]
+    )
+    events = stream.to_a
+
+    {
+      delta: events.find { |event| event.type == :"tool_calls.function.arguments.delta" },
+      done: events.find { |event| event.type == :"tool_calls.function.arguments.done" },
+      final: stream.get_final_completion.choices.first.message.tool_calls.first
+    }
+  end
+
+  def sse(choices)
+    chunks = choices.map do |choice|
+      payload = {
+        id: "chatcmpl-initial-tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt-4o-mini",
+        choices: [choice]
+      }
+      "data: #{JSON.generate(payload)}\n\n"
+    end
+
+    chunks.join + "data: [DONE]\n\n"
+  end
+
+  def role_choice
+    choice(delta: {role: "assistant"})
+  end
+
+  def tool_choice(arguments:)
+    choice(
+      delta: {
+        role: "assistant",
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_0",
+            type: "function",
+            function: {name: "lookup", arguments: arguments}
+          }
+        ]
+      }
+    )
+  end
+
+  def finish_choice
+    choice(delta: {}, finish_reason: "tool_calls")
+  end
+
+  def choice(delta:, finish_reason: nil)
+    {index: 0, delta: delta, finish_reason: finish_reason}
+  end
+
+  def hash_tool
+    function_tool(parameters: {type: "object", properties: {x: {type: "integer"}}})
+  end
+
+  def typed_tool
+    function_tool(parameters: TypedArguments)
+  end
+
+  def non_strict_tool
+    function_tool(strict: false, parameters: {type: "object", properties: {x: {type: "integer"}}})
+  end
+
+  def function_tool(strict: true, parameters:)
+    {
+      type: :function,
+      function: {name: "lookup", strict: strict, parameters: parameters}
+    }
+  end
+end


### PR DESCRIPTION
## Problem

When a complete, valid strict function-tool argument arrived in the first actual Chat Completions stream chunk, the `tool_calls.function.arguments.delta` event exposed `parsed: nil`. The identical tool chunk parsed correctly when preceded by an assistant-role-only chunk. Done events and the final completion were already correct, making delta behavior depend on chunk framing.

## Change

- Deep-dump the initial delta before coercing it into the completion snapshot, so nested tool calls use the same message-model representation as later accumulated chunks.
- Reuse the existing `parse_tool_calls!` path immediately after initial tool-call indexing and before events are built.
- Keep finish-reason handling first, preserving terminal error precedence.

No parser, typed-delta API, public API, generated model, dependency, payload limit, or event-ordering changes are introduced.

## User-visible behavior

For a strict `lookup` tool receiving the synthetic argument `{"x":1}`:

- Before, first actual chunk: delta `parsed` was `nil`; role-prefixed control was `{x: 1}`.
- After, both streams expose delta `parsed` as `{x: 1}`.

Typed tool configuration keeps the established contract: delta parsing is a Hash, while done/final parsing still converts to the configured model. Non-strict tools and incomplete JSON remain unparsed.

## Tests

- Added a public `OpenAI::Client#chat.completions.stream` WebMock regression for first-chunk versus role-prefixed strict tools, covering Hash and typed tool configurations plus non-strict and incomplete JSON behavior.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_initial_tool_parsing_test.rb` — 2 runs, 14 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_terminal_tool_test.rb` — 3 runs, 16 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_initial_finish_test.rb` — 3 runs, 48 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_stream_test.rb` — 10 runs, 47 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_parser_test.rb` — 11 runs, 186 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — passed; RuboCop inspected 2,805 files with no offenses, RBS validation passed, Sorbet examples typecheck passed.
- `mise exec ruby@4.0.6 -- bundle exec rake test` — 1,567 runs, 14,117 assertions, 0 failures, 0 errors, 1 skip.
- External private synthetic verifier reproduced the baseline mismatch and showed matching `{x: 1}` deltas after the fix.

## Review and security

- `$adversarial-review`: two consecutive clean rounds, each with two fresh independent read-only reviewers; no meaningful in-scope blocking findings.
- Focused deserialization review: the change reuses the existing data-only `JSON.parse` path, introduces no eval/logging/sensitive sink, and adds no arbitrary body/event/line limit. Synthetic fixtures use fake credentials and no customer data.
- Local public custom-code-budget check on committed head: success, 3,311 / 4,000 custom lines with 689 lines headroom.

Because this touches streamed JSON deserialization behavior, please include `@openai/sdks-team` review.

## Scope and limitations

Changed only `lib/openai/helpers/streaming/chat_completion_stream.rb` and the new focused regression test. A Codex Security workbench artifact-finalization attempt failed before producing a report because its draft schema was rejected and the scan became non-resumable; the focused manual security assessment above completed with no findings.
