### PR TITLE
fix: preserve text logprobs in response streams

### DIFF
--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -114,6 +114,7 @@ module OpenAI
                   output_index: event.output_index,
                   sequence_number: event.sequence_number,
                   type: event.type,
+                  **event.to_h.slice(:logprobs),
                   snapshot: content.text
                 )
             else
@@ -146,6 +147,7 @@ module OpenAI
                 sequence_number: event.sequence_number,
                 text: event.text,
                 type: event.type,
+                **event.to_h.slice(:logprobs),
                 parsed: parsed
               )
 

--- a/test/openai/helpers/response_stream_text_logprobs_test.rb
+++ b/test/openai/helpers/response_stream_text_logprobs_test.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResponseStreamTextLogprobsTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_normal_stream_preserves_text_event_logprobs_from_raw_stream
+    stream = nil
+    [nested_logprobs, [], nil].each do |logprobs|
+      stub_normal_stream(logprobs:)
+      raw_events = text_events(@client.responses.stream_raw(model: "test", input: "synthetic").to_a)
+
+      stub_normal_stream(logprobs:)
+      stream = @client.responses.stream(model: "test", input: "synthetic")
+      events = text_events(stream.to_a)
+
+      assert_text_events_preserve_logprobs(events, raw_events, snapshots: ["ok", "ok"])
+      stream.close
+      stream = nil
+    end
+
+  ensure
+    stream&.close
+  end
+
+  def test_resumed_stream_preserves_text_event_logprobs_without_snapshots
+    stream = nil
+    [nested_logprobs, [], nil].each do |logprobs|
+      stub_resumed_stream(logprobs:)
+      raw_events = text_events(@client.responses.retrieve_streaming("resp_synthetic", starting_after: 2).to_a)
+
+      stub_resumed_stream(logprobs:)
+      stream = @client.responses.stream(response_id: "resp_synthetic", starting_after: 2)
+      events = text_events(stream.to_a)
+
+      assert_text_events_preserve_logprobs(events, raw_events, snapshots: [nil, "ok"])
+      stream.close
+      stream = nil
+    end
+
+  ensure
+    stream&.close
+  end
+
+  private
+
+  def assert_text_events_preserve_logprobs(events, raw_events, snapshots:)
+    assert_equal(
+      [:"response.output_text.delta", :"response.output_text.done"],
+      events.map(&:type)
+    )
+    raw_logprobs = raw_events.map { |event| event.to_h[:logprobs] }
+    assert_equal(raw_logprobs, events.map { |event| event.to_h[:logprobs] })
+    assert_equal(["msg_synthetic", "msg_synthetic"], events.map(&:item_id))
+    assert_equal([0, 0], events.map(&:output_index))
+    assert_equal([0, 0], events.map(&:content_index))
+    assert_equal([3, 4], events.map(&:sequence_number))
+    assert_equal(snapshots, [events.fetch(0).snapshot, events.fetch(1).text])
+    if raw_logprobs.fetch(0).nil?
+      assert_nil(events.fetch(0).to_h[:logprobs])
+      assert_nil(events.fetch(1).to_h[:logprobs])
+      return
+    end
+
+    return if events.fetch(0).logprobs.empty?
+
+    logprob = events.fetch(0).logprobs.fetch(0)
+    assert_equal("ok", logprob.token)
+    assert_equal(-0.25, logprob.logprob)
+    assert_equal("okay", logprob.top_logprobs.fetch(0).token)
+    assert_equal(-1.0, logprob.top_logprobs.fetch(0).logprob)
+  end
+
+  def text_events(events)
+    events.grep(OpenAI::Models::Responses::ResponseTextDeltaEvent) +
+      events.grep(OpenAI::Models::Responses::ResponseTextDoneEvent)
+  end
+
+  def stub_normal_stream(logprobs:)
+    stub_request(:post, "http://localhost/responses").to_return(
+      status: 200,
+      headers: {"Content-Type" => "text/event-stream"},
+      body: sse(normal_events(logprobs:))
+    )
+  end
+
+  def stub_resumed_stream(logprobs:)
+    stub_request(:get, "http://localhost/responses/resp_synthetic?starting_after=2&stream=true").to_return(
+      status: 200,
+      headers: {"Content-Type" => "text/event-stream"},
+      body: sse(text_events_payload(logprobs:))
+    )
+  end
+
+  def sse(events)
+    events.map { |event| "event: #{event.fetch(:type)}\ndata: #{JSON.generate(event)}\n\n" }.join
+  end
+
+  def normal_events(logprobs:)
+    events = [
+      {type: "response.created", sequence_number: 0, response: response},
+      {type: "response.output_item.added", sequence_number: 1, output_index: 0, item: message_item},
+      {
+        type: "response.content_part.added",
+        sequence_number: 2,
+        item_id: "msg_synthetic",
+        output_index: 0,
+        content_index: 0,
+        part: {type: "output_text", text: "", annotations: [], logprobs: []}
+      },
+      *text_events_payload(logprobs:)
+    ]
+    events.each { |event| event[:logprobs] = logprobs unless logprobs.nil? }
+    events
+  end
+
+  def text_events_payload(logprobs:)
+    [
+      {
+        type: "response.output_text.delta",
+        sequence_number: 3,
+        item_id: "msg_synthetic",
+        output_index: 0,
+        content_index: 0,
+        delta: "ok",
+        logprobs: logprobs
+      },
+      {
+        type: "response.output_text.done",
+        sequence_number: 4,
+        item_id: "msg_synthetic",
+        output_index: 0,
+        content_index: 0,
+        text: "ok",
+        logprobs: logprobs
+      }
+    ]
+  end
+
+  def nested_logprobs
+    [{token: "ok", logprob: -0.25, top_logprobs: [{token: "okay", logprob: -1.0}]}]
+  end
+
+  def response
+    {id: "resp_synthetic", object: "response", status: "in_progress", model: "test", output: []}
+  end
+
+  def message_item
+    {id: "msg_synthetic", type: "message", role: "assistant", status: "in_progress", content: []}
+  end
+end


### PR DESCRIPTION
## Problem
When customers request message.output_text.logprobs, responses.stream_raw retains server-provided token, logprob, and top_logprobs data, but responses.stream reconstructs enriched text delta and done events without that field. Normal streams lose both events; resumed streams lose the done event.

## Fix
At the existing handwritten enrichment boundary, forward the raw logprobs field only when it is present while rebuilding response.output_text.delta and response.output_text.done events. This preserves nonempty and empty arrays without eagerly coercing an omitted required generated field. The resumed no-snapshot delta path already passes through the raw event.

## Customer impact
Responses stream consumers now receive the same server-provided text logprob data available from raw streaming, including nested top_logprobs and numeric values, for normal and server-resumed streams.

## Synthetic proof
A WebMock public-entrypoint regression compares raw and enriched text events for normal and resumed streams. It covers nested nonempty arrays, explicit empty arrays, and omitted fields; verifies event types, IDs, indexes, sequence numbers, snapshot/no-snapshot behavior, and typed nested values. Before the fix, enriched normal delta/done values were nil and resumed done was nil. After the fix, provided arrays match raw events.

## Compatibility and scope
No logprob aggregation or recalculation. No parsing, structured output, snapshot, final-response, get_output_text, resume filtering, generated model, signature, dependency, CI, budget, or public API changes. Omitted ordinary text-only fields remain tolerated. The change only returns existing API data through existing event objects and adds no logging, storage, transport, deserialization, or new exposure.

## Verification
- New regression: 2 runs, 54 assertions, 0 failures, 0 errors
- Adjacent isolation and unknown-event tests: 3 runs, 24 assertions, 0 failures, 0 errors
- Existing Responses streaming suite: 33 runs, 122 assertions, 0 failures, 0 errors
- Full rake test: 1567 runs, 14157 assertions, 0 failures, 0 errors, 1 skip
- rake lint: passed, including RuboCop, RBS validation, directives, rubyfmt, and Sorbet example typecheck
- Supplied public-path reproduction: reproduced before and passes after
- Trusted public custom-code budget: 3311 / 4000 lines, 689 headroom

## Review
Four adversarial-review rounds used two fresh independent read-only reviewers each. Round 2 found and prompted the omitted-logprobs compatibility correction. Rounds 3 and 4 were consecutive clean rounds on unchanged final code.

## Limitations
Validation uses safe synthetic SSE only; no live API calls were made.