### PR TITLE
fix: parse quoted response charsets

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -654,7 +654,8 @@ module OpenAI
         # @param content_type [String]
         # @param text [String]
         def force_charset!(content_type, text:)
-          charset = /charset=([^;\s]+)/.match(content_type)&.captures&.first
+          match = /(?:\A|;)\s*charset\s*=\s*(?:"([^"]+)"|([^;\s]+))/i.match(content_type)
+          charset = match&.captures&.compact&.first
 
           return unless charset
 

--- a/test/openai/client_test.rb
+++ b/test/openai/client_test.rb
@@ -1147,6 +1147,20 @@ class OpenAITest < Minitest::Test
     end
   end
 
+  def test_binary_content_honors_quoted_response_charset
+    stub_request(:get, "http://localhost/files/file_quoted_charset/content")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/plain; charset=\"UTF-8\""},
+        body: "\xC3\xA9".b
+      )
+
+    openai = OpenAI::Client.new(base_url: "http://localhost", api_key: "My API Key")
+    content = openai.files.content("file_quoted_charset")
+
+    assert_equal(Encoding::UTF_8, content.read.encoding)
+  end
+
   private
 
   def assert_web_search_statuses(resource, url)


### PR DESCRIPTION
## Summary

Handle quoted `charset` parameters when decoding raw response bodies.

`Content-Type: text/plain; charset="UTF-8"` currently leaves the returned `StringIO` tagged `ASCII-8BIT` because the quotes are included in the value passed to `Encoding.find`. The decoder now accepts quoted and unquoted charset values consistently.

Fixes #610.

## Testing

- public `files.content` regression: passed on Ruby 4.0.6
- `test/openai/client_test.rb`: 48 passed, 232 assertions
- `test/openai/internal/util_test.rb`: 62 passed, 286 assertions
- `bundle exec rake lint:rubocop`: 2,869 files inspected, no offenses
- `git diff --check`: passed

No response contents or return types change; only the declared Ruby string encoding is corrected when the charset value is quoted.
