### PR TITLE
ci: validate example runner timeout settings

### DIFF
--- a/scripts/examples-e2e.rb
+++ b/scripts/examples-e2e.rb
@@ -361,7 +361,7 @@ module OpenAIExamplesE2E
       options = {
         inventory_only: false,
         report_dir: Pathname(ENV.fetch("EXAMPLES_E2E_REPORT_DIR", @root.join("tmp/examples-e2e").to_s)),
-        timeout: Integer(ENV.fetch("EXAMPLES_E2E_TIMEOUT", DEFAULT_TIMEOUT.to_s), 10)
+        timeout: nil
       }
       OptionParser
         .new do |parser|
@@ -383,7 +383,21 @@ module OpenAIExamplesE2E
           end
         end
         .parse!(arguments)
+      options[:timeout] = effective_timeout(options[:timeout])
       options
+    end
+
+    def effective_timeout(explicit_timeout)
+      timeout = explicit_timeout.nil? ? environment_timeout : explicit_timeout
+      return timeout if timeout.positive?
+
+      raise ConfigurationError, "timeout must be a positive integer number of seconds"
+    end
+
+    def environment_timeout
+      Integer(ENV.fetch("EXAMPLES_E2E_TIMEOUT", DEFAULT_TIMEOUT.to_s), 10)
+    rescue ArgumentError
+      raise ConfigurationError, "timeout must be a positive integer number of seconds"
     end
 
     def ensure_api_key!

--- a/test/scripts/examples_e2e_timeout_test.rb
+++ b/test/scripts/examples_e2e_timeout_test.rb
@@ -12,6 +12,8 @@ require "yaml"
 require_relative "../../scripts/examples-e2e"
 
 class ExamplesE2ETimeoutTest < Minitest::Test
+  extend Minitest::Serial if defined?(Minitest::Serial)
+
   CLI_TEST_MUTEX = Mutex.new
 
   def test_rejects_invalid_effective_environment_timeouts_before_runner_or_report
@@ -188,6 +190,7 @@ class ExamplesE2ETimeoutTest < Minitest::Test
   end
 
   def with_environment(values)
+    previous = {}
     previous = values.to_h { |name, _value| [name, ENV[name]] }
     values.each { |name, value| ENV[name] = value }
     yield

--- a/test/scripts/examples_e2e_timeout_test.rb
+++ b/test/scripts/examples_e2e_timeout_test.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "minitest/mock"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "stringio"
+require "tmpdir"
+require "yaml"
+
+require_relative "../../scripts/examples-e2e"
+
+class ExamplesE2ETimeoutTest < Minitest::Test
+  def test_rejects_invalid_effective_environment_timeouts_before_runner_or_report
+    ["0", "-1", "", "not-a-number"].each do |timeout|
+      with_cli(timeout: timeout) do |cli, report_directory, error_output|
+        runner_started = false
+        factory = lambda do |**_options|
+          runner_started = true
+        end
+
+        status = OpenAIExamplesE2E::Runner.stub(:new, factory) { cli.run([]) }
+
+        assert_equal(1, status, "timeout #{timeout.inspect}")
+        refute(runner_started, "timeout #{timeout.inspect} constructed a runner")
+        assert_includes(error_output.string, "positive integer")
+        refute(report_directory.exist?)
+      end
+    end
+  end
+
+  def test_rejects_non_positive_cli_timeouts_before_runner_or_report
+    ["0", "-1"].each do |timeout|
+      with_cli do |cli, report_directory, error_output|
+        runner_started = false
+        factory = lambda do |**_options|
+          runner_started = true
+        end
+
+        status = OpenAIExamplesE2E::Runner.stub(:new, factory) do
+          cli.run(["--timeout", timeout])
+        end
+
+        assert_equal(1, status, "timeout #{timeout.inspect}")
+        refute(runner_started, "timeout #{timeout.inspect} constructed a runner")
+        assert_includes(error_output.string, "positive integer")
+        refute(report_directory.exist?)
+      end
+    end
+  end
+
+  def test_preserves_option_parser_diagnostic_for_malformed_cli_timeout
+    with_cli do |cli, report_directory, error_output|
+      runner_started = false
+      factory = lambda do |**_options|
+        runner_started = true
+      end
+
+      status = OpenAIExamplesE2E::Runner.stub(:new, factory) do
+        cli.run(["--timeout", "not-a-number"])
+      end
+
+      assert_equal(1, status)
+      refute(runner_started)
+      assert_includes(error_output.string, "invalid argument: --timeout not-a-number")
+      refute(report_directory.exist?)
+    end
+  end
+
+  def test_executable_argument_path_handles_invalid_environment_timeout
+    with_cli(timeout: "not-a-number") do |_cli, report_directory, _error_output, root|
+      runner_path = File.expand_path("../../scripts/examples-e2e.rb", __dir__)
+      _output, error_output, status = Open3.capture3(
+        {
+          "EXAMPLES_E2E_REPORT_DIR" => report_directory.to_s,
+          "EXAMPLES_E2E_TIMEOUT" => "not-a-number",
+          "OPENAI_API_KEY" => "sk-fake-timeout-test"
+        },
+        RbConfig.ruby,
+        "-r",
+        runner_path,
+        "-e",
+        "exit(OpenAIExamplesE2E::CLI.new(root: ARGV.shift).run(ARGV))",
+        root.to_s,
+        "--inventory-only"
+      )
+
+      assert_equal(1, status.exitstatus)
+      assert_includes(error_output, "ERROR: timeout must be a positive integer number of seconds")
+      refute(report_directory.exist?)
+    end
+  end
+
+  def test_uses_default_positive_timeout
+    assert_runner_timeout(180)
+  end
+
+  def test_uses_positive_environment_timeout
+    assert_runner_timeout(7, timeout: "7")
+  end
+
+  def test_valid_explicit_timeout_overrides_invalid_environment_default
+    assert_runner_timeout(5, timeout: "not-a-number", arguments: ["--timeout", "5"])
+  end
+
+  def test_inventory_only_preserves_valid_behavior_without_constructing_runner
+    with_cli(api_key: nil) do |cli, report_directory, error_output|
+      runner_started = false
+      factory = lambda do |**_options|
+        runner_started = true
+      end
+
+      status = OpenAIExamplesE2E::Runner.stub(:new, factory) { cli.run(["--inventory-only"]) }
+
+      assert_equal(0, status, error_output.string)
+      refute(runner_started)
+      assert(report_directory.join("report.json").exist?)
+    end
+  end
+
+  private
+
+  def assert_runner_timeout(expected_timeout, timeout: nil, arguments: [])
+    with_cli(timeout: timeout) do |cli, report_directory, error_output|
+      captured_timeout = nil
+      runner = Minitest::Mock.new
+      runner.expect(:run, empty_report)
+      factory = lambda do |**options|
+        captured_timeout = options.fetch(:timeout)
+        runner
+      end
+
+      status = OpenAIExamplesE2E::Runner.stub(:new, factory) { cli.run(arguments) }
+
+      assert_equal(0, status, error_output.string)
+      assert_equal(expected_timeout, captured_timeout)
+      assert(report_directory.join("report.json").exist?)
+      runner.verify
+    end
+  end
+
+  def with_cli(timeout: nil, api_key: "sk-fake-timeout-test")
+    Dir.mktmpdir("openai-examples-e2e-timeout-test") do |directory|
+      root = Pathname(directory)
+      example_path = root.join("examples/example.rb")
+      example_path.dirname.mkpath
+      example_path.write("# frozen_string_literal: true\n")
+      root.join("examples/e2e.yml").write(
+        YAML.dump(
+          "version" => 1,
+          "examples" => {
+            "examples/example.rb" => {"status" => "covered", "expected_output" => "synthetic"}
+          }
+        )
+      )
+      report_directory = root.join("artifacts")
+      output = StringIO.new
+      error_output = StringIO.new
+      cli = OpenAIExamplesE2E::CLI.new(root: root, output: output, error_output: error_output)
+
+      with_environment(
+        "EXAMPLES_E2E_TIMEOUT" => timeout,
+        "EXAMPLES_E2E_REPORT_DIR" => report_directory.to_s,
+        "OPENAI_API_KEY" => api_key
+      ) do
+        yield(cli, report_directory, error_output, root)
+      end
+    end
+  end
+
+  def empty_report
+    inventory = OpenAIExamplesE2E::InventorySummary.new(
+      covered: 1,
+      excluded: 0,
+      total: 1,
+      percentage: 100.0
+    )
+    OpenAIExamplesE2E::Report.new(inventory: inventory, results: [], excluded_examples: [])
+  end
+
+  def with_environment(values)
+    previous = values.to_h { |name, _value| [name, ENV[name]] }
+    values.each { |name, value| ENV[name] = value }
+    yield
+  ensure
+    previous.each { |name, value| ENV[name] = value }
+  end
+end

--- a/test/scripts/examples_e2e_timeout_test.rb
+++ b/test/scripts/examples_e2e_timeout_test.rb
@@ -12,6 +12,8 @@ require "yaml"
 require_relative "../../scripts/examples-e2e"
 
 class ExamplesE2ETimeoutTest < Minitest::Test
+  CLI_TEST_MUTEX = Mutex.new
+
   def test_rejects_invalid_effective_environment_timeouts_before_runner_or_report
     ["0", "-1", "", "not-a-number"].each do |timeout|
       with_cli(timeout: timeout) do |cli, report_directory, error_output|
@@ -20,7 +22,7 @@ class ExamplesE2ETimeoutTest < Minitest::Test
           runner_started = true
         end
 
-        status = OpenAIExamplesE2E::Runner.stub(:new, factory) { cli.run([]) }
+        status = with_stubbed_runner(factory) { cli.run([]) }
 
         assert_equal(1, status, "timeout #{timeout.inspect}")
         refute(runner_started, "timeout #{timeout.inspect} constructed a runner")
@@ -38,7 +40,7 @@ class ExamplesE2ETimeoutTest < Minitest::Test
           runner_started = true
         end
 
-        status = OpenAIExamplesE2E::Runner.stub(:new, factory) do
+        status = with_stubbed_runner(factory) do
           cli.run(["--timeout", timeout])
         end
 
@@ -57,7 +59,7 @@ class ExamplesE2ETimeoutTest < Minitest::Test
         runner_started = true
       end
 
-      status = OpenAIExamplesE2E::Runner.stub(:new, factory) do
+      status = with_stubbed_runner(factory) do
         cli.run(["--timeout", "not-a-number"])
       end
 
@@ -111,7 +113,7 @@ class ExamplesE2ETimeoutTest < Minitest::Test
         runner_started = true
       end
 
-      status = OpenAIExamplesE2E::Runner.stub(:new, factory) { cli.run(["--inventory-only"]) }
+      status = with_stubbed_runner(factory) { cli.run(["--inventory-only"]) }
 
       assert_equal(0, status, error_output.string)
       refute(runner_started)
@@ -131,7 +133,7 @@ class ExamplesE2ETimeoutTest < Minitest::Test
         runner
       end
 
-      status = OpenAIExamplesE2E::Runner.stub(:new, factory) { cli.run(arguments) }
+      status = with_stubbed_runner(factory) { cli.run(arguments) }
 
       assert_equal(0, status, error_output.string)
       assert_equal(expected_timeout, captured_timeout)
@@ -141,30 +143,32 @@ class ExamplesE2ETimeoutTest < Minitest::Test
   end
 
   def with_cli(timeout: nil, api_key: "sk-fake-timeout-test")
-    Dir.mktmpdir("openai-examples-e2e-timeout-test") do |directory|
-      root = Pathname(directory)
-      example_path = root.join("examples/example.rb")
-      example_path.dirname.mkpath
-      example_path.write("# frozen_string_literal: true\n")
-      root.join("examples/e2e.yml").write(
-        YAML.dump(
-          "version" => 1,
-          "examples" => {
-            "examples/example.rb" => {"status" => "covered", "expected_output" => "synthetic"}
-          }
+    CLI_TEST_MUTEX.synchronize do
+      Dir.mktmpdir("openai-examples-e2e-timeout-test") do |directory|
+        root = Pathname(directory)
+        example_path = root.join("examples/example.rb")
+        example_path.dirname.mkpath
+        example_path.write("# frozen_string_literal: true\n")
+        root.join("examples/e2e.yml").write(
+          YAML.dump(
+            "version" => 1,
+            "examples" => {
+              "examples/example.rb" => {"status" => "covered", "expected_output" => "synthetic"}
+            }
+          )
         )
-      )
-      report_directory = root.join("artifacts")
-      output = StringIO.new
-      error_output = StringIO.new
-      cli = OpenAIExamplesE2E::CLI.new(root: root, output: output, error_output: error_output)
+        report_directory = root.join("artifacts")
+        output = StringIO.new
+        error_output = StringIO.new
+        cli = OpenAIExamplesE2E::CLI.new(root: root, output: output, error_output: error_output)
 
-      with_environment(
-        "EXAMPLES_E2E_TIMEOUT" => timeout,
-        "EXAMPLES_E2E_REPORT_DIR" => report_directory.to_s,
-        "OPENAI_API_KEY" => api_key
-      ) do
-        yield(cli, report_directory, error_output, root)
+        with_environment(
+          "EXAMPLES_E2E_TIMEOUT" => timeout,
+          "EXAMPLES_E2E_REPORT_DIR" => report_directory.to_s,
+          "OPENAI_API_KEY" => api_key
+        ) do
+          yield(cli, report_directory, error_output, root)
+        end
       end
     end
   end
@@ -177,6 +181,10 @@ class ExamplesE2ETimeoutTest < Minitest::Test
       percentage: 100.0
     )
     OpenAIExamplesE2E::Report.new(inventory: inventory, results: [], excluded_examples: [])
+  end
+
+  def with_stubbed_runner(factory, &block)
+    OpenAIExamplesE2E::Runner.stub(:new, factory, &block)
   end
 
   def with_environment(values)


### PR DESCRIPTION
## Summary

- Validate the effective Examples E2E per-example timeout during CLI preflight.
- Keep valid explicit `--timeout` values higher precedence than `EXAMPLES_E2E_TIMEOUT`.
- Add focused synthetic regression coverage for in-process CLI behavior and a subprocess argument boundary.

## Problem

Before this change, `--timeout 0` and `--timeout -1` could construct a runner, while malformed `EXAMPLES_E2E_TIMEOUT` raised an unhandled `ArgumentError`. A malformed environment default also blocked a valid explicit `--timeout 5` override.

From a user perspective, invalid local timeout configuration now returns the existing concise CLI configuration-error result with exit 1 before runner construction, subprocess execution, credentialed API work, or report writes. Valid default, environment, and explicit timeout behavior is preserved.

## Implementation

The CLI now defers environment timeout parsing until after OptionParser has processed explicit arguments, resolves the effective timeout, and requires it to be a positive integer number of seconds. Only malformed environment conversion is mapped into ConfigurationError; normal OptionParser diagnostics remain unchanged.

The focused test serializes its synthetic CLI fixture lifetime for standalone runs and joins the full suite serial lane, so process-wide ENV mutation and Runner stubs cannot race parallel tests. Its environment cleanup snapshot is initialized before setup can raise.

## Scope and compatibility

Changed only:
- `scripts/examples-e2e.rb` CLI option parsing and preflight.
- New `test/scripts/examples_e2e_timeout_test.rb`.

No Runner, Executor, subprocess, report schema, workflow, inventory, SDK runtime API, dependency, generated file, or broader CLI refactor changes.

## Verification

- Reproduced the pre-fix behavior with the coordinator diagnostic: non-positive CLI values reached Runner; malformed environment values escaped as ArgumentError and blocked explicit override.
- Post-fix diagnostic: invalid effective values return handled exit 1 without Runner; explicit override and positive environment controls reach Runner.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/scripts/examples_e2e_timeout_test.rb`: 8 runs, 51 assertions, 0 failures, 0 errors, 0 skips.
- Parallelized harness load of the focused timeout file: 8 runs, 51 assertions, 0 failures, 0 errors, 0 skips.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/scripts/examples_e2e_test.rb`: 17 runs, 199 assertions, 0 failures, 0 errors, 0 skips.
- Rebased `mise exec ruby@4.0.6 -- bundle exec rake lint`: 2,875 Ruby files inspected with no offenses; 1,279 RBS files validated; Sorbet examples check passed.
- Final serialized `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` on candidate `5b1769de98046313a9febd740f9b5f7f1e9656f4`: 1,642 runs, 14,564 assertions, 0 failures, 0 errors, 1 skip.
- A prior same-head full run had one unrelated Realtime timing error; the exact test passed 3/3 in isolation with the recorded seed before the successful full rerun. No Realtime code or timeout changed.
- Trusted current-main public custom-code budget check: 3,363 / 4,000 custom lines, 637 headroom.

## Review and security

- Adversarial review used ten rounds total, always with two fresh independent read-only reviewers. Initial implementation converged in rounds 2/3 after round 1 added the missing subprocess regression. The CI race fix converged in rounds 4/5. Feedback safety/isolation fixes converged in rounds 7/8. After a current-main freshness rebase, rounds 9/10 were clean.
- Initial Ruby 4.0 CI exposed a parallel Minitest stub race in the new test; the in-scope test-only serialization fix was verified locally before re-push.
- Two automated review threads were addressed with individualized replies and resolved after the final fix push.
- Dedicated bounded security review of the Examples E2E credential preflight and report-confidentiality surface completed with no findings.
- Requesting @openai/sdks-team review because this touches CI credential preflight behavior.

## Limitations

The full suite retains one existing skip; no live examples or API requests were run.