### PR TITLE
fix: isolate base URL queries between requests

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -185,7 +185,7 @@ module OpenAI
           in [Hash, Hash, _]
             lhs.merge(rhs) { deep_merge_lr(_2, _3, concat: concat) }
           in [Array, Array, true]
-            lhs.concat(rhs)
+            lhs + rhs
           else
             rhs
           end

--- a/test/openai/base_query_isolation_test.rb
+++ b/test/openai/base_query_isolation_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::BaseQueryIsolationTest < Minitest::Test
+  class Capture < OpenAI::HTTPClient
+    attr_reader :urls
+
+    def initialize
+      super
+      @urls = []
+    end
+
+    def execute(request)
+      @urls << request.url.to_s
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: ["{}"]
+      )
+    end
+  end
+
+  def test_base_query_values_do_not_accumulate_between_public_requests
+    transport = Capture.new
+    client = OpenAI::Client.new(
+      api_key: "fake-key",
+      base_url: "https://sdk.example.test/v1?label=base",
+      http_client: transport
+    )
+    one = ["one"]
+    two = ["two"]
+
+    client.request(method: :get, path: "/v1", query: {"label" => one})
+    client.request(method: :get, path: "/v1", query: {"label" => two})
+    client.request(method: :get, path: "/v1")
+
+    assert_equal(
+      [
+        "https://sdk.example.test/v1?label=base&label=one",
+        "https://sdk.example.test/v1?label=base&label=two",
+        "https://sdk.example.test/v1?label=base"
+      ],
+      transport.urls
+    )
+    assert_equal(["one"], one)
+    assert_equal(["two"], two)
+  end
+
+  def test_concatenating_deep_merge_does_not_mutate_input_arrays
+    left = ["base"]
+    right = ["request"]
+
+    merged = OpenAI::Internal::Util.deep_merge(
+      {label: left},
+      {label: right},
+      concat: true
+    )
+
+    assert_equal({label: ["base", "request"]}, merged)
+    assert_equal(["base"], left)
+    assert_equal(["request"], right)
+  end
+end


### PR DESCRIPTION
## Problem

A client configured with a base URL query could retain array-valued query parameters from earlier documented `OpenAI::Client#request` calls. For example, with `https://sdk.example.test/v1?label=base`, requests using `label=["one"]`, then `label=["two"]`, then no extra query could send `base+one`, `base+one+two`, and stale accumulated values.

## Fix

The existing concatenating deep-merge boundary now returns a new array instead of mutating its left-hand array. Each request still receives the same effective query ordering and concat result for that request, while the cached base query and caller-owned arrays remain unchanged.

A focused public-request regression uses a synthetic HTTPClient stub to prove `base+one`, `base+two`, then base alone. A minimal helper-level control verifies neither merge input array is mutated.

## Compatibility and scope

- Preserves scalar-versus-array precedence, recursive hash merging, concat ordering/result semantics, base-path selection, and nil/empty handling.
- The other production `concat: true` caller, structured-output `UnionOf`, receives equivalent merged array values.
- No public API, URI policy, transport, auth, redirect, parser, generated file, dependency, signature, or security-policy changes.

## Verification

- Red proof before fix: new regression failed with stale `base+one+two` accumulation and mutated left input.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/base_query_isolation_test.rb` — 2 runs, 6 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/internal/util_test.rb` — 63 runs, 287 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/structured_output_test.rb` — 8 runs, 60 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/client_test.rb` — 49 runs, 265 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/internal/request_options_scope_test.rb` — 6 runs, 18 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/internal/transport/base_client_origin_test.rb` — 24 runs, 412 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/internal/transport/base_client_redirect_test.rb` — 38 runs, 380 assertions.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop, RBS validation, and Sorbet passed.
- `mise exec ruby@4.0.6 -- bundle exec rake build:gem` — passed.
- Serialized full suite with current-spec mock: 1,636 runs, 14,519 assertions, 0 failures, 0 errors, 1 skip.
- Public custom-code budget on committed candidate: 3,363 / 4,000 lines; 637 headroom.

## Review

Two consecutive adversarial-review rounds completed on unchanged code with two fresh read-only reviewers per round. All four reviewers reported no meaningful in-scope blockers. The request/transport security review found no change to origins, redirects, authentication, destinations, or logging.

## Limitations

No live API calls were run; verification uses synthetic/offline transport and the repository mock suite.