### PR TITLE
fix: expose response metadata on binary results

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,8 +936,9 @@ a supplied logger are isolated and never replace an API result or API error.
 ### Response metadata and request IDs
 
 OpenAI recommends logging request IDs in production so requests can be traced
-during troubleshooting. Top-level models and pages returned by the client expose
-immutable HTTP response metadata through `last_response`:
+during troubleshooting. Top-level models, pages, streams, and binary StringIO
+values returned by the client expose immutable HTTP response metadata through
+`last_response`:
 
 ```ruby
 response = openai.responses.create(model: "gpt-5.2", input: "Say 'this is a test'.")
@@ -945,6 +946,10 @@ puts(response.last_response.status)                 # 200
 puts(response.last_response.headers["x-request-id"]) # req_123
 puts(response.last_response.request_id)             # req_123
 puts(response._request_id)                           # req_123
+
+audio = openai.audio.speech.create(input: "Hello!", model: "tts-1", voice: "alloy")
+puts(audio.last_response.headers["x-request-id"])    # req_456
+puts(audio._request_id)                               # req_456
 ```
 
 Header names and values are normalized to strings, header names are lowercase,
@@ -953,11 +958,12 @@ HTTP response that opened the stream. Higher-level streaming helpers expose the
 same metadata as their underlying stream; models assembled from stream events
 do not.
 
-`last_response` and `_request_id` are only populated on top-level typed models
-and pages returned by the client. They are `nil` on constructed or nested models
-and are not included in `to_h`, JSON, or YAML output. Endpoints returning raw
-primitives, binary data, or `nil` do not expose this metadata. Unlike other
-properties that begin with an underscore, `_request_id` is public.
+`last_response` and `_request_id` are only populated on top-level models,
+pages, streams, and direct binary `StringIO` responses returned by the client.
+They are `nil` on constructed or nested models, unavailable on primitive or
+union-backed plain-text fallbacks, and are not included in `to_h`, JSON, or
+YAML output. Endpoints returning `nil` have no object that can carry metadata.
+Unlike other properties that begin with an underscore, `_request_id` is public.
 
 For failed HTTP requests, catch `OpenAI::Errors::APIStatusError` and use
 `request_id`:

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -874,12 +874,18 @@ module OpenAI
 
           unwrap = req[:unwrap]
           response_metadata = response.metadata
+          direct_binary_response = model.is_a?(Class) && model <= StringIO
           include_raw_body = req[:options].to_h[:include_raw_body] == true &&
             (req[:page] ||
-              (model.is_a?(Class) && model <= OpenAI::Internal::Type::BaseModel) ||
+              (model.is_a?(Class) &&
+                (model <= OpenAI::Internal::Type::BaseModel || direct_binary_response)) ||
               model.is_a?(OpenAI::Internal::Type::Union))
           raw_body = nil
-          decoded = if include_raw_body
+          decoded = if direct_binary_response
+            body = response.body.to_a.join
+            raw_body = body if include_raw_body
+            StringIO.new(body)
+          elsif include_raw_body
             OpenAI::Internal::Util.decode_content(response.headers, stream: response.body) do |body|
               raw_body = body
             end
@@ -887,11 +893,11 @@ module OpenAI
             OpenAI::Internal::Util.decode_content(response.headers, stream: response.body)
           end
 
-          if include_raw_body && !decoded.is_a?(StringIO)
+          if include_raw_body && (!decoded.is_a?(StringIO) || direct_binary_response)
             response_metadata = OpenAI::ResponseMetadata.new(
               status: response.status,
               headers: response.headers,
-              body: raw_body&.freeze
+              body: decoded.is_a?(StringIO) ? raw_body&.dup&.freeze : raw_body&.freeze
             )
           end
 
@@ -912,6 +918,8 @@ module OpenAI
             OpenAI::Internal::Type::Converter.coerce(model, unwrapped).tap do |result|
               if result.is_a?(OpenAI::Internal::Type::BaseModel)
                 result._set_last_response(response_metadata)
+              elsif result.is_a?(StringIO) && direct_binary_response
+                result.extend(OpenAI::ResponseCarrier)._set_last_response(response_metadata)
               end
             end
           end

--- a/lib/openai/internal/type/base_stream.rb
+++ b/lib/openai/internal/type/base_stream.rb
@@ -19,6 +19,14 @@ module OpenAI
         # @return [Hash{String=>String}]
         def headers = last_response.headers
 
+        # The ID of the API request, returned via the x-request-id response
+        # header.
+        #
+        # @api public
+        #
+        # @return [String, nil]
+        def _request_id = last_response.request_id
+
         # Metadata from the HTTP response that opened this stream.
         #
         # @api public

--- a/lib/openai/request_options.rb
+++ b/lib/openai/request_options.rb
@@ -66,9 +66,10 @@ module OpenAI
     optional :timeout, Float
 
     # @!attribute include_raw_body
-    #   Retain the exact successful HTTP response body on the returned model or
-    #   page through `last_response.body`. Body retention is disabled by default
-    #   and cannot be enabled for streaming responses.
+    #   Retain the exact successful HTTP response body on the returned model,
+    #   page, or direct binary StringIO response through `last_response.body`.
+    #   Body retention is disabled by default and cannot be enabled for
+    #   streaming responses.
     #
     #   @return [Boolean, nil]
     optional :include_raw_body, OpenAI::Internal::Type::Boolean

--- a/rbi/openai/internal/type/base_stream.rbi
+++ b/rbi/openai/internal/type/base_stream.rbi
@@ -18,6 +18,10 @@ module OpenAI
         sig { returns(T::Hash[String, String]) }
         attr_reader :headers
 
+        sig { returns(T.nilable(String)) }
+        def _request_id
+        end
+
         sig { returns(OpenAI::ResponseMetadata) }
         attr_reader :last_response
 

--- a/sig/openai/internal/type/base_stream.rbs
+++ b/sig/openai/internal/type/base_stream.rbs
@@ -8,6 +8,8 @@ module OpenAI
 
         attr_reader headers: ::Hash[String, String]
 
+        def _request_id: -> String?
+
         attr_reader last_response: OpenAI::ResponseMetadata
 
         def close: -> void

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -471,10 +471,10 @@ class OpenAITest < Minitest::Test
     end
   end
 
-  def test_raw_response_body_does_not_freeze_union_backed_text_responses
+  def test_union_backed_text_responses_remain_plain_string_io
     stub_request(:post, "http://localhost/audio/transcriptions").to_return(
       status: 200,
-      headers: {"content-type" => "text/plain"},
+      headers: {"content-type" => "text/plain", "x-request-id" => "req_text"},
       body: "transcribed audio"
     )
 
@@ -489,6 +489,8 @@ class OpenAITest < Minitest::Test
     assert_instance_of(StringIO, response)
     assert_equal("transcribed audio", response.read)
     assert_equal(1, response.write("!"))
+    refute_respond_to(response, :_request_id)
+    refute_respond_to(response, :last_response)
   end
 
   def test_raw_response_body_is_available_on_paginated_responses
@@ -579,7 +581,7 @@ class OpenAITest < Minitest::Test
     assert_equal("req_error", error.request_id)
   end
 
-  def test_non_model_results_are_not_wrapped_in_response_metadata
+  def test_binary_results_preserve_string_io_behavior_and_expose_response_metadata
     stub_request(:get, "http://localhost/files/file_123/content")
       .to_return(
         status: 200,
@@ -596,26 +598,63 @@ class OpenAITest < Minitest::Test
 
     assert_instance_of(StringIO, content)
     assert_equal("file contents", content.read)
-    refute_respond_to(content, :last_response)
+    assert_equal("req_binary", content._request_id)
+    assert_equal(200, content.last_response.status)
+    assert_equal("req_binary", content.last_response.request_id)
+    assert_equal(1, content.write("!"))
+    assert_nil(content.last_response.body)
+    refute_respond_to(StringIO.new, :last_response)
     assert_nil(result)
   end
 
-  def test_raw_response_body_does_not_change_non_model_results
+  def test_speech_results_expose_response_metadata
+    stub_request(:post, "http://localhost/audio/speech").to_return(
+      status: 200,
+      headers: {"X-Request-ID" => "req_speech"},
+      body: "synthetic audio"
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    audio = openai.audio.speech.create(input: "hello", model: "tts-1", voice: "alloy")
+
+    assert_instance_of(StringIO, audio)
+    assert_equal("synthetic audio", audio.read)
+    assert_equal("req_speech", audio._request_id)
+    assert_equal("req_speech", audio.last_response.request_id)
+  end
+
+  def test_binary_results_ignore_json_content_type
+    stub_request(:get, "http://localhost/files/file_123/content").to_return(
+      status: 200,
+      headers: {"content-type" => "application/json", "x-request-id" => "req_json_binary"},
+      body: "{\"payload\":true}"
+    )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    content = openai.files.content("file_123")
+
+    assert_instance_of(StringIO, content)
+    assert_equal("{\"payload\":true}", content.read)
+    assert_equal("req_json_binary", content._request_id)
+  end
+
+  def test_raw_response_body_is_available_on_binary_results
     stub_request(:get, "http://localhost/files/file_123/content")
-      .to_return(status: 200, body: "file contents")
-    stub_request(:delete, "http://localhost/responses/resp_123")
-      .to_return(status: 204, body: "")
+      .to_return(status: 200, headers: {"X-Request-ID" => "req_binary_raw"}, body: "file contents")
 
     openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
 
     content = openai.files.content("file_123", request_options: {include_raw_body: true})
-    result = openai.responses.delete("resp_123", request_options: {include_raw_body: true})
-
     assert_instance_of(StringIO, content)
     assert_equal("file contents", content.read)
     assert_equal(1, content.write("!"))
-    refute_respond_to(content, :last_response)
-    assert_nil(result)
+    assert_equal("req_binary_raw", content._request_id)
+    assert_equal("file contents", content.last_response.body)
+    assert_predicate(content.last_response.body, :frozen?)
+    serialized = YAML.dump(content)
+    refute_includes(serialized, "last_response")
+    refute_includes(serialized, "req_binary_raw")
+    refute_includes(serialized, "file contents")
   end
 
   def test_client_default_request_default_retry_attempts

--- a/test/openai/resources/responses/streaming_test.rb
+++ b/test/openai/resources/responses/streaming_test.rb
@@ -137,6 +137,7 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     stream = @client.responses.stream_raw(**basic_params)
 
     assert_equal(200, stream.last_response.status)
+    assert_equal("req_stream", stream._request_id)
     assert_equal("req_stream", stream.last_response.request_id)
     assert_equal("text/event-stream", stream.last_response.headers["content-type"])
     assert_same(stream.last_response.headers, stream.headers)


### PR DESCRIPTION
## API contract

For endpoints that directly return a binary `StringIO`, the SDK still returns that same writable `StringIO` object. The object now also exposes `last_response` and `_request_id`, so callers can read headers and request IDs without losing the familiar IO API.

With `include_raw_body: true`, `last_response.raw_body` is a separate frozen copy of the bytes; reading or writing the returned IO does not mutate the retained raw body. Binary endpoints stay binary even when the server labels the response as JSON. Streaming responses expose `_request_id` on the stream object. Union-backed text fallbacks and user-created `StringIO` values are unchanged.

## Blocked by

- https://github.com/openai/openai/pull/1396337 — Castiron source support
- https://github.com/openai/openai-ruby-internal/pull/80 — generated loader, carrier, and signatures

This draft contains only the SDK-owned runtime, documentation, and tests. It intentionally does not duplicate the generated `ResponseCarrier` files from the internal generator artifact.

## What changed

- Attach response metadata to direct binary `StringIO` results.
- Preserve a frozen raw-body copy when requested.
- Expose request IDs on streaming results.
- Document the behavior and add focused regressions for binary, streaming, YAML, and fallback cases.

## Validation

- `bundle exec ruby -Ilib -ropenai/response_carrier -Itest test/openai/client_test.rb` (with the generated carrier from #80 on `RUBYLIB`)
- `bundle exec ruby -Ilib -ropenai/response_carrier -Itest test/openai/resources/responses/streaming_test.rb` (with the generated carrier from #80 on `RUBYLIB`)
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck`
- `mise exec ruby@4.0.6 -- bundle exec rubocop lib/openai/internal/transport/base_client.rb lib/openai/internal/type/base_stream.rb lib/openai/request_options.rb test/openai/client_test.rb test/openai/resources/responses/streaming_test.rb`
- `git diff --check`
