### PR TITLE
ci: preserve trailing RBS alias comments

### DIFF
--- a/scripts/rbs_format.rb
+++ b/scripts/rbs_format.rb
@@ -45,11 +45,15 @@ module RBSFormat
     alias_declarations(RBS::Parser.parse_signature(source).last).reverse_each do |declaration|
       location = declaration.location
       kind = location[:keyword].source
+      line_end = source.index("\n", location.end_pos) || source.length
+      trailing_comment = source[location.end_pos...line_end].match(/\A[ \t]*(#.*)\z/)&.captures&.first
       restorations[location.start_pos] = if location.source.include?("#")
         location.source
       else
         "#{kind} #{declaration.new_name} = #{declaration.old_name}"
       end
+
+      restorations[location.start_pos] += " #{trailing_comment}" if trailing_comment
 
       protected_source[location.start_pos...location.end_pos] = "# #{kind} #{marker}-#{location.start_pos}\n#{declaration.new_name}: #{declaration.old_name}"
     end

--- a/test/scripts/rbs_format_test.rb
+++ b/test/scripts/rbs_format_test.rb
@@ -40,6 +40,35 @@ class RBSFormatTest < Minitest::Test
     assert_equal("module Example\n  module Alias = ::Enumerable\nend\n", RBSFormat.format(source))
   end
 
+  def test_preserves_trailing_comments_on_top_level_and_nested_aliases
+    source = <<~RBS
+      class   TopClass   =   ::String # top-level class note
+      module\tTopModule\t=\t::Enumerable # top-level module note
+      module Example
+        class   NestedClass   =   ::String # nested class note
+        module\tNestedModule\t=\t::Enumerable # nested module note
+      end
+    RBS
+
+    expected = <<~RBS
+      class TopClass = ::String # top-level class note
+
+      module TopModule = ::Enumerable # top-level module note
+
+      module Example
+        class NestedClass = ::String # nested class note
+
+        module NestedModule = ::Enumerable # nested module note
+      end
+    RBS
+
+    formatted = RBSFormat.format(source)
+
+    assert_equal(expected, formatted)
+    assert_equal(formatted, RBSFormat.format(formatted))
+    RBS::Parser.parse_signature(formatted)
+  end
+
   def test_does_not_treat_commented_declarations_as_aliases
     source = <<~RBS
       # class Alias = ::String
@@ -114,6 +143,21 @@ class RBSFormatTest < Minitest::Test
         assert_empty(RBSFormat.run([file.path], check: false))
         assert_equal(source, File.read(file.path))
       end
+    end
+  end
+
+  def test_check_and_write_modes_preserve_trailing_alias_comments
+    source = "class   Alias   =   ::String # compatibility note\n"
+    expected = "class Alias = ::String # compatibility note\n"
+
+    Tempfile.create(["rbs-format", ".rbs"]) do |file|
+      file.write(source)
+      file.flush
+
+      assert_equal([file.path], RBSFormat.run([file.path], check: true))
+      assert_equal(source, File.read(file.path))
+      assert_equal([file.path], RBSFormat.run([file.path], check: false))
+      assert_equal(expected, File.read(file.path))
     end
   end
 


### PR DESCRIPTION
## Problem

The repository RBS formatter silently deleted a trailing comment attached to a real class or module alias declaration. For example, formatting synthetic input such as `class Alias = ::String # keep this compatibility note` produced `class Alias = ::String`, so write mode could erase compatibility notes from handwritten signatures.

## Fix

The existing alias workaround now captures a whitespace-delimited same-line `#...` suffix immediately after the parser location and restores it after normalizing the alias declaration. This keeps normal alias whitespace formatting while leaving existing handling for internal and adjacent-keyword comments unchanged.

## Before and after

```rbs
# Before formatter output
class Alias = ::String

# After formatter output
class Alias = ::String # keep this compatibility note
```

The regression uses only deterministic synthetic RBS data and covers top-level and nested class and module aliases, spaces and tabs, parseability, idempotence, check-mode non-mutation, and write-mode preservation.

## Scope and compatibility

This is a CI/tooling-only change confined to `scripts/rbs_format.rb` and `test/scripts/rbs_format_test.rb`. It does not change the gem runtime, public API, signatures/models, generated files, dependencies, formatter policy, or annotation behavior. No dedicated runtime security surface is touched.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/scripts/rbs_format_test.rb` — 17 runs, 52 assertions, 0 failures, 0 errors, 0 skips
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop inspected 2,869 files with no offenses; Sorbet no errors; 1,278 RBS files validated
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck` — Sorbet no errors; 1,278 RBS files validated
- `env TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1,624 runs, 14,434 assertions, 0 failures, 0 errors, 1 skip
- Trusted current-main public custom-code budget check on committed candidate `acb63d6e0dcfa00a746ad113dbb3be6a77632888` — success, 3,363 / 4,000 custom lines

## Review

Two consecutive fresh-context adversarial-review rounds completed on the unchanged final diff. Each round used two independent read-only reviewers: correctness/security/contracts/compatibility/tests and architecture/simplicity/ownership/performance. All four reviews were clean with no supported in-scope blocking findings and no separate follow-up findings.

## Limitations

The broad suite retains its existing single skip. No live API examples were run.
