### PR TITLE
ci: avoid Ruby startup races in cleanup tests

### DIFF
--- a/test/scripts/test_workflow_test.rb
+++ b/test/scripts/test_workflow_test.rb
@@ -42,7 +42,7 @@ class TestWorkflowTest < Minitest::Test
   end
 
   def test_failed_mock_start_leaves_preexisting_listener_running
-    listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
+    listener_pid = spawn_waiting_process
     stdout, stderr, status = run_test_script(
       curl_mode: "http_error",
       mock_mode: "fail"
@@ -71,8 +71,8 @@ class TestWorkflowTest < Minitest::Test
   end
 
   def test_cleanup_stops_only_the_mock_owned_by_this_invocation
-    owned_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
-    preexisting_ipv6_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
+    owned_pid = spawn_waiting_process(pgroup: true)
+    preexisting_ipv6_pid = spawn_waiting_process(pgroup: true)
     stdout, stderr, status = run_test_script(
       curl_mode: "unavailable_until_mock",
       mock_owned_pid: owned_pid.to_s
@@ -99,7 +99,7 @@ class TestWorkflowTest < Minitest::Test
   end
 
   def test_failed_mock_readiness_cleans_up_the_owned_process_group
-    owned_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
+    owned_pid = spawn_waiting_process(pgroup: true)
     stdout, stderr, status = run_test_script(
       curl_mode: "unavailable_until_mock",
       mock_mode: "fail",
@@ -271,8 +271,8 @@ class TestWorkflowTest < Minitest::Test
   end
 
   def test_cleanup_leaves_non_listening_connections_running
-    listener_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60", pgroup: true)
-    client_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 60")
+    listener_pid = spawn_waiting_process(pgroup: true)
+    client_pid = spawn_waiting_process
     stdout, stderr, status = run_test_script(
       curl_mode: "unavailable_until_mock",
       mock_owned_pid: listener_pid.to_s
@@ -316,6 +316,12 @@ class TestWorkflowTest < Minitest::Test
   end
 
   private
+
+  def spawn_waiting_process(pgroup: false)
+    # Ruby can lose TERM during interpreter startup. These fixtures only need
+    # to wait for cleanup, so use a process with the native signal disposition.
+    Process.spawn("sleep", "60", pgroup: pgroup)
+  end
 
   def assert_bundle_ran
     assert_equal(["exec rake test"], calls(@bundle_calls))


### PR DESCRIPTION
The cleanup ownership tests can send TERM while a freshly spawned `ruby -e 'sleep 60'` fixture is still initializing. Replace those waiting-only Ruby processes with native `sleep` processes so cleanup uses the default OS signal handling from process startup.

## Root cause

[Ruby 3.3 CI on #604](https://github.com/openai/openai-ruby/actions/runs/33816588480/job/100849976225?pr=604) failed in `TestWorkflowTest#test_cleanup_leaves_non_listening_connections_running` with `expected cleanup to stop listener PID 2544`. This is separate from the Steady package-installation timeout and the PID-record publication race addressed by #603.

The test fixtures and `scripts/test` are unchanged between #604 and `main` at `94581ef37b47cc960f70db511b41299ab1cc9475`. The same test passed in [the main Ruby 3.3 job](https://github.com/openai/openai-ruby/actions/runs/33812004281/job/100835709759).

A bounded native-Linux signal probe reproduced the fixture race on Ruby 4.0.6: in 2 of 30 attempts, TERM sent 6 ms after spawn returned successfully before the Ruby program reached its body, but the process subsequently printed its readiness marker and remained alive beyond the test's five-second deadline. A second TERM stopped each process. The same 30 startup timings produced zero missed terminations with native `sleep`.

## Change

Use one private helper for the six waiting-process fixtures. Preserve their process-group settings, the five-second cleanup deadline, and the assertions that owned processes exit while unrelated processes remain alive. The mock launcher, cleanup scripts, SDK runtime, and dependencies are unchanged.

## Validation

- Workflow test file: 15 tests, 57 assertions, no failures/errors/skips.
- Same file with the full SDK test setup loaded: 15 tests, 57 assertions, no failures/errors/skips.
- `scripts/rubyfmt --check`, targeted RuboCop, and `git diff --check` passed.
- Native signal comparison: Ruby fixtures missed 2/30 initial TERM signals; native `sleep` missed 0/30.
- [Full CI passed](https://github.com/openai/openai-ruby/actions/runs/33817411524) on `cb05b371f2f2c4cc21556a6e165e3a35744ca6d9`, including Ruby 3.3, 3.4, and 4.0. CodeQL, baseline consistency, and both custom-code budget checks also passed.
