### PR TITLE
fix: accept string Responses structured-output tags

### DIFF
--- a/lib/openai/helpers/structured_output/response_parser.rb
+++ b/lib/openai/helpers/structured_output/response_parser.rb
@@ -85,7 +85,7 @@ module OpenAI
           in {
               text: {
                   format: {
-                      type: :json_schema,
+                      type: :json_schema | "json_schema",
                       schema: OpenAI::StructuredOutput::JsonSchemaConverter => model
                     }
                 }
@@ -108,7 +108,7 @@ module OpenAI
                   name: name,
                   parameters: tool.to_json_schema
                 }
-              in {type: :function, parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}
+              in {type: :function | "function", parameters: OpenAI::StructuredOutput::JsonSchemaConverter => params}
                 func = tool.fetch(:function, tool)
                 name = func[:name] ||= params.name.split("::").last
                 tool_models.store(name, params)

--- a/test/openai/helpers/responses_string_type_hints_test.rb
+++ b/test/openai/helpers/responses_string_type_hints_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResponsesStringTypeHintsTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class TypeHintText < OpenAI::BaseModel
+    required :value, String
+  end
+
+  class TypeHintTool < OpenAI::BaseModel
+    required :argument, Integer
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_string_json_schema_tag_matches_symbol_tag
+    symbol_wire, symbol_response = create_response(
+      text: text_config(:json_schema),
+      output: [text_output]
+    )
+    string_wire, string_response = create_response(
+      text: text_config("json_schema"),
+      output: [text_output]
+    )
+
+    assert_equal(symbol_wire.fetch("text"), string_wire.fetch("text"))
+    assert_equal(wire_schema(TypeHintText), string_wire.dig("text", "format", "schema"))
+    assert_equal("explicit_text", string_wire.dig("text", "format", "name"))
+    assert_equal(false, string_wire.dig("text", "format", "strict"))
+    assert_equal("keep", string_wire.dig("text", "format", "description"))
+    assert_instance_of(TypeHintText, symbol_response.output.first.content.first.parsed)
+    assert_instance_of(TypeHintText, string_response.output.first.content.first.parsed)
+    assert_equal("ok", string_response.output.first.content.first.parsed.value)
+  end
+
+  def test_string_function_tag_matches_symbol_tag
+    symbol_wire, symbol_response = create_response(
+      tools: [tool_config(:function)],
+      output: [tool_output("lookup")]
+    )
+    string_wire, string_response = create_response(
+      tools: [tool_config("function")],
+      output: [tool_output("lookup")]
+    )
+
+    assert_equal(symbol_wire.fetch("tools"), string_wire.fetch("tools"))
+    assert_equal(wire_schema(TypeHintTool), string_wire.dig("tools", 0, "parameters"))
+    assert_equal("lookup", string_wire.dig("tools", 0, "name"))
+    assert_equal(false, string_wire.dig("tools", 0, "strict"))
+    assert_equal("keep", string_wire.dig("tools", 0, "description"))
+    assert_instance_of(TypeHintTool, symbol_response.output.first.parsed)
+    assert_instance_of(TypeHintTool, string_response.output.first.parsed)
+    assert_equal(7, string_response.output.first.parsed.argument)
+  end
+
+  def test_string_tags_register_text_and_tool_models_together
+    wire, response = create_response(
+      text: text_config("json_schema"),
+      tools: [tool_config("function")],
+      output: [text_output, tool_output("lookup")]
+    )
+
+    assert_equal(wire_schema(TypeHintText), wire.dig("text", "format", "schema"))
+    assert_equal(wire_schema(TypeHintTool), wire.dig("tools", 0, "parameters"))
+    assert_instance_of(TypeHintText, response.output.fetch(0).content.first.parsed)
+    assert_instance_of(TypeHintTool, response.output.fetch(1).parsed)
+  end
+
+  def test_string_function_tag_preserves_default_tool_name
+    wire, response = create_response(
+      tools: [{type: "function", parameters: TypeHintTool}],
+      output: [tool_output("TypeHintTool")]
+    )
+
+    assert_equal("TypeHintTool", wire.dig("tools", 0, "name"))
+    assert_instance_of(TypeHintTool, response.output.first.parsed)
+  end
+
+  private
+
+  def wire_schema(model)
+    JSON.parse(JSON.generate(model.to_json_schema))
+  end
+
+  def create_response(text: nil, tools: nil, output:)
+    wire = nil
+    stub_request(:post, "http://localhost/responses").to_return do |request|
+      wire = JSON.parse(request.body)
+      {
+        status: 200,
+        headers: {"Content-Type" => "application/json"},
+        body: JSON.generate(id: "resp_synthetic", object: "response", status: "completed", output: output)
+      }
+    end
+
+    params = {model: "gpt-4o-mini", input: "synthetic"}
+    params.store(:text, text) if text
+    params.store(:tools, tools) if tools
+    response = @client.responses.create(**params)
+
+    [wire, response]
+  end
+
+  def text_config(type)
+    {
+      format: {
+        type: type,
+        name: "explicit_text",
+        strict: false,
+        description: "keep",
+        schema: TypeHintText
+      }
+    }
+  end
+
+  def tool_config(type)
+    {
+      type: type,
+      name: "lookup",
+      strict: false,
+      description: "keep",
+      parameters: TypeHintTool
+    }
+  end
+
+  def text_output
+    {
+      type: "message",
+      id: "msg_synthetic",
+      role: "assistant",
+      status: "completed",
+      content: [{type: "output_text", text: "{\"value\":\"ok\"}", annotations: []}]
+    }
+  end
+
+  def tool_output(name)
+    {
+      type: "function_call",
+      id: "fc_synthetic",
+      call_id: "call_synthetic",
+      name: name,
+      arguments: "{\"argument\":7}",
+      status: "completed"
+    }
+  end
+end


### PR DESCRIPTION
## Problem

Responses structured-output preparation recognized symbol tags but missed the equivalent string tags for nested text JSON schema formats and flat function tools. A request such as `type: "json_schema"` or `type: "function"` with an OpenAI structured-output model serialized the Ruby class name instead of the model JSON schema, so returned text or tool calls had no typed `parsed` value.

## User impact

Applications that build request hashes from JSON-like configuration can use the documented existing Responses shapes with string tag values and receive the same schema serialization and typed parsing as symbol-tag callers.

## Fix

Widen the two existing Responses parser pattern matches to accept the string spellings alongside their supported symbols:

- nested `text.format.type`: `:json_schema` or `"json_schema"`
- flat tool `type`: `:function` or `"function"`

No global coercion or request normalization was added. Existing name/default-name, strictness, sibling options, raw schema, mutation, and retrieval-hint behavior remain on their current paths.

## Regression coverage

Added a network-disabled public `client.responses.create` WebMock test file that inspects wire JSON and typed results for:

- string versus symbol nested text tags
- string versus symbol flat function-tool tags
- both string-tag paths together
- the existing default tool-name behavior

The safe synthetic red probe showed symbol forms sending object schemas and returning typed values, while string forms sent class-name strings and returned nil parsed fields. After the fix, both forms send equivalent schemas and return typed values. No live API calls were made.

## Scope and non-goals

Only `lib/openai/helpers/structured_output/response_parser.rb` and the new focused test file changed. This does not add public APIs, model features, Sorbet behavior, general transport coercion, strictness changes, streaming-state changes, generated-file edits, dependencies, schema caching, recursion work, or broader normalization.

## Validation

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/responses_string_type_hints_test.rb` — 4 runs, 22 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/structured_output_api_names_test.rb` — 40 runs, 133 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/resources/responses/streaming_test.rb` — 33 runs, 122 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — 2,870 RuboCop files clean; RBS validation and Sorbet examples clean
- serialized `TEST_API_BASE_URL=... mise exec ruby@4.0.6 -- bundle exec rake test` — 1,627 runs, 14,451 assertions, 0 failures, 0 errors, 1 skip
- trusted public custom-code budget on committed candidate — 3,363 / 4,000 lines, 637 headroom

## Review and security

Two consecutive adversarial-review rounds completed on unchanged code, each with two new independent read-only reviewers; all four reviews were clean. A bounded security review found no new credential, transport, logging, dependency, or deserialization boundary: the change only recognizes existing request tags and uses the existing schema conversion and model-registration paths.

## Limitations

The tests use safe synthetic WebMock responses and do not claim a live-server rejection or make live API requests.