### PR TITLE
fix: type chat completion streams for Sorbet

### DIFF
--- a/rbi/openai/helpers/streaming/chat_completion_stream.rbi
+++ b/rbi/openai/helpers/streaming/chat_completion_stream.rbi
@@ -1,0 +1,164 @@
+# typed: strong
+
+module OpenAI
+  module Helpers
+    module Streaming
+      class ChatCompletionStream
+        include OpenAI::Internal::Type::BaseStream
+
+        ChatCompletionStreamEvent = T.type_alias do
+          T.any(
+            ChatChunkEvent,
+            ChatContentDeltaEvent,
+            ChatContentDoneEvent,
+            ChatRefusalDeltaEvent,
+            ChatRefusalDoneEvent,
+            ChatFunctionToolCallArgumentsDeltaEvent,
+            ChatFunctionToolCallArgumentsDoneEvent,
+            ChatLogprobsContentDeltaEvent,
+            ChatLogprobsContentDoneEvent,
+            ChatLogprobsRefusalDeltaEvent,
+            ChatLogprobsRefusalDoneEvent
+          )
+        end
+
+        Message = type_member { {fixed: ChatCompletionStreamEvent} }
+        Elem = type_member { {fixed: ChatCompletionStreamEvent} }
+
+        sig { returns(OpenAI::Chat::ChatCompletion) }
+        def get_final_completion
+        end
+
+        sig { returns(String) }
+        def get_output_text
+        end
+
+        sig { returns(T.self_type) }
+        def until_done
+        end
+
+        sig { returns(T.nilable(OpenAI::Chat::ChatCompletion)) }
+        def current_completion_snapshot
+        end
+
+        sig { returns(T::Enumerator[String]) }
+        def text
+        end
+      end
+    end
+  end
+
+  module Resources
+    class Chat
+      class Completions
+        sig do
+          params(
+            messages: T::Array[
+              T.any(
+                OpenAI::Chat::ChatCompletionDeveloperMessageParam::OrHash,
+                OpenAI::Chat::ChatCompletionSystemMessageParam::OrHash,
+                OpenAI::Chat::ChatCompletionUserMessageParam::OrHash,
+                OpenAI::Chat::ChatCompletionAssistantMessageParam::OrHash,
+                OpenAI::Chat::ChatCompletionToolMessageParam::OrHash,
+                OpenAI::Chat::ChatCompletionFunctionMessageParam::OrHash
+              )
+            ],
+            model: T.any(String, OpenAI::ChatModel::OrSymbol),
+            audio: T.nilable(OpenAI::Chat::ChatCompletionAudioParam::OrHash),
+            frequency_penalty: T.nilable(Float),
+            function_call: T.any(
+              OpenAI::Chat::CompletionCreateParams::FunctionCall::FunctionCallMode::OrSymbol,
+              OpenAI::Chat::ChatCompletionFunctionCallOption::OrHash
+            ),
+            functions: T::Array[OpenAI::Chat::CompletionCreateParams::Function::OrHash],
+            logit_bias: T.nilable(T::Hash[Symbol, Integer]),
+            logprobs: T.nilable(T::Boolean),
+            max_completion_tokens: T.nilable(Integer),
+            max_tokens: T.nilable(Integer),
+            metadata: T.nilable(T::Hash[Symbol, String]),
+            modalities: T.nilable(T::Array[OpenAI::Chat::CompletionCreateParams::Modality::OrSymbol]),
+            moderation: T.nilable(OpenAI::Chat::CompletionCreateParams::Moderation::OrHash),
+            n: T.nilable(Integer),
+            parallel_tool_calls: T::Boolean,
+            prediction: T.nilable(OpenAI::Chat::ChatCompletionPredictionContent::OrHash),
+            presence_penalty: T.nilable(Float),
+            prompt_cache_key: T.nilable(String),
+            prompt_cache_options: OpenAI::Chat::CompletionCreateParams::PromptCacheOptions::OrHash,
+            prompt_cache_retention: T.nilable(OpenAI::Chat::CompletionCreateParams::PromptCacheRetention::OrSymbol),
+            reasoning_effort: T.nilable(OpenAI::ReasoningEffort::OrSymbol),
+            response_format: T.any(
+              OpenAI::ResponseFormatText::OrHash,
+              OpenAI::ResponseFormatJSONSchema::OrHash,
+              OpenAI::ResponseFormatJSONObject::OrHash
+            ),
+            safety_identifier: T.nilable(String),
+            seed: T.nilable(Integer),
+            service_tier: T.nilable(OpenAI::Chat::CompletionCreateParams::ServiceTier::OrSymbol),
+            stop: T.nilable(OpenAI::Chat::CompletionCreateParams::Stop::Variants),
+            store: T.nilable(T::Boolean),
+            stream_options: T.nilable(OpenAI::Chat::ChatCompletionStreamOptions::OrHash),
+            temperature: T.nilable(Float),
+            tool_choice: T.any(
+              OpenAI::Chat::ChatCompletionToolChoiceOption::Auto::OrSymbol,
+              OpenAI::Chat::ChatCompletionAllowedToolChoice::OrHash,
+              OpenAI::Chat::ChatCompletionNamedToolChoice::OrHash,
+              OpenAI::Chat::ChatCompletionNamedToolChoiceCustom::OrHash
+            ),
+            tools: T::Array[
+              T.any(OpenAI::Chat::ChatCompletionFunctionTool::OrHash, OpenAI::Chat::ChatCompletionCustomTool::OrHash)
+            ],
+            top_logprobs: T.nilable(Integer),
+            top_p: T.nilable(Float),
+            user: String,
+            verbosity: T.nilable(OpenAI::Chat::CompletionCreateParams::Verbosity::OrSymbol),
+            web_search_options: OpenAI::Chat::CompletionCreateParams::WebSearchOptions::OrHash,
+            stream: T.noreturn,
+            request_options: OpenAI::RequestOptions::OrHash
+          )
+            .returns(OpenAI::Streaming::ChatCompletionStream)
+        end
+        def stream(
+          messages:,
+          model:,
+          audio: nil,
+          frequency_penalty: nil,
+          function_call: nil,
+          functions: nil,
+          logit_bias: nil,
+          logprobs: nil,
+          max_completion_tokens: nil,
+          max_tokens: nil,
+          metadata: nil,
+          modalities: nil,
+          moderation: nil,
+          n: nil,
+          parallel_tool_calls: nil,
+          prediction: nil,
+          presence_penalty: nil,
+          prompt_cache_key: nil,
+          prompt_cache_options: nil,
+          prompt_cache_retention: nil,
+          reasoning_effort: nil,
+          response_format: nil,
+          safety_identifier: nil,
+          seed: nil,
+          service_tier: nil,
+          stop: nil,
+          store: nil,
+          stream_options: nil,
+          temperature: nil,
+          tool_choice: nil,
+          tools: nil,
+          top_logprobs: nil,
+          top_p: nil,
+          user: nil,
+          verbosity: nil,
+          web_search_options: nil,
+          stream: nil,
+          request_options: {}
+        )
+        end
+      end
+    end
+  end
+end

--- a/rbi/openai/helpers/streaming/chat_completion_stream.rbi
+++ b/rbi/openai/helpers/streaming/chat_completion_stream.rbi
@@ -1,6 +1,20 @@
 # typed: strong
 
 module OpenAI
+  module Models
+    module Chat
+      class ParsedChoice < OpenAI::Models::Chat::ChatCompletion::Choice
+        sig { returns(T.nilable(OpenAI::Chat::ChatCompletion::Choice::FinishReason::TaggedSymbol)) }
+        attr_accessor :finish_reason
+      end
+
+      class ParsedChatCompletion < OpenAI::Models::Chat::ChatCompletion
+        sig { returns(T::Array[OpenAI::Models::Chat::ParsedChoice]) }
+        attr_accessor :choices
+      end
+    end
+  end
+
   module Helpers
     module Streaming
       class ChatCompletionStream
@@ -37,7 +51,7 @@ module OpenAI
         def until_done
         end
 
-        sig { returns(T.nilable(OpenAI::Chat::ChatCompletion)) }
+        sig { returns(T.nilable(OpenAI::Chat::ParsedChatCompletion)) }
         def current_completion_snapshot
         end
 
@@ -89,6 +103,7 @@ module OpenAI
             response_format: T.any(
               OpenAI::ResponseFormatText::OrHash,
               OpenAI::ResponseFormatJSONSchema::OrHash,
+              OpenAI::StructuredOutput::JsonSchemaConverter,
               OpenAI::ResponseFormatJSONObject::OrHash
             ),
             safety_identifier: T.nilable(String),
@@ -105,7 +120,11 @@ module OpenAI
               OpenAI::Chat::ChatCompletionNamedToolChoiceCustom::OrHash
             ),
             tools: T::Array[
-              T.any(OpenAI::Chat::ChatCompletionFunctionTool::OrHash, OpenAI::Chat::ChatCompletionCustomTool::OrHash)
+              T.any(
+                OpenAI::StructuredOutput::JsonSchemaConverter,
+                OpenAI::Chat::ChatCompletionFunctionTool::OrHash,
+                OpenAI::Chat::ChatCompletionCustomTool::OrHash
+              )
             ],
             top_logprobs: T.nilable(Integer),
             top_p: T.nilable(Float),

--- a/rbi/openai/helpers/streaming/chat_completion_stream.rbi
+++ b/rbi/openai/helpers/streaming/chat_completion_stream.rbi
@@ -6,11 +6,31 @@ module OpenAI
       class ParsedChoice < OpenAI::Models::Chat::ChatCompletion::Choice
         sig { returns(T.nilable(OpenAI::Chat::ChatCompletion::Choice::FinishReason::TaggedSymbol)) }
         attr_accessor :finish_reason
+
+        sig do
+          params(
+            index: Integer,
+            logprobs: T.nilable(OpenAI::Chat::ChatCompletion::Choice::Logprobs::OrHash),
+            message: OpenAI::Chat::ChatCompletionMessage::OrHash,
+            finish_reason: T.nilable(OpenAI::Chat::ChatCompletion::Choice::FinishReason::OrSymbol)
+          )
+            .returns(T.attached_class)
+        end
+        def self.new(index:, logprobs:, message:, finish_reason: nil)
+        end
+
+        sig { returns(OpenAI::Internal::AnyHash) }
+        def to_hash
+        end
       end
 
       class ParsedChatCompletion < OpenAI::Models::Chat::ChatCompletion
         sig { returns(T::Array[OpenAI::Models::Chat::ParsedChoice]) }
         attr_accessor :choices
+
+        sig { returns(OpenAI::Internal::AnyHash) }
+        def to_hash
+        end
       end
     end
   end
@@ -39,7 +59,18 @@ module OpenAI
         Message = type_member { {fixed: ChatCompletionStreamEvent} }
         Elem = type_member { {fixed: ChatCompletionStreamEvent} }
 
-        sig { returns(OpenAI::Chat::ChatCompletion) }
+        sig do
+          params(
+            raw_stream: T.untyped,
+            response_format: T.untyped,
+            input_tools: T.untyped
+          )
+            .void
+        end
+        def initialize(raw_stream:, response_format: nil, input_tools: nil)
+        end
+
+        sig { returns(OpenAI::Chat::ParsedChatCompletion) }
         def get_final_completion
         end
 

--- a/rbi/openai/helpers/streaming/events.rbi
+++ b/rbi/openai/helpers/streaming/events.rbi
@@ -28,6 +28,10 @@ module OpenAI
       end
 
       class ChatChunkEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(T.untyped) }
         def chunk
         end
@@ -38,6 +42,10 @@ module OpenAI
       end
 
       class ChatContentDeltaEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(String) }
         def delta
         end
@@ -52,6 +60,10 @@ module OpenAI
       end
 
       class ChatContentDoneEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(String) }
         def content
         end
@@ -62,6 +74,10 @@ module OpenAI
       end
 
       class ChatRefusalDeltaEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(String) }
         def delta
         end
@@ -72,12 +88,20 @@ module OpenAI
       end
 
       class ChatRefusalDoneEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(String) }
         def refusal
         end
       end
 
       class ChatFunctionToolCallArgumentsDeltaEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(String) }
         def name
         end
@@ -100,6 +124,10 @@ module OpenAI
       end
 
       class ChatFunctionToolCallArgumentsDoneEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(String) }
         def name
         end
@@ -118,24 +146,48 @@ module OpenAI
       end
 
       class ChatLogprobsContentDeltaEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(T.untyped) }
         def content
+        end
+
+        sig { returns(T::Array[OpenAI::Chat::ChatCompletionTokenLogprob]) }
+        def snapshot
         end
       end
 
       class ChatLogprobsContentDoneEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(T.untyped) }
         def content
         end
       end
 
       class ChatLogprobsRefusalDeltaEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(T.untyped) }
         def refusal
+        end
+
+        sig { returns(T::Array[OpenAI::Chat::ChatCompletionTokenLogprob]) }
+        def snapshot
         end
       end
 
       class ChatLogprobsRefusalDoneEvent < OpenAI::Internal::Type::BaseModel
+        sig { returns(Symbol) }
+        def type
+        end
+
         sig { returns(T.untyped) }
         def refusal
         end

--- a/rbi/openai/helpers/streaming/events.rbi
+++ b/rbi/openai/helpers/streaming/events.rbi
@@ -95,7 +95,7 @@ module OpenAI
         end
 
         sig { returns(T.untyped) }
-        def parsed_arguments
+        def parsed
         end
       end
 
@@ -113,7 +113,7 @@ module OpenAI
         end
 
         sig { returns(T.untyped) }
-        def parsed_arguments
+        def parsed
         end
       end
 
@@ -154,8 +154,13 @@ module OpenAI
         def last_response
         end
 
-        sig { returns(T.untyped) }
-        def each
+        sig do
+          params(
+            blk: T.proc.params(event: ChatCompletionStream::ChatCompletionStreamEvent).void
+          )
+            .void
+        end
+        def each(&blk)
         end
       end
     end

--- a/test/openai/helpers/chat_stream_sorbet_test.rb
+++ b/test/openai/helpers/chat_stream_sorbet_test.rb
@@ -28,10 +28,20 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
     source = <<~RUBY
       # typed: strict
 
+      class MathResponse < OpenAI::BaseModel
+        required :answer, Integer
+      end
+
+      class MathTool < OpenAI::BaseModel
+        required :x, Integer
+      end
+
       client = OpenAI::Client.new(api_key: "test-key")
       stream = client.chat.completions.stream(
         model: "gpt-4o-mini",
-        messages: [OpenAI::Chat::ChatCompletionUserMessageParam.new(content: "Hello")]
+        messages: [OpenAI::Chat::ChatCompletionUserMessageParam.new(content: "Hello")],
+        response_format: MathResponse,
+        tools: [MathTool]
       )
 
       T.assert_type!(stream, OpenAI::Streaming::ChatCompletionStream)
@@ -39,9 +49,24 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
       stream.text.each { |text| T.assert_type!(text, String) }
       stream.each do |event|
         T.assert_type!(event, OpenAI::Helpers::Streaming::ChatCompletionStream::ChatCompletionStreamEvent)
+        T.assert_type!(event.type, Symbol)
+
+        case event
+        when OpenAI::Streaming::ChatLogprobsContentDeltaEvent
+          T.assert_type!(event.snapshot, T::Array[OpenAI::Chat::ChatCompletionTokenLogprob])
+        when OpenAI::Streaming::ChatLogprobsRefusalDeltaEvent
+          T.assert_type!(event.snapshot, T::Array[OpenAI::Chat::ChatCompletionTokenLogprob])
+        end
       end
       T.assert_type!(stream.get_final_completion, OpenAI::Chat::ChatCompletion)
-      T.assert_type!(stream.current_completion_snapshot, T.nilable(OpenAI::Chat::ChatCompletion))
+      snapshot = stream.current_completion_snapshot
+      T.assert_type!(snapshot, T.nilable(OpenAI::Chat::ParsedChatCompletion))
+      if snapshot
+        T.assert_type!(
+          snapshot.choices.fetch(0).finish_reason,
+          T.nilable(OpenAI::Chat::ChatCompletion::Choice::FinishReason::TaggedSymbol)
+        )
+      end
       T.assert_type!(stream.get_output_text, String)
       T.assert_type!(stream.until_done, OpenAI::Streaming::ChatCompletionStream)
       T.assert_type!(stream.status, Integer)
@@ -107,6 +132,28 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
     stream&.close
   end
 
+  def test_current_snapshot_keeps_a_nil_finish_reason_before_terminal_chunk
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: chat_nonterminal_stream_body
+      )
+    client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+    stream = client.chat.completions.stream(
+      model: "gpt-4o-mini",
+      messages: [{role: :user, content: "Synthetic"}]
+    )
+
+    stream.to_a
+
+    snapshot = stream.current_completion_snapshot
+    refute_nil(snapshot)
+    assert_nil(snapshot.choices.first.finish_reason)
+  ensure
+    stream&.close
+  end
+
   private def typecheck(source)
     root = File.expand_path("../../..", __dir__)
     Tempfile.create(["chat-stream-sorbet", ".rb"]) do |file|
@@ -129,6 +176,18 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
       created: 1,
       model: "gpt-4o-mini",
       choices: [{index: 0, delta: {role: "assistant", content: "Hello"}, finish_reason: "stop"}]
+    }
+
+    "data: #{JSON.generate(payload)}\n\ndata: [DONE]\n\n"
+  end
+
+  private def chat_nonterminal_stream_body
+    payload = {
+      id: "chatcmpl-sorbet-partial",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      choices: [{index: 0, delta: {role: "assistant", content: "Hello"}, finish_reason: nil}]
     }
 
     "data: #{JSON.generate(payload)}\n\ndata: [DONE]\n\n"

--- a/test/openai/helpers/chat_stream_sorbet_test.rb
+++ b/test/openai/helpers/chat_stream_sorbet_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "open3"
+require "tempfile"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_shipped_rbi_types_high_level_chat_stream_workflow
+    source = <<~RUBY
+      # typed: strict
+
+      client = OpenAI::Client.new(api_key: "test-key")
+      stream = client.chat.completions.stream(
+        model: "gpt-4o-mini",
+        messages: [OpenAI::Chat::ChatCompletionUserMessageParam.new(content: "Hello")]
+      )
+
+      T.assert_type!(stream, OpenAI::Streaming::ChatCompletionStream)
+      T.assert_type!(stream.text, T::Enumerator[String])
+      stream.text.each { |text| T.assert_type!(text, String) }
+      stream.each do |event|
+        T.assert_type!(event, OpenAI::Helpers::Streaming::ChatCompletionStream::ChatCompletionStreamEvent)
+      end
+      T.assert_type!(stream.get_final_completion, OpenAI::Chat::ChatCompletion)
+      T.assert_type!(stream.current_completion_snapshot, T.nilable(OpenAI::Chat::ChatCompletion))
+      T.assert_type!(stream.get_output_text, String)
+      T.assert_type!(stream.until_done, OpenAI::Streaming::ChatCompletionStream)
+      T.assert_type!(stream.status, Integer)
+      T.assert_type!(stream.headers, T::Hash[String, String])
+      T.assert_type!(stream.last_response, OpenAI::ResponseMetadata)
+      T.assert_type!(stream._request_id, T.nilable(String))
+      stream.close
+
+      done = T.must(T.let(nil, T.nilable(OpenAI::Streaming::ChatFunctionToolCallArgumentsDoneEvent)))
+      delta = T.must(T.let(nil, T.nilable(OpenAI::Streaming::ChatFunctionToolCallArgumentsDeltaEvent)))
+      done.parsed
+      delta.parsed
+    RUBY
+
+    stdout, stderr, status = typecheck(source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbi_rejects_wrong_chat_stream_contracts
+    source = <<~RUBY
+      # typed: strict
+
+      client = OpenAI::Client.new(api_key: "test-key")
+      client.chat.completions.stream(
+        model: 123,
+        messages: [OpenAI::Chat::ChatCompletionUserMessageParam.new(content: "Hello")]
+      )
+
+      event = T.must(
+        T.let(nil, T.nilable(OpenAI::Streaming::ChatFunctionToolCallArgumentsDoneEvent))
+      )
+      event.parsed_arguments
+    RUBY
+
+    stdout, stderr, status = typecheck(source)
+    output = "#{stdout}\n#{stderr}"
+
+    refute_predicate(status, :success?, output)
+    assert_includes(output, "Expected")
+    assert_includes(output, "Method \`parsed_arguments\` does not exist")
+  end
+
+  def test_text_returns_the_declared_eager_enumerator_shape
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: chat_stream_body
+      )
+    client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+    stream = client.chat.completions.stream(
+      model: "gpt-4o-mini",
+      messages: [{role: :user, content: "Synthetic"}]
+    )
+
+    text = stream.text
+
+    assert_instance_of(Enumerator, text)
+    refute_instance_of(Enumerator::Lazy, text)
+    assert_equal(["Hello"], text.to_a)
+  ensure
+    stream&.close
+  end
+
+  private def typecheck(source)
+    root = File.expand_path("../../..", __dir__)
+    Tempfile.create(["chat-stream-sorbet", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+    end
+  end
+
+  private def chat_stream_body
+    payload = {
+      id: "chatcmpl-sorbet-shape",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      choices: [{index: 0, delta: {role: "assistant", content: "Hello"}, finish_reason: "stop"}]
+    }
+
+    "data: #{JSON.generate(payload)}\n\ndata: [DONE]\n\n"
+  end
+end

--- a/test/openai/helpers/chat_stream_sorbet_test.rb
+++ b/test/openai/helpers/chat_stream_sorbet_test.rb
@@ -45,6 +45,8 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
       )
 
       T.assert_type!(stream, OpenAI::Streaming::ChatCompletionStream)
+      constructed = OpenAI::Streaming::ChatCompletionStream.new(raw_stream: T.unsafe(nil))
+      T.assert_type!(constructed, OpenAI::Streaming::ChatCompletionStream)
       T.assert_type!(stream.text, T::Enumerator[String])
       stream.text.each { |text| T.assert_type!(text, String) }
       stream.each do |event|
@@ -58,7 +60,24 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
           T.assert_type!(event.snapshot, T::Array[OpenAI::Chat::ChatCompletionTokenLogprob])
         end
       end
-      T.assert_type!(stream.get_final_completion, OpenAI::Chat::ChatCompletion)
+      final_completion = stream.get_final_completion
+      T.assert_type!(final_completion, OpenAI::Chat::ParsedChatCompletion)
+      T.assert_type!(
+        final_completion.choices.fetch(0).finish_reason,
+        T.nilable(OpenAI::Chat::ChatCompletion::Choice::FinishReason::TaggedSymbol)
+      )
+      T.assert_type!(final_completion.to_hash, OpenAI::Internal::AnyHash)
+      T.assert_type!(final_completion.choices.fetch(0).to_hash, OpenAI::Internal::AnyHash)
+      parsed_choice = OpenAI::Chat::ParsedChoice.new(
+        index: 0,
+        logprobs: nil,
+        message: T.unsafe(nil)
+      )
+      T.assert_type!(
+        parsed_choice.finish_reason,
+        T.nilable(OpenAI::Chat::ChatCompletion::Choice::FinishReason::TaggedSymbol)
+      )
+      T.assert_type!(parsed_choice.to_hash, OpenAI::Internal::AnyHash)
       snapshot = stream.current_completion_snapshot
       T.assert_type!(snapshot, T.nilable(OpenAI::Chat::ParsedChatCompletion))
       if snapshot
@@ -150,6 +169,14 @@ class OpenAI::Test::ChatStreamSorbetTest < Minitest::Test
     snapshot = stream.current_completion_snapshot
     refute_nil(snapshot)
     assert_nil(snapshot.choices.first.finish_reason)
+    assert(snapshot.choices.first.to_hash.key?(:finish_reason))
+    assert_nil(snapshot.choices.first.to_hash[:finish_reason])
+    omitted_choice = OpenAI::Chat::ParsedChoice.new(
+      index: snapshot.choices.first.index,
+      logprobs: snapshot.choices.first.logprobs,
+      message: snapshot.choices.first.message
+    )
+    refute(omitted_choice.to_hash.key?(:finish_reason))
   ensure
     stream&.close
   end


### PR DESCRIPTION
## Problem

The documented high-level Chat Completions streaming helper works at runtime, but the shipped RBI omitted `client.chat.completions.stream`, `ChatCompletionStream#text`, `#get_final_completion`, and other stream methods. It also advertised `parsed_arguments` on function-tool argument events even though runtime exposes `parsed`.

This is a Sorbet typing fix, not a runtime behavior change. A typed application using the supported high-level workflow failed compilation with five missing-method errors; the equivalent `stream_raw` call type-checked.

```ruby
client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
stream = client.chat.completions.stream(
  model: "gpt-4o-mini",
  messages: [{role: :user, content: "Hello"}]
)

stream.text.each { |text| puts(text) }
completion = stream.get_final_completion
```

## Change

- Add a handwritten Chat stream RBI that mirrors the existing `stream_raw` request keyword contract and returns the public `OpenAI::Streaming::ChatCompletionStream`.
- Type high-level stream event callbacks, eager text enumeration, final completion, current snapshot, output text, and lifecycle/response metadata inherited from the existing stream base.
- Correct the two function-tool argument event readers from nonexistent `parsed_arguments` to runtime-backed `parsed`.
- Add focused real-Sorbet positive and negative consumer checks plus an offline runtime shape check.

Synthetic before/after:

```text
before: Method stream does not exist on OpenAI::Resources::Chat::Completions
        Method parsed does not exist on ChatFunctionToolCallArgumentsDoneEvent
after:  No errors! Great job.
        parsed_arguments remains a Sorbet error
```

## Compatibility and scope

Runtime code, request behavior, transport models, parser behavior, generated RBI files, RBS, and Responses streaming are unchanged. Existing parsed values remain `T.untyped`, matching the established contract. `text` is declared as the ordinary eager `Enumerator` returned at runtime, not a lazy enumerator.

Customer incidence is not measured; the deterministic impact is a compile-time failure for Sorbet consumers using this public workflow.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_sorbet_test.rb` — 3 runs, 11 assertions, 0 failures
- Original positive consumer probe via `SRB_SKIP_GEM_RBIS=1 ... srb typecheck` — no errors
- Existing `stream_raw` control probe via Sorbet — no errors
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_completion_stream_test.rb` — 10 runs, 47 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_fingerprint_test.rb` — 1 run, 32 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_terminal_tool_test.rb` — 3 runs, 16 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec rake format:rb`
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck`
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck:sorbet`
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop`
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubyfmt`
- Serialized `TEST_API_BASE_URL=... mise exec ruby@4.0.6 -- bundle exec rake test` — 1,711 runs, 14,919 assertions, 0 failures, 0 errors, 1 skip
- Required adversarial review — two consecutive clean rounds, two fresh independent read-only reviewers per round
- Trusted committed-candidate public custom-code budget check — success, 3,365 / 4,000 lines

## Limitations

No live API request was made; verification uses synthetic offline data and the repository mock. This does not measure how many downstream Sorbet applications use Chat streaming.
