### PR TITLE
fix: handle quoted response charsets

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -655,6 +655,7 @@ module OpenAI
         # @param text [String]
         def force_charset!(content_type, text:)
           charset = /charset=([^;\s]+)/.match(content_type)&.captures&.first
+          charset = charset[1...-1] if charset&.start_with?("\"") && charset.end_with?("\"")
 
           return unless charset
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -850,6 +850,14 @@ class OpenAI::Test::UtilContentDecodingTest < Minitest::Test
       assert_equal(encoding, text.encoding)
     end
   end
+
+  def test_quoted_charset
+    text = String.new.force_encoding(Encoding::BINARY)
+
+    OpenAI::Internal::Util.force_charset!("application/json; charset=\"UTF-8\"", text: text)
+
+    assert_equal(Encoding::UTF_8, text.encoding)
+  end
 end
 
 class OpenAI::Test::UtilSseTest < Minitest::Test


### PR DESCRIPTION
## Summary

- Handle balanced quotes around response `charset` parameters before resolving the Ruby encoding.
- Add regression coverage for `charset="UTF-8"`.

## Root cause

The charset extractor included surrounding quotes in the captured value. Ruby rejects `"UTF-8"` as an encoding name, and the existing `ArgumentError` fallback left the response tagged as `ASCII-8BIT`.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/util_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec rubocop lib/openai/internal/util.rb test/openai/internal/util_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec rake test`
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop`
- End-to-end local HTTP reproduction through `client.files.content` confirmed quoted and unquoted UTF-8 both return `StringIO` with unchanged bytes tagged `UTF-8`.

Closes #610
