### PR TITLE
fix: normalize Bedrock environment bearer tokens

### DIFF
--- a/lib/openai/providers/bedrock.rb
+++ b/lib/openai/providers/bedrock.rb
@@ -602,8 +602,9 @@ module OpenAI
           token_provider
         elsif environment_bearer
           lambda do
-            ENV["AWS_BEARER_TOKEN_BEDROCK"] ||
+            token = ENV["AWS_BEARER_TOKEN_BEDROCK"] ||
               raise(OpenAI::Errors::Error, Bedrock::MISSING_CREDENTIALS_MESSAGE)
+            Bedrock.normalize_optional_string(token) || token
           end
         end
 

--- a/test/openai/providers/bedrock_environment_token_normalization_test.rb
+++ b/test/openai/providers/bedrock_environment_token_normalization_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "bedrock_test_helper"
+
+class OpenAI::Test::BedrockEnvironmentTokenNormalizationTest < Minitest::Test
+  extend Minitest::Serial
+  include OpenAI::Test::BedrockTestHelper
+
+  MODEL_URL = "https://bedrock-mantle.us-east-1.api.aws/v1/models"
+
+  def test_environment_bearer_token_is_normalized_like_explicit_api_key
+    padded_token = "\nfake-bedrock-token\n"
+    observed_headers = []
+    stub_request(:get, MODEL_URL).to_return do |request|
+      observed_headers << request.headers.fetch("Authorization")
+      {status: 200, headers: {"Content-Type" => "application/json"}, body: "{\"object\":\"list\",\"data\":[]}"}
+    end
+
+    ENV["AWS_BEARER_TOKEN_BEDROCK"] = padded_token
+    request_models
+    request_models(api_key: padded_token)
+
+    assert_equal(["Bearer fake-bedrock-token", "Bearer fake-bedrock-token"], observed_headers)
+  end
+
+  def test_environment_bearer_token_refreshes_and_normalizes_each_request
+    observed_headers = []
+    stub_request(:get, MODEL_URL).to_return do |request|
+      observed_headers << request.headers.fetch("Authorization")
+      {status: 200, headers: {"Content-Type" => "application/json"}, body: "{\"object\":\"list\",\"data\":[]}"}
+    end
+
+    ENV["AWS_BEARER_TOKEN_BEDROCK"] = "\nfirst-token\n"
+    with_bedrock_client do |client|
+      client.models.list
+      ENV["AWS_BEARER_TOKEN_BEDROCK"] = "\nsecond-token\n"
+      client.models.list
+    end
+
+    assert_equal(["Bearer first-token", "Bearer second-token"], observed_headers)
+  end
+
+  def test_environment_bearer_token_refresh_keeps_blank_and_removed_values_failing
+    ENV["AWS_BEARER_TOKEN_BEDROCK"] = "initial-token"
+
+    with_bedrock_client do |client|
+      ENV["AWS_BEARER_TOKEN_BEDROCK"] = " \n "
+      assert_raises(OpenAI::Errors::Error) { client.models.list }
+      ENV.delete("AWS_BEARER_TOKEN_BEDROCK")
+      assert_raises(OpenAI::Errors::Error) { client.models.list }
+    end
+
+    assert_not_requested(:get, MODEL_URL)
+  end
+
+  private def request_models(api_key: OpenAI::Internal::OMIT)
+    with_bedrock_client(api_key: api_key) { |client| client.models.list }
+  end
+
+  private def with_bedrock_client(api_key: OpenAI::Internal::OMIT)
+    options = {region: "us-east-1"}
+    options[:api_key] = api_key unless api_key.equal?(OpenAI::Internal::OMIT)
+    http_client = OpenAI::NetHTTPClient.new
+    client = OpenAI::Client.new(
+      provider: OpenAI::Providers.bedrock(**options),
+      max_retries: 0,
+      http_client: http_client
+    )
+    yield client
+  ensure
+    http_client&.close
+  end
+end


### PR DESCRIPTION
## Problem

When `AWS_BEARER_TOKEN_BEDROCK` contained surrounding whitespace, Bedrock selected bearer authentication but its per-request refresh lambda returned the raw environment value. A surrounding newline then reached Net::HTTP's Authorization header and raised locally before the request was sent. The equivalent explicit `api_key` was already normalized.

## Fix

Normalize only the freshly read environment token with Bedrock's existing optional-string helper before each request. The lambda still reads `ENV` per request, preserves the existing missing-token error, and deliberately leaves whitespace-only rotated values to the existing non-empty bearer validator.

From a caller's perspective, a value such as a fake token with surrounding newlines now produces the same `Bearer fake-bedrock-token` header whether supplied through `AWS_BEARER_TOKEN_BEDROCK` or explicit `api_key`.

## Verification

- Reproduced before the fix with the offline public `OpenAI::Client` + Bedrock provider + native Net::HTTP path under WebMock: newline-padded ENV token raised `ArgumentError: header field value cannot include CR/LF`, while the same explicit key succeeded.
- After the fix, the same offline probe succeeds for plain, space-padded, and newline-padded ENV and explicit values with identical normalized headers.
- Added focused synthetic coverage for ENV/explicit parity, per-request rotated ENV normalization, and blank/removed rotation failure without fallback.
- `mise exec ruby@4.0.6 -- env BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec ruby -Itest test/openai/providers/bedrock_environment_token_normalization_test.rb --verbose` — 3 runs, 4 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- env BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec rake test:bedrock` — 44 runs, 390 assertions, 0 failures, 0 errors, 1 skip.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RBS/Sorbet/directive validation and RuboCop passed; 2,867 files inspected, no offenses.
- `env TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1,581 runs, 14,247 assertions, 0 failures, 0 errors, 1 skip.
- Trusted current-main public custom-code budget check on committed candidate — 3,311 / 4,000 custom lines; 689 lines headroom.

## Review and security

- Required adversarial review converged with two consecutive clean rounds; each round used two fresh, independent, read-only reviewers.
- Dedicated authentication security diff scan completed with full scoped coverage and zero findings. This is a caller-owned configuration normalization inconsistency, not a vulnerability disclosure.
- Requesting `@openai/sdks-team` review because this touches authentication behavior.

## Compatibility and scope

Explicit `api_key` precedence, explicit `api_key: nil` semantics, caller `token_provider` behavior, AWS credential modes, endpoint/signing/profile/region behavior, and public APIs are unchanged.

Non-goals: no generic bearer-provider semantics change, environment caching, credential fallback, dependency/lockfile/generated-file changes, auth signature changes, or provider restructuring.

No live AWS/OpenAI requests or real credentials were used.
