### PR TITLE
examples: fix structured streaming model DSL docs

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -150,9 +150,9 @@ The Responses API supports structured outputs via the `text` parameter:
 
 ```ruby
 class Haiku < OpenAI::BaseModel
-  field :first_line, String
-  field :second_line, String
-  field :third_line, String
+  required :first_line, String
+  required :second_line, String
+  required :third_line, String
 end
 
 stream = client.responses.stream(
@@ -391,9 +391,9 @@ The Chat Completions API supports structured outputs via the `response_format` p
 
 ```ruby
 class Haiku < OpenAI::BaseModel
-  field :first_line, String
-  field :second_line, String
-  field :third_line, String
+  required :first_line, String
+  required :second_line, String
+  required :third_line, String
 end
 
 stream = client.chat.completions.stream(


### PR DESCRIPTION
## Problem

The two published structured-streaming Haiku examples in `helpers.md` used `field`, which is not an `OpenAI::BaseModel` DSL method. Copying either example raised `NoMethodError` while defining the model, before the SDK could send a request.

## Fix

Replace only the six Haiku declarations with the existing `required` DSL: three fields in the Responses Structured Outputs example and three in the Chat Completions Structured Outputs example.

From a user perspective, both snippets now define the model through the supported public SDK path, stream a response, and expose `first_line`, `second_line`, and `third_line` on the parsed model.

## Safe reproduction

An offline, synthetic WebMock driver extracted the exact two published Ruby fences and blocked all network access:

- Before: both snippets raised `NoMethodError: undefined method 'field'` with 0 requests.
- After: each snippet made exactly 1 mocked request through its public streaming API and printed all 3 typed fields.

No live API examples were run and no credentials or customer data were used.

## Scope and compatibility

- Changed file: `helpers.md` only.
- Changed lines: exactly the six model field declarations.
- No runtime API, parser, type, signature, model name, prompt, schema, streaming semantics, dependency, generated file, or test-infrastructure changes.
- This is documentation/example correction only; shipped gem behavior is unchanged.
- Security assessment: no auth, transport, deserialization, logging, upload, dependency, CI, or release surface changed.

## Verification

- Offline extracted-snippet red/green proof: both public streaming snippets execute and print all three parsed fields after the change.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_test.rb` — 8 runs, 60 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/responses/streaming_test.rb` — 33 runs, 122 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/chat/completions/streaming_test.rb` — 22 runs, 107 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop 2,866 files, RBS 1,278 files, Sorbet examples typecheck, and directive validation all clean.
- `git diff --check` — clean.
- Trusted current-main public custom-code budget check — success, 3,311/4,000 lines.

## Adversarial review

Two consecutive rounds completed on unchanged code. Each round used two new, independent, read-only reviewers: correctness/contracts/security/tests and architecture/scope/simplicity. All four reviews were clean with no supported in-scope findings.

## Limitations

The broad full repository test suite was not run because this docs-only change is covered by the exact extracted-snippet regression proof and focused structured-streaming suites, and the shared full-suite slot was in use.
