### PR TITLE
fix: parse strict tools in later chat choices

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -188,7 +188,7 @@ module OpenAI
         def create_new_choice_snapshot(choice)
           OpenAI::Internal::Type::Converter.coerce(
             OpenAI::Models::Chat::ParsedChoice,
-            choice.to_h.except(:delta).merge(message: choice.delta.to_h)
+            choice.to_h.except(:delta).merge(message: model_dump(choice.delta))
           )
         end
 

--- a/test/openai/helpers/chat_stream_late_choice_tool_test.rb
+++ b/test/openai/helpers/chat_stream_late_choice_tool_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamLateChoiceToolTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class TypedArguments < OpenAI::BaseModel
+    required :x, Integer
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_late_choice_strict_arguments_match_initial_choice_parsing
+    [hash_tool, typed_tool].each do |tool|
+      initial = stream_result(initial_choices, tool, choice_index: 0)
+      late = stream_result(late_choices(arguments: "{\"x\":1}"), tool, choice_index: 1)
+
+      assert_equal({x: 1}, late.fetch(:delta).parsed)
+      assert_equal(initial.fetch(:delta).parsed, late.fetch(:delta).parsed)
+      assert_instance_of(
+        OpenAI::Chat::ChatCompletionMessageFunctionToolCall::Function,
+        late.fetch(:final).function
+      )
+
+      if tool == typed_tool
+        assert_instance_of(TypedArguments, late.fetch(:done).parsed)
+        assert_instance_of(TypedArguments, late.fetch(:final).function.parsed)
+      else
+        assert_equal({x: 1}, late.fetch(:done).parsed)
+        assert_equal({x: 1}, late.fetch(:final).function.parsed)
+      end
+
+      assert_equal("{\"x\":1}", late.fetch(:raw_function).arguments)
+      refute_respond_to(late.fetch(:raw_function), :parsed)
+    end
+  end
+
+  def test_late_choice_non_strict_and_incomplete_arguments_remain_unparsed
+    non_strict = stream_result(late_choices(arguments: "{\"x\":1}"), non_strict_tool, choice_index: 1)
+    incomplete = stream_result(late_choices(arguments: "{\"x\":"), hash_tool, choice_index: 1)
+
+    assert_nil(non_strict.fetch(:delta).parsed)
+    assert_nil(non_strict.fetch(:done).parsed)
+    assert_nil(incomplete.fetch(:delta).parsed)
+    assert_nil(incomplete.fetch(:done).parsed)
+  end
+
+  private
+
+  def stream_result(choices, tool, choice_index:)
+    WebMock.reset!
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: sse(choices)
+      )
+
+    stream = @client.chat.completions.stream(
+      messages: [{content: "Synthetic", role: :user}],
+      model: "gpt-4o-mini",
+      n: choices.any? { |choice| choice[:index] == 1 } ? 2 : 1,
+      tools: [tool]
+    )
+    events = stream.to_a
+    chunks = events.filter_map { |event| event.chunk if event.type == :chunk }
+    raw_choice = chunks.flat_map(&:choices).find { |choice| choice.index == choice_index && choice.delta.tool_calls }
+
+    {
+      delta: events.find { |event| event.type == :"tool_calls.function.arguments.delta" },
+      done: events.find { |event| event.type == :"tool_calls.function.arguments.done" },
+      final: stream
+        .get_final_completion
+        .choices
+        .find { |choice| choice.index == choice_index }
+        .message
+        .tool_calls
+        .first,
+      raw_function: raw_choice.delta.tool_calls.first.function
+    }
+  end
+
+  def sse(choices)
+    chunks = choices.map do |choice|
+      payload = {
+        id: "chatcmpl-late-tool",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt-4o-mini",
+        choices: [choice]
+      }
+      "data: #{JSON.generate(payload)}\n\n"
+    end
+
+    chunks.join + "data: [DONE]\n\n"
+  end
+
+  def initial_choices
+    [tool_choice(index: 0, arguments: "{\"x\":1}"), finish_choice(index: 0)]
+  end
+
+  def late_choices(arguments:)
+    [
+      {index: 0, delta: {role: "assistant", content: "control"}, finish_reason: "stop"},
+      tool_choice(index: 1, arguments:),
+      finish_choice(index: 1)
+    ]
+  end
+
+  def tool_choice(index:, arguments:)
+    {
+      index:,
+      delta: {
+        role: "assistant",
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_0",
+            type: "function",
+            function: {name: "lookup", arguments:}
+          }
+        ]
+      },
+      finish_reason: nil
+    }
+  end
+
+  def finish_choice(index:)
+    {index:, delta: {}, finish_reason: "tool_calls"}
+  end
+
+  def hash_tool
+    function_tool(parameters: {type: "object", properties: {x: {type: "integer"}}})
+  end
+
+  def typed_tool
+    function_tool(parameters: TypedArguments)
+  end
+
+  def non_strict_tool
+    function_tool(strict: false, parameters: {type: "object", properties: {x: {type: "integer"}}})
+  end
+
+  def function_tool(strict: true, parameters:)
+    {
+      type: :function,
+      function: {name: "lookup", strict:, parameters:}
+    }
+  end
+end


### PR DESCRIPTION
## Problem

`client.chat.completions.stream` could abort when a valid strict function tool call arrived in a choice first seen after the initial SSE chunk. The late-choice snapshot retained the streaming delta's function model, which does not expose the completion-message `parsed=` field. The same arguments already parsed correctly when their choice appeared in the first chunk.

~~~ruby
tool = {
  type: :function,
  function: {
    name: "lookup",
    strict: true,
    parameters: {
      type: "object",
      properties: {x: {type: "integer"}},
      required: ["x"],
      additionalProperties: false
    }
  }
}

stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  n: 2,
  messages: [{role: :user, content: "Find x"}],
  tools: [tool]
)

stream.each do |event|
  next unless event.type == :"tool_calls.function.arguments.delta"

  p event.parsed # => {x: 1}
end
~~~

With synthetic SSE carrying identical `{"x":1}` arguments:

- Before: initial choice => `{x: 1}`; later new choice => `NoMethodError: undefined method 'parsed='`.
- After: initial choice => `{x: 1}`; later new choice => `{x: 1}` for delta and final parsing.

## Fix

At the existing `create_new_choice_snapshot` boundary, deep-dump the late choice delta before coercing it into `ParsedChoice`. This matches the established initial-choice and existing-choice conversion paths, gives the snapshot the completion-message tool model, and keeps retained raw chunks unchanged.

The focused public-path test covers strict hash and typed-model arguments, delta/done/final representations, raw-chunk isolation, and unchanged non-strict/incomplete JSON behavior.

## Compatibility and scope

This is a backward-compatible streaming bug fix. It does not change public APIs, generated models, schemas, parser rules, tool execution, payload limits, transport, dependencies, or unrelated accumulation semantics. Deterministic reach is proven through the supported public `n` plus strict-tools workflow; customer incidence is not measured.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/chat_stream_late_choice_tool_test.rb` (2 runs, 18 assertions)
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/chat_stream_initial_tool_parsing_test.rb` (2 runs, 14 assertions)
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/chat_stream_logprob_isolation_test.rb` (3 runs, 14 assertions)
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/chat_completion_stream_test.rb` (10 runs, 47 assertions)
- `mise exec ruby@4.0.6 -- bundle exec rake lint` (2,908 files, no offenses; RBS/Sorbet clean)
- `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` (1,710 runs, 14,926 assertions, 0 failures, 0 errors, 1 skip)
- Trusted current-main public custom-code budget: success, 3,365 / 4,000 lines
- Bounded deserialization/isolation security review: no new parser, sink, limit, transport, dependency, logging, or secret-handling surface
- Adversarial review: two consecutive clean rounds, each with two fresh independent read-only reviewers

## Limitations

Validation uses deterministic synthetic SSE and the repository mock server; it does not claim live-server observation or customer-incidence measurement.
