### PR TITLE
ci: isolate RuboCop directive policy tests

### DIFF
--- a/test/scripts/validate_rubocop_directives_test.rb
+++ b/test/scripts/validate_rubocop_directives_test.rb
@@ -6,9 +6,12 @@ require "fileutils"
 require "open3"
 require "tmpdir"
 
+require_relative "../openai/test_helper"
 require_relative "../../scripts/rubocop_directive_guard"
 
 class ValidateRuboCopDirectivesTest < Minitest::Test
+  extend Minitest::Serial
+
   def test_allows_narrow_disable_directives
     assert_empty(violations("disable Lint/EmptyBlock"))
   end


### PR DESCRIPTION
## Problem

The RuboCop suppression-policy test class contains multiple `Date.stub(:today, ...)` cases. Under the repository parallel Minitest runner, overlapping stubs can race while Minitest restores its shared method aliases, raising `NameError: undefined method __minitest_stub__today` even though the policy assertions themselves are valid.

## User perspective

Before this change, the deterministic synthetic runner reproduced the existing class in parallel with 2 runs, 6 assertions, and 1 cleanup error. After this change, the same runner reports random/serial order with 2 runs, 6 assertions, and 0 errors. The standalone test file also remains green.

## Smallest fix

Load the existing repository test helper so `Minitest::Serial` is available during standalone invocation, then extend only `ValidateRuboCopDirectivesTest` with that framework-provided serial runner. No policy assertion, fixture date, test rule, or production behavior changes.

## Compatibility and scope

This is CI/test reliability only; it does not change shipped gem runtime or public APIs. The diff is limited to `test/scripts/validate_rubocop_directives_test.rb`. Non-goals include broader suite serialization, clock injection, Date monkey patches, scheduler changes, policy/config changes, framework-helper changes, unrelated cleanup, and weakened assertions.

## Verification

- Deterministic baseline reproduction before the fix: 2 runs, 6 assertions, 0 failures, 1 error.
- Deterministic runner after the fix: 2 runs, 6 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/validate_rubocop_directives_test.rb`: 17 runs, 50 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/scripts/validate_rubocop_directives_test.rb`: 17 runs, 50 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- bundle exec rake lint`: RBS validation, RuboCop directive validation, Sorbet, and RuboCop all passed; 2,866 files inspected with no offenses.
- Base-matching isolated mock check for the previously unrelated Safety Alerts environment mismatch: 1 run, 2 assertions, 0 failures, 0 errors.
- Full `mise exec ruby@4.0.6 -- bundle exec rake test` against the verified base-matching mock: 1,581 runs, 14,247 assertions, 0 failures, 0 errors, 1 skip.
- Trusted public custom-code budget check on committed candidate `5ef97fb0869ec9a387840e0114bb6dbcfbff5f05` against current main `fab0e76e2da96fe76755758b6dc0f1c0d50e3af3`: passed at 3,311 / 4,000 lines.

## Review

Two consecutive adversarial-review rounds completed on unchanged code, each with two fresh read-only reviewers and no meaningful in-scope blocking findings. Security assessment found no auth, transport, path, deserialization, logging, dependency, webhook, or release surface change. `@openai/sdks-team` review is requested because this is CI/test reliability work.

## Limitations

Earlier broad-suite attempts against the pre-existing shared localhost mock exposed an unrelated stale-spec 404 and one separate empty-PID test-workflow race; neither is caused by or changed in this one-file diff. The final full-suite result above used the verified base-matching isolated mock.