### PR TITLE
examples: fix manual pagination predicates

### DIFF
--- a/lib/openai/internal/conversation_cursor_page.rb
+++ b/lib/openai/internal/conversation_cursor_page.rb
@@ -5,7 +5,7 @@ module OpenAI
     # @generic Elem
     #
     # @example
-    #   if conversation_cursor_page.has_next?
+    #   if conversation_cursor_page.next_page?
     #     conversation_cursor_page = conversation_cursor_page.next_page
     #   end
     #

--- a/lib/openai/internal/cursor_page.rb
+++ b/lib/openai/internal/cursor_page.rb
@@ -5,7 +5,7 @@ module OpenAI
     # @generic Elem
     #
     # @example
-    #   if cursor_page.has_next?
+    #   if cursor_page.next_page?
     #     cursor_page = cursor_page.next_page
     #   end
     #

--- a/lib/openai/internal/next_cursor_page.rb
+++ b/lib/openai/internal/next_cursor_page.rb
@@ -5,7 +5,7 @@ module OpenAI
     # @generic Elem
     #
     # @example
-    #   if next_cursor_page.has_next?
+    #   if next_cursor_page.next_page?
     #     next_cursor_page = next_cursor_page.next_page
     #   end
     #

--- a/lib/openai/internal/page.rb
+++ b/lib/openai/internal/page.rb
@@ -5,7 +5,7 @@ module OpenAI
     # @generic Elem
     #
     # @example
-    #   if page.has_next?
+    #   if page.next_page?
     #     page = page.next_page
     #   end
     #


### PR DESCRIPTION
## Problem

The YARD manual-pagination examples for Page, CursorPage, NextCursorPage, and ConversationCursorPage told users to call `has_next?`, but that predicate does not exist. Copying those examples raises `NoMethodError` before pagination can proceed.

## Fix

Update the four example predicates to call the existing `next_page?` method. This is a documentation-only correction: runtime behavior, public APIs, signatures, README content, and generated resources/models are unchanged.

## User perspective

Before:
```ruby
if page.has_next?
  page = page.next_page
end
```

After:
```ruby
if page.next_page?
  page = page.next_page
end
```

The same correction applies to cursor, next-cursor, and conversation-cursor page examples.

## Verification

- Supplied offline public-client smoke script: red baseline showed `has_next?` raising `NoMethodError` on all four terminal page objects; green candidate showed documented `next_page?` returning `false` on all four.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/page_test.rb` (1 run, 3 assertions)
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/path_parameter_query_test.rb` (17 runs, 36 assertions)
- `mise exec ruby@4.0.6 -- bundle exec rake lint` (RuboCop 2,804 files; RBS 1,250 files; directive validation and example typecheck passed)
- `git diff --check`
- Trusted public custom-code budget check: 3,311 / 4,000 lines, verified snapshot `6ae9f6c5f61f147b7edd2d20439d48cbc21d0739`.
- Isolated `test_installed_gem_completes_real_x509_issuer_and_api_handshakes` passed (1 run, 6 assertions); a separately built gem contains `lib/openai/models/admin/organization/admin_api_key.rb`.

## Review and scope

Six adversarial-review rounds, each with two fresh independent read-only reviewers, completed cleanly; rounds 1-2 preceded initial publication, rounds 3-4 preceded the prefix/verification metadata update, and rounds 5-6 preceded this limitation-wording update. No security-sensitive surfaces are touched.

Non-goals: no runtime/API/alias/cursor-policy/pagination/error changes; no README, signature, generated, budget, config, or test-infrastructure changes; no unrelated documentation cleanup.

## Limitations

The broad local `mise exec ruby@4.0.6 -- bundle exec rake test` run (seed 64807) completed with 1 failure, 0 errors, and 1 skip across 1,565 runs and 14,101 assertions: the installed-gem X.509 smoke could not load `lib/openai/models/admin/organization/admin_api_key`. The same packaging test passes in isolation, a fresh package contains that file, five untouched-main focused runs of both GemPackagingTest cases also pass, and the exact-head CI package job plus all Ruby matrix tests pass. Shared-state interference is a supported hypothesis, not a proven root cause; no production or test change is inferred from this evidence.