### PR TITLE
fix: honor raw StringIO request cursors

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -638,7 +638,10 @@ module OpenAI
           in [_, Symbol | Numeric]
             [headers, body.to_s]
           in [_, StringIO]
-            [headers, body.string]
+            [headers, body.string.byteslice(body.pos..) || body.string.byteslice(0, 0)]
+          in [_, OpenAI::FilePart] if body.content.is_a?(StringIO)
+            content = body.content
+            [headers, content.string.byteslice(content.pos..) || content.string.byteslice(0, 0)]
           in [_, OpenAI::FilePart]
             [headers, body.content]
           else

--- a/test/openai/raw_stringio_request_test.rb
+++ b/test/openai/raw_stringio_request_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::RawStringIORequestTest < Minitest::Test
+  extend Minitest::Serial
+
+  include WebMock::API
+
+  REQUEST_URL = "https://example.test/probe"
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def test_request_sends_bytes_remaining_at_current_cursor_without_consuming
+    [
+      [0, "abcdef"],
+      [3, "def"],
+      [6, ""],
+      [10, ""]
+    ].each do |position, expected|
+      raw_forms.each do |wrap|
+        source = StringIO.new("abcdef")
+        source.pos = position
+
+        assert_equal([expected], request_bodies(wrap.call(source)), "byte position #{position}")
+        assert_equal(position, source.pos)
+        assert_equal("abcdef", source.string)
+        assert_equal(Encoding::UTF_8, source.string.encoding)
+        refute_predicate(source, :closed?)
+      end
+    end
+  end
+
+  def test_request_slices_at_multibyte_byte_cursor_without_consuming
+    raw_forms.each do |wrap|
+      source = StringIO.new("éx")
+      source.pos = "é".bytesize
+
+      assert_equal(["x"], request_bodies(wrap.call(source)))
+      assert_equal("é".bytesize, source.pos)
+      assert_equal(Encoding::UTF_8, source.string.encoding)
+      refute_predicate(source, :closed?)
+    end
+  end
+
+  def test_retry_replays_identical_remaining_bytes_for_each_raw_form
+    raw_forms.each do |wrap|
+      source = StringIO.new("abcdef")
+      source.pos = 3
+
+      assert_equal(%w[def def], request_bodies(wrap.call(source), retry_once: true))
+      assert_equal(3, source.pos)
+      assert_equal("abcdef", source.string)
+      assert_equal(Encoding::UTF_8, source.string.encoding)
+      refute_predicate(source, :closed?)
+    end
+  end
+
+  private def raw_forms
+    [-> (source) { source }, -> (source) { OpenAI::FilePart.new(source) }]
+  end
+
+  private def request_bodies(body, retry_once: false)
+    bodies = []
+    stub_request(:post, REQUEST_URL).to_return do |request|
+      bodies << request.body
+      status = retry_once && bodies.one? ? 500 : 200
+      {status: status, headers: {"content-type" => "application/json"}, body: "{}"}
+    end
+
+    client = OpenAI::Client.new(
+      base_url: "https://example.test",
+      api_key: "fake-test-key",
+      max_retries: retry_once ? 1 : 0,
+      initial_retry_delay: 0,
+      max_retry_delay: 0
+    )
+    client.request(
+      method: :post,
+      path: "probe",
+      headers: {"content-type" => "application/octet-stream"},
+      body: body
+    )
+    bodies
+  end
+end


### PR DESCRIPTION
## Problem

The generic `OpenAI::Client#request` path did not honor a caller-owned `StringIO` cursor for raw request bodies. A direct `StringIO` at byte position 3 sent the full `abcdef` buffer, while a `StringIO` wrapped in `OpenAI::FilePart` could be consumed by the first transport attempt and send an empty retry body.

## Fix

At the existing raw `encode_content` dispatch boundary, snapshot only the bytes remaining from the current `StringIO#pos` for both direct raw `StringIO` and raw `FilePart(StringIO)` bodies. The snapshot uses byte slicing and does not read, rewind, close, or otherwise mutate the caller-owned object. The guarded `FilePart` branch keeps non-`StringIO` payloads on their existing path and deliberately does not recursively re-encode raw string content as JSON.

## User-visible behavior

For a buffer containing `abcdef`:

- byte position 0 sends `abcdef`
- byte position 3 sends `def`
- EOF and beyond EOF send an empty body
- a retryable 500→200 request replays the same remaining bytes on both attempts

The regression also checks a UTF-8 byte cursor (`éx` positioned after `é`) and preserves caller content, position, encoding, and open ownership.

## Compatibility and scope

This is limited to raw `StringIO` normalization in `lib/openai/internal/util.rb` plus a focused public-client regression. It does not change retry eligibility or callbacks, IO stream behavior, multipart encoding, headers, `Pathname`, `String`, JSON, JSONL, non-`StringIO` `FilePart`, generated resources, signatures, dependencies, or public APIs.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/raw_stringio_request_test.rb` — 3 runs, 70 assertions
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/file_part_serialization_cursor_test.rb` — 2 runs, 30 assertions
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/net_http_client_stringio_length_test.rb` — 3 runs, 38 assertions
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/util_test.rb` — 63 runs, 287 assertions
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/http_client_test.rb` — 36 runs, 158 assertions
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — 2,875 files, no offenses; RBS validation and Sorbet examples typecheck passed
- `TEST_API_BASE_URL=<coordinator mock> mise exec ruby@4.0.6 -- bundle exec rake test` — 1,637 runs, 14,583 assertions, 0 failures, 0 errors, 1 skip
- trusted current-main public custom-code budget check — 3,363 / 4,000 custom lines, 637 lines headroom

## Review and security

Two consecutive fresh adversarial-review rounds completed with two independent read-only reviewers per round and no unresolved in-scope findings. A bounded transport/file security review found no new disclosure, mutation, logging, header, redirect, retry-eligibility, or multipart risk; the change reduces accidental prefix transmission for cursor-positioned raw bodies.

## Limitations

The full suite retains its existing single skipped test and emits existing dependency warnings; neither is introduced by this change.
