### PR TITLE
ci: refuse lossy RBS comment rewrites

### DIFF
--- a/scripts/rbs_format.rb
+++ b/scripts/rbs_format.rb
@@ -61,12 +61,29 @@ module RBSFormat
     formatter = SyntaxTree::RBS::Formatter.new(protected_source, [], 80)
     Format.new(formatter).visit(SyntaxTree::RBS.parse(protected_source))
     formatter.flush
-    formatter.output.join.gsub(
+    formatted = formatter.output.join.gsub(
       /# (?:class|module) #{Regexp.escape(marker)}-(\d+)\n *[^\n]+$/
     ) do
       restorations.fetch(Regexp.last_match(1).to_i)
     end
+
+    ensure_comments_preserved!(source, formatted)
+    formatted
   end
+
+  def ensure_comments_preserved!(source, formatted)
+    return if comments(source) == comments(formatted)
+
+    raise "RBS formatter cannot safely preserve comments; format manually"
+  end
+
+  def comments(source)
+    RBS::Parser.lex(source).value.filter_map do |token|
+      token.value.sub(/[ \t\r]+\z/, "") if token.comment?
+    end
+  end
+
+  private_class_method :ensure_comments_preserved!, :comments
 
   def alias_declarations(declarations)
     declarations.flat_map do |declaration|

--- a/test/scripts/rbs_format_comment_loss_test.rb
+++ b/test/scripts/rbs_format_comment_loss_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "tempfile"
+
+require_relative "../../scripts/rbs_format"
+
+class RBSFormatCommentLossTest < Minitest::Test
+  LOSSY_SOURCES = [
+    "type label = String # keep explanation\n",
+    "Example: String # keep explanation\n",
+    "class Example\n  def call: -> String # keep explanation\nend\n"
+  ].freeze
+
+  def test_format_refuses_results_that_lose_trailing_comments
+    LOSSY_SOURCES.each do |source|
+      error = assert_raises(RuntimeError) { RBSFormat.format(source) }
+
+      assert_equal("RBS formatter cannot safely preserve comments; format manually", error.message)
+    end
+  end
+
+  def test_check_and_write_paths_leave_lossy_source_unchanged
+    LOSSY_SOURCES.each do |source|
+      Tempfile.create(["rbs-format-comment-loss", ".rbs"]) do |file|
+        file.write(source)
+        file.flush
+
+        assert_raises(RuntimeError) { RBSFormat.run([file.path], check: true) }
+        assert_equal(source, File.read(file.path))
+
+        assert_raises(RuntimeError) { RBSFormat.run([file.path], check: false) }
+        assert_equal(source, File.read(file.path))
+      end
+    end
+  end
+
+  def test_preserved_comments_and_literal_hashes_still_format_idempotently
+    source = <<~RBS
+      # first comment
+      # second comment
+      # first comment
+      %a{# not a comment}
+      type label = "# not a comment"
+      class   Alias   =   ::String # alias comment
+    RBS
+    source = source.sub("# first comment\n", "# first comment  \n")
+
+    formatted = RBSFormat.format(source)
+
+    assert_equal(formatted, RBSFormat.format(formatted))
+    assert_equal(
+      ["# first comment", "# second comment", "# first comment", "# alias comment"],
+      comments(formatted)
+    )
+  end
+
+  def test_crlf_comment_whitespace_does_not_look_lossy
+    source = "# keep explanation\r\nclass   Example\r\nend\r\n"
+
+    formatted = RBSFormat.format(source)
+
+    assert_equal("# keep explanation\nclass Example\nend\n", formatted)
+    assert_equal(formatted, RBSFormat.format(formatted))
+  end
+
+  private
+
+  def comments(source)
+    RBS::Parser.lex(source).value.select(&:comment?).map do |token|
+      token.value.sub(/[ \t\r]+\z/, "")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The repository RBS formatter can silently drop trailing comments that its underlying formatter does not preserve. A formatting run could therefore rewrite an RBS file and lose human-authored context without reporting an error.

## Change

- Compare the ordered comment-token sequence from the original source with the final post-alias-restoration formatter output.
- Use `RBS::Parser.lex(...).value` so only real RBS comments participate; `#` inside strings and annotations remains ordinary syntax.
- Ignore only trailing space/tab and CRLF normalization that formatting legitimately changes.
- Raise a concise content-free error before `format` returns, so both check and write modes refuse a lossy result before a file can be written.

## Reproduction and verification

Before this change, the offline synthetic reproduction wrote away trailing comments on a type declaration, constant, and method without error. With this change, those same cases raise `RBS formatter cannot safely preserve comments; format manually`, and the source tempfile remains byte-for-byte unchanged. Standalone comments plus literal/annotation `#` controls continue to succeed.

Tests and checks run with Ruby 4.0.6:

- `bundle exec ruby -Itest test/scripts/rbs_format_comment_loss_test.rb` — 4 runs, 22 assertions
- `bundle exec ruby -Itest test/scripts/rbs_format_test.rb` — 17 runs, 52 assertions
- `bundle exec ruby -Itest test/scripts/formatting_policy_test.rb` — 11 runs, 208 assertions
- Offline `verify_rbs_comment_loss.rb` red/green reproduction — lossy cases now fail before writes; controls pass
- Read-only `sig/**/*.rbs` scan — 1,279 files, 0 proposed changes, 0 guard errors
- `bundle exec rake lint` — RuboCop 2,874 files, typecheck clean, 1,279 RBS files validated
- `TEST_API_BASE_URL=http://127.0.0.1:49137 bundle exec rake test` — 1,634 runs, 14,513 assertions, 0 failures, 0 errors, 1 skip
- Trusted current-main public custom-code check on committed candidate — 3,363 / 4,000 lines, 637 headroom

## Scope and compatibility

This is deliberately a fail-safe output guard, not a new comment-placement implementation or formatter rewrite. It changes only `scripts/rbs_format.rb` and a focused handwritten test. Existing record formatting, class/module alias restoration, parse errors, deterministic path ordering, ordinary check/write behavior, and idempotence remain intact.

## Review

Adversarial review used fresh independent correctness and architecture reviewers. After correcting narrow whitespace and CRLF normalization findings, two consecutive rounds were clean. A bounded security review found no credential, network, dependency, deserialization, workflow, or logging surface change; the new error intentionally contains no source or comment text.

Requesting `@openai/sdks-team` review for this build-tooling behavior.
