### PR TITLE
fix: parse SSE retry metadata as decimal

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -871,7 +871,7 @@ module OpenAI
                 in "id" unless value.include?("\0")
                   current.merge!(id: value)
                 in "retry" if /^\d+$/ =~ value
-                  current.merge!(retry: Integer(value))
+                  current.merge!(retry: Integer(value, 10))
                 else
                 end
               else

--- a/test/openai/sse_decimal_retry_test.rb
+++ b/test/openai/sse_decimal_retry_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::SseDecimalRetryTest < Minitest::Test
+  extend Minitest::Serial
+
+  def test_digit_only_retry_metadata_does_not_interrupt_raw_chat_stream
+    %w[0 8 08 09 010].each do |retry_value|
+      stream = raw_stream(retry_value)
+
+      assert_equal(1, stream.to_a.length, "retry=#{retry_value}")
+    ensure
+      stream&.close
+    end
+  end
+
+  def test_digit_only_retry_metadata_is_parsed_as_decimal
+    {
+      "0" => 0,
+      "8" => 8,
+      "08" => 8,
+      "09" => 9,
+      "010" => 10
+    }.each do |retry_value, expected|
+      event = OpenAI::Internal::Util.decode_sse(["retry: #{retry_value}\n", "data: ok\n", "\n"]).first
+
+      assert_equal(expected, event.fetch(:retry), "retry=#{retry_value}")
+    end
+  end
+
+  private
+
+  def raw_stream(retry_value)
+    payload = {
+      id: "chatcmpl_synthetic",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "test",
+      choices: [{index: 0, delta: {role: "assistant", content: "ok"}, finish_reason: "stop"}]
+    }
+    wire = "retry: #{retry_value}\ndata: #{JSON.generate(payload)}\n\ndata: [DONE]\n\n".b
+    transport = OpenAI::HTTPClient.new
+    response = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "text/event-stream"},
+      body: [wire]
+    )
+
+    transport.stub(:execute, response) do
+      client = OpenAI::Client.new(
+        api_key: "synthetic-key",
+        base_url: "https://sdk.example.test",
+        http_client: transport
+      )
+      return client.chat.completions.stream_raw(
+        model: "test",
+        messages: [{role: :user, content: "synthetic"}]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Problem

WHATWG SSE retry fields containing ASCII digits are decimal integers, but Ruby Integer(value) infers prefixes. On a valid Chat event stream, retry: 08 and retry: 09 raised ArgumentError before the following data event, while retry: 010 was interpreted as 8 instead of 10.

## User-visible behavior

A public Chat stream_raw call now accepts legal leading-zero retry metadata and still yields the following chunk:

```ruby
stream = client.chat.completions.stream_raw(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Hello"}]
)
stream.each { |chunk| puts chunk.choices.first.delta.content }
```

With the same valid synthetic data event after it, retry: 08 previously raised ArgumentError; now the chunk is delivered and the retry metadata is 8. Likewise, retry: 010 is stored as 10, not 8. Required digit-only values 0, 8, 08, 09, and 010 map to 0, 8, 8, 9, and 10.

## Fix

At the existing digit-only retry conversion in decode_sse, pass explicit base 10 to Integer. The existing ASCII-digit guard is unchanged, so malformed, signed, fractional, and non-ASCII retry values remain ignored.

## Scope and compatibility

The diff is limited to that one numeric conversion and a focused regression test. It does not add reconnection, retry policy, parser state, payload limits, API changes, dependencies, generated changes, or alter event data, event IDs, UTF-8/BOM handling, fragments, line endings, EOF dispatch, or stream closing behavior.

## Verification

- Red proof: the new focused test raised ArgumentError for 08 in both public stream and metadata paths before the fix.
- Focused regression: 2 runs, 10 assertions, 0 failures.
- Existing util SSE tests: 63 runs, 287 assertions, 0 failures.
- UTF-8 boundary tests: 5 runs, 8 assertions, 0 failures.
- Chat completion streaming tests: 22 runs, 107 assertions, 0 failures.
- Ruby formatting, RuboCop (2,880 files), and typecheck passed.
- Serialized full suite against the current-spec mock: 1,658 runs, 14,680 assertions, 0 failures, 0 errors, 1 skip.
- Trusted current-main public custom-code budget: 3,363 / 4,000 lines, 637 headroom.
- Two consecutive fresh adversarial-review rounds with two independent read-only reviewers each were clean.
- Bounded streaming/deserialization security review was clean; no new trust boundary, logging, allocation limit, state, or sink was introduced.

## Limitations

The full suite retains one existing skipped test and emitted existing dependency/runtime warnings. No live API examples were run.