### PR TITLE
fix: match response charset parameters case-insensitively

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -659,10 +659,13 @@ module OpenAI
         #
         # https://www.iana.org/assignments/character-sets/character-sets.xhtml
         #
+        # Media type parameter names are case-insensitive, so `Charset=` and
+        # `CHARSET=` name the same parameter as `charset=`.
+        #
         # @param content_type [String]
         # @param text [String]
         def force_charset!(content_type, text:)
-          charset = /charset=([^;\s]+)/.match(content_type)&.captures&.first
+          charset = /charset=([^;\s]+)/i.match(content_type)&.captures&.first
           charset = charset[1...-1] if charset&.start_with?("\"") && charset.end_with?("\"")
 
           return unless charset

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -691,7 +691,8 @@ module OpenAI
         #
         # Read a media type parameter value: either a token that ends at the first
         # whitespace, or a quoted string in which `\` escapes the next character.
-        # A quoted string that is never closed has no value.
+        # A quoted string that is never closed, or has non-whitespace after its
+        # closing quote, has no value.
         #
         # @param value [String]
         #
@@ -702,14 +703,16 @@ module OpenAI
           unquoted = String.new
           escaped = false
 
-          value[1..].to_s.each_char do |char|
+          value[1..].to_s.each_char.with_index do |char, index|
             if escaped
               unquoted << char
               escaped = false
             elsif char == "\\"
               escaped = true
             elsif char == "\""
-              return unquoted
+              return unquoted if value[(index + 2)..].to_s.match?(/\A\s*\z/)
+
+              return nil
             else
               unquoted << char
             end

--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -657,18 +657,99 @@ module OpenAI
 
         # @api private
         #
-        # https://www.iana.org/assignments/character-sets/character-sets.xhtml
+        # Split a media type on its `;` delimiters, ignoring any that appear inside a
+        # quoted string so that a parameter value may contain one.
         #
-        # Media type parameter names are case-insensitive, so `Charset=` and
-        # `CHARSET=` name the same parameter as `charset=`.
+        # @param content_type [String]
+        #
+        # @return [Array<String>]
+        private def split_media_type_segments(content_type)
+          segments = [String.new]
+          quoted = escaped = false
+
+          content_type.to_s.each_char do |char|
+            if escaped
+              segments.last << char
+              escaped = false
+            elsif quoted && char == "\\"
+              segments.last << char
+              escaped = true
+            elsif char == "\""
+              segments.last << char
+              quoted = !quoted
+            elsif char == ";" && !quoted
+              segments << String.new
+            else
+              segments.last << char
+            end
+          end
+
+          segments
+        end
+
+        # @api private
+        #
+        # Read a media type parameter value: either a token that ends at the first
+        # whitespace, or a quoted string in which `\` escapes the next character.
+        # A quoted string that is never closed has no value.
+        #
+        # @param value [String]
+        #
+        # @return [String, nil]
+        private def read_media_type_value(value)
+          return value[/\A[^;\s]+/] unless value.start_with?("\"")
+
+          unquoted = String.new
+          escaped = false
+
+          value[1..].to_s.each_char do |char|
+            if escaped
+              unquoted << char
+              escaped = false
+            elsif char == "\\"
+              escaped = true
+            elsif char == "\""
+              return unquoted
+            else
+              unquoted << char
+            end
+          end
+
+          nil
+        end
+
+        # @api private
+        #
+        # Find the value of the `charset` media type parameter. Parameter names are
+        # case-insensitive, so `Charset` and `CHARSET` name the same parameter, but the
+        # name has to match in full: a `charset` suffix of another parameter's name, or
+        # a `charset=` inside a quoted value, belongs to a different parameter.
+        #
+        # @param content_type [String]
+        #
+        # @return [String, nil]
+        private def media_type_charset(content_type)
+          split_media_type_segments(content_type).each do |segment|
+            name, separator, value = segment.partition("=")
+            next if separator.empty?
+            next unless name.strip.casecmp?("charset")
+
+            return read_media_type_value(value.lstrip)
+          end
+
+          nil
+        end
+
+        # @api private
+        #
+        # https://www.iana.org/assignments/character-sets/character-sets.xhtml
         #
         # @param content_type [String]
         # @param text [String]
         def force_charset!(content_type, text:)
-          charset = /charset=([^;\s]+)/i.match(content_type)&.captures&.first
-          charset = charset[1...-1] if charset&.start_with?("\"") && charset.end_with?("\"")
+          charset = media_type_charset(content_type)
 
-          return unless charset
+          return if charset.nil? || charset.empty?
 
           begin
             encoding = Encoding.find(charset)

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -901,20 +901,43 @@ class OpenAI::Test::UtilContentDecodingTest < Minitest::Test
     end
   end
 
+  # Decode a response body the way a caller would, so the assertion covers the
+  # path users actually observe. JSON bodies are parsed and never reach
+  # `force_charset!`, so the charset only shapes a raw text or error payload.
+  def decoded_body_encoding(content_type)
+    OpenAI::Internal::Util
+      .decode_content({"content-type" => content_type}, stream: ["body".b])
+      .string
+      .encoding
+  end
+
   def test_charset_parameter_name_is_case_insensitive
     # Media type parameter names are case-insensitive, so a response labelled
     # `Charset=` has to decode the same as one labelled `charset=`. Matching only
     # the lowercase spelling left the body at `Encoding::BINARY`.
     [
-      "application/json; Charset=utf-8",
-      "application/json; CHARSET=utf-8",
-      "application/json; ChArSeT=\"utf-8\""
+      "text/plain; Charset=utf-8",
+      "text/plain; CHARSET=utf-8",
+      "text/plain; ChArSeT=\"utf-8\""
     ].each do |content_type|
-      text = String.new.force_encoding(Encoding::BINARY)
+      assert_equal(Encoding::UTF_8, decoded_body_encoding(content_type), content_type)
+    end
+  end
 
-      OpenAI::Internal::Util.force_charset!(content_type, text: text)
+  def test_charset_matches_only_a_parameter_named_charset
+    # The name has to match in full and at the parameter level: a `charset` suffix
+    # of another parameter's name, and a `charset=` inside a quoted value, both
+    # belong to a different parameter and must not select the encoding.
+    cases = {
+      "text/plain; X-CHARSET=ISO-8859-1; charset=utf-8" => Encoding::UTF_8,
+      "text/plain; title=\"note; Charset=ISO-8859-1;\"; charset=utf-8" => Encoding::UTF_8,
+      "text/plain; title=\"note; charset=ISO-8859-1;\"" => Encoding::BINARY,
+      "text/plain; not-charset=ISO-8859-1" => Encoding::BINARY,
+      "text/plain; charset=\"UTF-8\"; x=\"\\\"charset=ISO-8859-1\\\"\"" => Encoding::UTF_8
+    }
 
-      assert_equal(Encoding::UTF_8, text.encoding, content_type)
+    cases.each do |content_type, encoding|
+      assert_equal(encoding, decoded_body_encoding(content_type), content_type)
     end
   end
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -901,6 +901,23 @@ class OpenAI::Test::UtilContentDecodingTest < Minitest::Test
     end
   end
 
+  def test_charset_parameter_name_is_case_insensitive
+    # Media type parameter names are case-insensitive, so a response labelled
+    # `Charset=` has to decode the same as one labelled `charset=`. Matching only
+    # the lowercase spelling left the body at `Encoding::BINARY`.
+    [
+      "application/json; Charset=utf-8",
+      "application/json; CHARSET=utf-8",
+      "application/json; ChArSeT=\"utf-8\""
+    ].each do |content_type|
+      text = String.new.force_encoding(Encoding::BINARY)
+
+      OpenAI::Internal::Util.force_charset!(content_type, text: text)
+
+      assert_equal(Encoding::UTF_8, text.encoding, content_type)
+    end
+  end
+
   def test_quoted_charset
     text = String.new.force_encoding(Encoding::BINARY)
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -933,7 +933,8 @@ class OpenAI::Test::UtilContentDecodingTest < Minitest::Test
       "text/plain; title=\"note; Charset=ISO-8859-1;\"; charset=utf-8" => Encoding::UTF_8,
       "text/plain; title=\"note; charset=ISO-8859-1;\"" => Encoding::BINARY,
       "text/plain; not-charset=ISO-8859-1" => Encoding::BINARY,
-      "text/plain; charset=\"UTF-8\"; x=\"\\\"charset=ISO-8859-1\\\"\"" => Encoding::UTF_8
+      "text/plain; charset=\"UTF-8\"junk" => Encoding::BINARY,
+      "text/plain; x=\"\\\"charset=ISO-8859-1\\\"\"; charset=\"UTF-8\"" => Encoding::UTF_8
     }
 
     cases.each do |content_type, encoding|


### PR DESCRIPTION
## Problem

`force_charset!` looks for the charset parameter with a case-sensitive pattern:

https://github.com/openai/openai-ruby/blob/8e6abfd57a33ae7c7360f496f8baf15e1cf74db4/lib/openai/internal/util.rb#L659-L660

Media type parameter names are case-insensitive ([RFC 9110 8.3.1](https://www.rfc-editor.org/rfc/rfc9110#section-8.3.1)), so `Charset=` names the same parameter as `charset=`. The pattern only matched the lowercase spelling:

```ruby
text = String.new.force_encoding(Encoding::BINARY)
OpenAI::Internal::Util.force_charset!("application/json; Charset=utf-8", text: text)
text.encoding  # => #<Encoding:BINARY (ASCII-8BIT)>
```

The charset is ignored and the body is handed back still tagged `Encoding::BINARY`, so callers get bytes where they expected decoded text.

## Fix

Add the `i` flag.

Every other media type pattern in this file already ignores case, so this one was the outlier:

- `JSON_CONTENT` and `JSONL_CONTENT` are both defined with `%r{...}i`
- the `text/event-stream` branch of `decode_content` uses `%r{...}i`

Charset *values* were already matched case-insensitively, since `Encoding.find` handles that; `test_charset` covers it.

## Tests

`test_charset_parameter_name_is_case_insensitive` covers `Charset=`, `CHARSET=`, and a mixed-case quoted form. It fails on `main` with `Encoding::BINARY` where `Encoding::UTF_8` is expected.
