### PR TITLE
ci: wait for ready mock PID records

### DIFF
--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -256,6 +256,22 @@ class TestWorkflowTest < Minitest::Test
     end
   end
 
+  def test_wait_for_file_requires_published_content
+    pid_record = File.join(@directory, "publishing-pid")
+    File.write(pid_record, "")
+
+    error = assert_raises(RuntimeError) { wait_for_file(pid_record, timeout: 0) }
+    assert_includes(error.message, "timed out waiting for")
+
+    File.write(pid_record, "42")
+    assert_raises(RuntimeError) { wait_for_file(pid_record, timeout: 0) }
+
+    File.write(pid_record, "4242\n")
+    wait_for_file(pid_record, timeout: 0)
+
+    assert_equal(4242, Integer(File.read(pid_record), 10))
+  end
+
   def test_process_exit_wait_treats_zombie_as_exited
     skip("requires Linux procfs") unless File.directory?("/proc/self")
 
@@ -462,11 +478,17 @@ class TestWorkflowTest < Minitest::Test
 
   def wait_for_file(path, timeout:)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-    until File.exist?(path)
+    until published_pid_record?(path)
       raise "timed out waiting for #{path}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
 
       sleep(0.01)
     end
+  end
+
+  def published_pid_record?(path)
+    File.read(path).match?(/\A\d+\n\z/)
+  rescue Errno::ENOENT
+    false
   end
 
   def wait_for_exit(pid, timeout:)


### PR DESCRIPTION
## Problem

`TestWorkflowTest#test_mock_launcher_cleans_up_its_process_group_when_interrupted` waited only for the PID-record path to exist. The mock fixture publishes that record with shell redirection, which creates/truncates the file before `printf` writes the PID. At that legitimate boundary, the test could read an empty record and raise `ArgumentError` from `Integer("")`.

## Change

- Treat a mock PID record as ready only when it contains the fixture's complete newline-terminated numeric publication shape.
- Add a deterministic regression that exercises empty, partial, and complete synthetic PID records through the existing private helper without timing sleeps.

From the test consumer's perspective, an empty or partially published record now remains pending until the existing deadline, while `"4242\n"` is accepted and parsed successfully.

## Scope and compatibility

This is confined to `test/scripts/test_workflow_test.rb`. It preserves existing process ownership, interruption cleanup assertions, deadlines, standalone/full-suite behavior, and all production scripts. It does not change public APIs, dependencies, generated files, common helpers, or repository policy/configuration.

## Verification

- Reproduced the prior helper boundary with the assigned synthetic probe: an existing zero-byte file returned immediately and the real consumer conversion raised `ArgumentError`.
- Red regression before fix: `1 runs, 1 assertions, 1 failures`.
- Focused regression after fix: `1 runs, 5 assertions, 0 failures, 0 errors, 0 skips`.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/scripts/test_workflow_test.rb`: `16 runs, 61 assertions, 0 failures, 0 errors, 1 skip`.
- `mise exec ruby@4.0.6 -- bundle exec rake lint`: clean (`2867 files inspected, no offenses detected`; `1278 RBS files` validated; Sorbet and directive checks clean).
- `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test`: `1582 runs, 14252 assertions, 0 failures, 0 errors, 1 skip`.
- Trusted current-main public custom-code check on committed candidate: success, `3311` custom lines / `4000` limit (`689` headroom).

## Review

Three required fresh-context adversarial-review rounds were run with two independent read-only reviewers each. Round 1 identified that non-empty content alone could admit a partial PID, which this final change corrects. Rounds 2 and 3 were consecutive clean rounds on unchanged final code.

Security assessment: test-fixture-only change; no authentication, transport, path, deserialization, logging, webhook, dependency, CI, or release security surface changed.

## Limitations

The regression validates the fixture publication contract rather than attempting to force a scheduler-dependent full-suite race. One platform-dependent existing test remains skipped in local runs.
