### PR TITLE
fix: rank tied union variants by declaration order

### DIFF
--- a/lib/openai/internal/type/union.rb
+++ b/lib/openai/internal/type/union.rb
@@ -184,7 +184,7 @@ module OpenAI
           exactness = state.fetch(:exactness)
 
           alternatives = []
-          known_variants.each do |_, variant_fn|
+          known_variants.each_with_index do |(_, variant_fn), index|
             target = variant_fn.call
             exact = state[:exactness] = {yes: 0, no: 0, maybe: 0}
             state[:branched] += 1
@@ -197,7 +197,10 @@ module OpenAI
               state[:error] = error || previous_error
               return coerced
             elsif maybe.positive?
-              alternatives << [[-yes, -maybe, no], exact, coerced, error]
+              # `Array#sort_by!` is not stable, so equally-ranked variants would
+              # otherwise be ordered arbitrarily. Break ties on declaration order
+              # to keep the chosen variant the same across platforms and runs.
+              alternatives << [[-yes, -maybe, no, index], exact, coerced, error]
             end
           end
 

--- a/test/openai/internal/type/base_model_test.rb
+++ b/test/openai/internal/type/base_model_test.rb
@@ -697,6 +697,25 @@ class OpenAI::Test::UnionTest < Minitest::Test
     end
   end
 
+  def test_coerce_breaks_alternative_ties_on_declaration_order
+    # `Integer` and `Float` both coerce the string inexactly, so the two
+    # alternatives rank identically. `Array#sort_by!` is not stable, so without an
+    # explicit tie-break the runner-up could be picked and the union would return
+    # a Float for a type that declares `Integer` first.
+    forward = U0.new(Integer, Float)
+    reverse = U0.new(Float, Integer)
+
+    # `2 == 2.0`, so the variant that won is only visible in the coerced class.
+    assert_instance_of(Integer, OpenAI::Internal::Type::Converter.coerce(forward, "2"))
+    assert_instance_of(Float, OpenAI::Internal::Type::Converter.coerce(reverse, "2"))
+
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    OpenAI::Internal::Type::Converter.coerce(forward, "2", state: state)
+
+    assert_equal({yes: 0, no: 0, maybe: 1}, state.fetch(:exactness))
+    assert_equal(2, state.fetch(:branched))
+  end
+
   def test_coerce_preserves_existing_union_model_variants
     model = M1.new(t: :a)
     state = OpenAI::Internal::Type::Converter.new_coerce_state


### PR DESCRIPTION
## Problem

When no variant matches exactly, `Union#coerce` collects the inexact candidates and ranks them:

https://github.com/openai/openai-ruby/blob/8e6abfd57a33ae7c7360f496f8baf15e1cf74db4/lib/openai/internal/type/union.rb#L182-L187

`Array#sort_by!` is not stable, so candidates that rank identically end up in an arbitrary order and the runner-up can win. `OpenAI::UnionOf[Integer, Float]` coercing `"2"` is the smallest case: both variants coerce inexactly and tie at `maybe: 1`.

```ruby
forward = OpenAI::UnionOf[Integer, Float]
reverse = OpenAI::UnionOf[Float, Integer]

OpenAI::Internal::Type::Converter.coerce(forward, "2").class  # => Float
OpenAI::Internal::Type::Converter.coerce(reverse, "2").class  # => Integer
```

`forward` declares `Integer` first and still returns a `Float`. Reversing the declaration order does not change which variant wins, so variant order is silently meaningless for tied candidates, and the outcome is a property of the sort implementation rather than of the type.

## Fix

Add the variant's declaration index to the sort key:

```ruby
alternatives << [[-yes, -maybe, no, index], exact, coerced, error]
```

The index is unique, so the ranking becomes a total order and ties resolve to the earliest-declared variant. Nothing else about the ranking changes: exactness still dominates, and the index only breaks ties that were previously decided arbitrarily.

## Tests

`test_coerce_breaks_alternative_ties_on_declaration_order` asserts the coerced **class** for both declaration orders, since `2 == 2.0` makes value-only assertions pass either way. It fails on `main` and passes here.

This also fixes the existing `UnionTest#test_coerce` case `[U1, "2"] => [{maybe: 1}, 2, "2"]`, which expects the first-declared `const: :a` variant to win the same kind of tie.
