### PR TITLE
examples: correct streaming helper guide examples

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -22,7 +22,7 @@ puts
 
 The stream will be cancelled when the block exits but you can also close it prematurely by calling `stream.close`.
 
-See an example of streaming helpers in action in [`examples/responses/streaming.rb`](examples/responses/streaming.rb).
+See an example of streaming helpers in action in [`examples/responses/streaming_basic.rb`](examples/responses/streaming_basic.rb).
 
 ### Events
 
@@ -199,7 +199,7 @@ puts
 
 The stream will be cancelled when the block exits but you can also close it prematurely by calling `stream.close`.
 
-See an example of streaming helpers in action in [`examples/chat/streaming.rb`](examples/chat/streaming.rb).
+See an example of streaming helpers in action in [`examples/chat/streaming_basic.rb`](examples/chat/streaming_basic.rb).
 
 ### Events
 
@@ -246,14 +246,13 @@ when OpenAI::Streaming::ChatChunkEvent
 
 #### `ChatContentDeltaEvent`
 
-This event is yielded whenever a text content delta is returned by the API & includes the delta and the accumulated snapshot, e.g.
+This event is yielded whenever a text content delta is returned by the API & includes the delta and the accumulated snapshot. Use these string values while content is streaming; when using structured outputs, typed parsed content is available from the done event or final completion.
 
 ```ruby
 when OpenAI::Streaming::ChatContentDeltaEvent
   event.type  # :"content.delta"
   event.delta  # " world"
   event.snapshot  # "Hello world"
-  event.parsed  # Your partially parsed model instance (when using structured outputs)
 ```
 
 #### `ChatContentDoneEvent`
@@ -290,16 +289,16 @@ when OpenAI::Streaming::ChatRefusalDoneEvent
 
 #### `ChatFunctionToolCallArgumentsDeltaEvent`
 
-This event is yielded whenever function call arguments are being streamed & includes the delta and accumulated snapshot, e.g.
+This event is yielded whenever function call arguments are being streamed & includes the delta and accumulated snapshot. For strict tools, `parsed` is populated once the accumulated arguments are complete, valid JSON.
 
 ```ruby
 when OpenAI::Streaming::ChatFunctionToolCallArgumentsDeltaEvent
   event.type  # :"tool_calls.function.arguments.delta"
   event.name  # "get_weather"
   event.index  # 0 (tool call index in array)
-  event.arguments_delta  # '{"location": "San'
-  event.arguments  # '{"location": "San Francisco"'
-  event.parsed  # {location: "San Francisco"} (if strict: true)
+  event.arguments_delta  # ' Francisco"}'
+  event.arguments  # '{"location": "San Francisco"}'
+  event.parsed  # {location: "San Francisco"} (for a strict tool)
 ```
 
 #### `ChatFunctionToolCallArgumentsDoneEvent`
@@ -397,7 +396,7 @@ class Haiku < OpenAI::BaseModel
 end
 
 stream = client.chat.completions.stream(
-  model: "gpt-4",
+  model: "gpt-4o-mini",
   messages: [{role: "user", content: "Write a haiku about Ruby"}],
   response_format: Haiku
 )

--- a/lib/openai/helpers/streaming/chat_events.rb
+++ b/lib/openai/helpers/streaming/chat_events.rb
@@ -22,17 +22,18 @@ module OpenAI
       #
       # Emitted as the assistant's text response is being generated. Each event
       # contains the new text fragment (delta) and the complete accumulated
-      # text so far (snapshot).
+      # text so far (snapshot). Use these string values while content is
+      # streaming; when using structured outputs, typed parsed content is
+      # available from the done event or final completion.
       #
       # @example
       #   event.delta    # => "Hello"        (new fragment)
       #   event.snapshot # => "Hello world"  (accumulated text)
-      #   event.parsed   # => {name: "John"} (if using structured outputs)
       class ChatContentDeltaEvent < OpenAI::Internal::Type::BaseModel
         required :type, const: :"content.delta"
         required :delta, String
         required :snapshot, String
-        # Partially parsed structured output
+        # Parsed content for structured outputs is available from done/final results.
         optional :parsed, Object
       end
 
@@ -81,14 +82,15 @@ module OpenAI
       # Incremental function tool call arguments update.
       #
       # Emitted as function arguments are being streamed. Provides both the
-      # raw JSON fragments and incrementally parsed arguments for strict tools.
+      # raw JSON fragments and, for strict tools, parsed arguments once the
+      # accumulated arguments are complete, valid JSON.
       #
       # @example
       #   event.name            # => "get_weather"
       #   event.index           # => 0 (tool call index in array)
-      #   event.arguments_delta # => '{"location": "San'  (new fragment)
-      #   event.arguments       # => '{"location": "San Francisco"'  (accumulated JSON)
-      #   event.parsed # => {location: "San Francisco"}  (if strict: true)
+      #   event.arguments_delta # => ' Francisco"}'  (new fragment)
+      #   event.arguments       # => '{"location": "San Francisco"}'  (accumulated JSON)
+      #   event.parsed # => {location: "San Francisco"}  (for a strict tool)
       class ChatFunctionToolCallArgumentsDeltaEvent < OpenAI::Internal::Type::BaseModel
         required :type, const: :"tool_calls.function.arguments.delta"
         required :name, String


### PR DESCRIPTION
## Problem

Ruby users following the streaming helper guide encountered two local links to example files that do not exist. The Chat structured-output Haiku used gpt-4, even though JSON-schema structured outputs require a supported GPT-4o-class model. The Chat content and strict function-tool delta examples also implied tolerant partial-JSON parsing that the SDK does not implement.

## Change

- Point the Responses and Chat streaming-helper links at the existing streaming_basic.rb examples.
- Change only the structured-output Chat Haiku model from gpt-4 to gpt-4o-mini.
- Direct content-stream users to delta and snapshot during streaming, with typed parsed content on done/final results when structured outputs are configured.
- Document that strict tool arguments become parsed only once accumulated arguments are complete, valid JSON; the example now shows a final fragment completing valid accumulated JSON.
- Keep the matching Chat event YARD comments consistent with the guide.

## Safe synthetic before/after evidence

The offline public-path WebMock probe disables all network access. On the immutable base it demonstrated content delta parsed values [nil, nil], followed by a typed Haiku done result; for a strict function stream it demonstrated incomplete accumulated arguments {"x": with parsed nil, then complete {"x":1} with parsed {x: 1}. The corrected guide now describes that existing behavior. The same probe verifies that the old link targets are absent and both new streaming_basic.rb targets exist.

## Impact and compatibility

This is documentation and comments only. It changes no runtime statement, schema, event type, field, method, request serialization, public API, dependency, or generated file. Existing users receive more accurate runnable examples; runtime behavior is unchanged.

## Scope and non-goals

Changed only helpers.md and comments in lib/openai/helpers/streaming/chat_events.rb. This does not implement partial JSON parsing, remove parsed fields, redesign documentation, change unrelated model selections, add tests, or modify open-PR-owned files.

## Verification

- Offline public-path streaming guide contract probe: passed; confirmed content delta parsed [nil, nil], typed done result, strict tool parsed [nil, {x: 1}], and link existence.
- test/openai/resources/chat/completions/streaming_test.rb: 22 runs, 107 assertions, 0 failures.
- test/openai/resources/chat/completions/streaming_snapshot_test.rb: 15 runs, 73 assertions, 0 failures.
- test/openai/helpers/chat_completion_stream_test.rb: 10 runs, 47 assertions, 0 failures.
- test/openai/helpers/chat_completion_parser_test.rb: 11 runs, 186 assertions, 0 failures.
- rake lint: passed; RuboCop inspected 2,869 files with no offenses, Sorbet examples typecheck passed, and 1,278 RBS files validated.
- Ruby syntax, changed complete guide fence compilation, git diff --check, link checks, and offline example inventory: passed.
- Trusted current-main public custom-code budget check on committed candidate: passed at 3,363 / 4,000 custom lines.

## Adversarial review and security

Four fresh-context two-reviewer rounds were run. Round 2 found one in-scope wording issue: parsed content needed to be qualified as requiring structured outputs. That was fixed. Rounds 3 and 4 were consecutive clean rounds on unchanged code. Security assessment: comments/docs only; no authentication, transport, deserialization, logging, dependency, CI, or other sensitive surface changed.

## Limitations

No live API example was run; model capability is documentation-backed, and behavioral verification used safe synthetic public-path streams.