### PR TITLE
test: isolate race-prone transport and gem packaging tests

### DIFF
--- a/test/openai/gem_packaging_test.rb
+++ b/test/openai/gem_packaging_test.rb
@@ -9,8 +9,9 @@ require "uri"
 require_relative "test_helper"
 
 class OpenAI::Test::GemPackagingTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
   def test_packages_every_relative_readme_link
-    specification = Gem::Specification.load(File.expand_path("../../openai.gemspec", __dir__))
     readme = File.read(File.expand_path("../../README.md", __dir__))
     relative_links = readme.scan(/\[[^\]]+\]\(([^\s)]+)(?:\s+[^)]*)?\)/).flatten.filter_map do |target|
       uri = URI.parse(target)
@@ -19,7 +20,7 @@ class OpenAI::Test::GemPackagingTest < Minitest::Test
 
     Dir.mktmpdir("openai-gem-packaging-test") do |directory|
       gem_file = File.join(directory, "openai.gem")
-      Gem::Package.build(specification, false, false, gem_file)
+      build_gem(gem_file)
       package = Gem::Package.new(gem_file)
 
       assert_empty(relative_links - package.contents, "README links are missing from the built gem")
@@ -46,13 +47,12 @@ class OpenAI::Test::GemPackagingTest < Minitest::Test
   end
 
   def test_installed_gem_completes_real_x509_issuer_and_api_handshakes
-    specification = Gem::Specification.load(File.expand_path("../../openai.gemspec", __dir__))
     smoke_script = File.expand_path("support/x509_installed_gem_smoke.rb", __dir__)
 
     Dir.mktmpdir("openai-x509-installed-gem") do |directory|
       gem_file = File.join(directory, "openai.gem")
       install_directory = File.join(directory, "install")
-      Gem::Package.build(specification, false, false, gem_file)
+      build_gem(gem_file)
       install_output, install_status = Open3.capture2e(
         RbConfig.ruby,
         "-S",
@@ -87,5 +87,24 @@ class OpenAI::Test::GemPackagingTest < Minitest::Test
       assert_predicate(status, :success?, output)
       assert_includes(output, "installed gem X.509 issuer/API mTLS verification passed")
     end
+  end
+
+  private
+
+  def build_gem(gem_file)
+    # RubyGems reads gemspec paths relative to the process-wide working
+    # directory. Build in a child process so parallel tests that temporarily
+    # change directory cannot corrupt the archive.
+    output, status = Open3.capture2e(
+      RbConfig.ruby,
+      "-S",
+      "gem",
+      "build",
+      "openai.gemspec",
+      "--output",
+      gem_file,
+      chdir: ROOT
+    )
+    assert_predicate(status, :success?, output)
   end
 end

--- a/test/openai/net_http_client_stringio_length_test.rb
+++ b/test/openai/net_http_client_stringio_length_test.rb
@@ -3,6 +3,8 @@
 require_relative "test_helper"
 
 class OpenAI::Test::NetHTTPClientStringIOLengthTest < Minitest::Test
+  extend Minitest::Serial
+
   include WebMock::API
 
   REQUEST_URL = "https://example.test/probe"


### PR DESCRIPTION
## Summary

- run `NetHTTPClientStringIOLengthTest` through the existing `Minitest::Serial` path so its process-global WebMock state cannot race other transport tests
- build package-test gems through an isolated `gem build` subprocess rooted at the repository
- keep the package tests parallel while preventing another test's process-wide `chdir` from changing which relative gemspec files RubyGems reads

Fixes the intermittent `APIConnectionError` seen in the Ruby 4.0 job on PR #596: https://github.com/openai/openai-ruby/actions/runs/33797368190/job/100788180390?pr=596

Fixes the incomplete installed gem seen in the Ruby 3.4 job on PR #599: https://github.com/openai/openai-ruby/actions/runs/33808338935/job/100824050354?pr=599

## Root cause

The gemspec lists relative paths. `Gem::Package.build` resolves those paths against the process-wide working directory, while other parallel tests invoke tooling such as RuboCop that temporarily changes that directory. Depending on the interleaving, RubyGems could validate or archive files from the wrong location and produce an incomplete gem. Building through a child process gives each build a stable working directory and also isolates RubyGems' mutable global state.

## Testing

- 25 consecutive focused Net::HTTP StringIO test runs
- 96 concurrent isolated RubyGem builds, with every archive checked against the full gemspec file list
- 10 consecutive parallel `GemPackagingTest` runs
- full suite with the failing CI seed `SEED=27213`: 1,581 runs, 14,251 assertions, 0 failures, 1 skip
- rubyfmt check on both changed files
- RuboCop on both changed files
