### PR TITLE
ci: serialize lint task checks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -174,7 +174,17 @@ task("test:live:smoke") do
 end
 
 desc("Lint and typecheck")
-multitask(lint: [:"lint:rubocop", :"lint:rubocop_directives", :typecheck])
+# RuboCop temporarily changes cwd; sibling commands must not launch alongside it.
+task(:lint) do
+  failures = []
+  [:"lint:rubocop", :"lint:rubocop_directives", :typecheck].each do |name|
+    Rake::Task[name].invoke
+  rescue SystemExit, StandardError => error
+    failures << error
+  end
+
+  raise failures.first unless failures.empty?
+end
 
 desc("Build yard docs")
 multitask(:"build:docs") do

--- a/test/scripts/lint_task_scheduling_test.rb
+++ b/test/scripts/lint_task_scheduling_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "json"
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+
+class LintTaskSchedulingTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_lint_keeps_existing_checks_and_runs_cwd_sensitive_work_serially
+    result = run_rakefile_probe(
+      <<~RUBY
+        require "json"
+        require "rake"
+        require "timeout"
+        require "tmpdir"
+
+        load "Rakefile"
+
+        lint = Rake::Task["lint"]
+        rubocop = Rake::Task["lint:rubocop"]
+        typecheck = Rake::Task["typecheck"]
+        rubocop_prerequisites = rubocop.prerequisites
+        typecheck_prerequisites = typecheck.prerequisites
+
+        %w[
+          lint:rubocop
+          lint:rubocop_directives
+          lint:rubyfmt
+          lint:rbs_format
+          typecheck
+          typecheck:sorbet
+          validate:rbs
+        ].each { Rake::Task[_1].clear_actions }
+
+        entered = Queue.new
+        released = Queue.new
+        invoked = []
+        observed_cwd = nil
+        Dir.mktmpdir do |directory|
+          %w[lint:rubocop_directives lint:rubyfmt lint:rbs_format validate:rbs].each do |name|
+            Rake::Task[name].enhance { invoked << name }
+          end
+          rubocop.enhance do
+            invoked << "lint:rubocop"
+            Dir.chdir(directory) do
+              entered << true
+              Timeout.timeout(1) { released.pop }
+            rescue Timeout::Error
+              nil
+            end
+          end
+          Rake::Task["typecheck:sorbet"].enhance do
+            invoked << "typecheck:sorbet"
+            Timeout.timeout(2) { entered.pop }
+            observed_cwd = Dir.pwd
+            released << true
+          end
+
+          lint.invoke
+        end
+
+        puts JSON.generate(
+          lint_class: lint.class.name,
+          invoked: invoked,
+          rubocop_prerequisites: rubocop_prerequisites,
+          typecheck_prerequisites: typecheck_prerequisites,
+          observed_cwd: observed_cwd
+        )
+      RUBY
+    )
+
+    assert_equal("Rake::Task", result.fetch("lint_class"))
+    assert_equal(
+      %w[
+        lint:rbs_format
+        lint:rubocop
+        lint:rubocop_directives
+        lint:rubyfmt
+        typecheck:sorbet
+        validate:rbs
+      ],
+      result.fetch("invoked").sort
+    )
+    assert_equal(
+      %w[lint:rubocop_directives lint:rubyfmt lint:rbs_format],
+      result.fetch("rubocop_prerequisites")
+    )
+    assert_equal(%w[typecheck:sorbet validate:rbs], result.fetch("typecheck_prerequisites"))
+    assert_equal(ROOT, result.fetch("observed_cwd"))
+  end
+
+  def test_lint_propagates_existing_check_failures
+    result = run_rakefile_probe(
+      <<~RUBY
+        require "json"
+        require "rake"
+
+        load "Rakefile"
+
+        %w[
+          lint:rubocop
+          lint:rubocop_directives
+          lint:rubyfmt
+          lint:rbs_format
+          typecheck
+          typecheck:sorbet
+          validate:rbs
+        ].each { Rake::Task[_1].clear_actions }
+        invoked = []
+        Rake::Task["lint:rubocop"].enhance do
+          invoked << "lint:rubocop"
+          raise "synthetic rubocop failure"
+        end
+        Rake::Task["typecheck:sorbet"].enhance { invoked << "typecheck:sorbet" }
+
+        begin
+          Rake::Task["lint"].invoke
+        rescue RuntimeError => error
+          puts JSON.generate(error: error.message, invoked: invoked)
+        end
+      RUBY
+    )
+
+    assert_equal("synthetic rubocop failure", result.fetch("error"))
+    assert_equal(%w[lint:rubocop typecheck:sorbet], result.fetch("invoked"))
+  end
+
+  private
+
+  def run_rakefile_probe(source)
+    stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby,
+      "-e",
+      source,
+      chdir: ROOT
+    )
+    assert(status.success?, "#{stdout}\n#{stderr}")
+
+    JSON.parse(stdout)
+  end
+end


### PR DESCRIPTION
## Problem

The existing top-level `rake lint` gate used `Rake::MultiTask`. During supported `FORMAT_FILE` source discovery, RuboCop can temporarily change the process working directory while loading configuration. A sibling Sorbet launch could then inherit that temporary directory and fail to find `examples`.

## User-visible impact

Developers and CI can see a spurious lint failure even when the source tree is valid:

```
Couldn't open directory `examples`
```

The failure depends on task timing rather than source correctness.

## Fix

The top-level lint gate now invokes the same three existing branches in order:

1. RuboCop (including suppression validation, rubyfmt, and RBS formatting)
2. the existing explicit suppression-policy task
3. typecheck (Sorbet plus RBS validation)

Failures are collected so every top-level branch is still attempted, then the first failure is re-raised so the gate remains failing when any check fails. No check, command, `FORMAT_FILE` behavior, policy, dependency, or public SDK API changed.

## Regression coverage

The new focused test loads the real Rakefile in an isolated subprocess and uses safe synthetic task actions:

- it holds a cwd-changing RuboCop action and verifies Sorbet observes the repository root;
- it verifies the existing RuboCop/typecheck prerequisite graph still includes rubyfmt, RBS formatting/validation, suppression validation, and Sorbet;
- it verifies a synthetic RuboCop failure still allows the typecheck branch to run and still fails the lint gate.

Before this change, the supplied real-path driver observed Sorbet running from the external fixture directory and failing to open `examples`. Afterward, the same driver reports `parallel: false`, the repository-root cwd, and success.

## Scope and non-goals

Changed only:

- `Rakefile`
- `test/scripts/lint_task_scheduling_test.rb`

This does not add a scheduler abstraction, subprocess rewrite, mutex framework, timeout change, workflow/configuration change, policy exemption, dependency, generated-file patch, or unrelated cleanup. It does not explain the separate historical packaging failure.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/lint_task_scheduling_test.rb` — 2 runs, 9 assertions, 0 failures/errors/skips
- supplied `verify_lint_cwd.rb` against the edited worktree — success; Sorbet cwd equals repository root
- `mise exec ruby@4.0.6 -- bundle exec ./scripts/rubyfmt --check -- Rakefile test/scripts/lint_task_scheduling_test.rb` — pass
- `mise exec ruby@4.0.6 -- bundle exec rubocop --force-exclusion Rakefile test/scripts/lint_task_scheduling_test.rb` — 2 files, 0 offenses
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/formatting_policy_test.rb` — 11 runs, 208 assertions, 0 failures/errors/skips
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/validate_rubocop_directives_test.rb` — 17 runs, 50 assertions, 0 failures/errors/skips
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/validate_rbs_test.rb` — 13 runs, 77 assertions, 0 failures/errors/skips
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/rbs_format_test.rb` — 13 runs, 39 assertions, 0 failures/errors/skips
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — pass; RuboCop 2,867 files, directives, Sorbet, and 1,278 RBS validation all green
- `env TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1,583 runs, 14,256 assertions, 0 failures/errors, 1 skip
- trusted current-main public custom-code budget check on committed candidate — 3,311 / 4,000, success

## Review and security

Adversarial review converged after a supported failure-propagation finding was fixed, followed by two consecutive clean rounds with exactly two fresh independent read-only reviewers per round. The final candidate had no unresolved in-scope findings.

Security assessment: this changes local/CI task scheduling only. It adds no auth, transport, endpoint, redirect, TLS, upload/path, deserialization, logging, webhook, dependency, workflow-permission, or release-credential surface. SDK-team review is requested because this is CI/developer-tooling behavior.

## Limitations

The full suite retains one existing skip. No live API examples were run.
