### PR TITLE
examples: fix workload identity setup snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,10 @@ For secure, automated environments like cloud-managed Kubernetes, Azure, and GCP
 
 `client_id` remains available as an optional parameter for token exchange setups that require an explicit OAuth client ID.
 
+If `OPENAI_API_KEY` is already set in your environment, pass `api_key: nil`
+to explicitly opt out of that ambient API key when constructing a workload
+identity client.
+
 ### X.509 Workload Identity (Preview)
 
 Organizations enrolled in the X.509 workload identity preview can exchange a
@@ -534,6 +538,7 @@ workload_identity = OpenAI::Auth::WorkloadIdentity.new(
 )
 
 client = OpenAI::Client.new(
+  api_key: nil,
   workload_identity: workload_identity,
 )
 
@@ -555,6 +560,7 @@ workload_identity = OpenAI::Auth::WorkloadIdentity.new(
 )
 
 client = OpenAI::Client.new(
+  api_key: nil,
   workload_identity: workload_identity,
 )
 ```
@@ -571,6 +577,7 @@ workload_identity = OpenAI::Auth::WorkloadIdentity.new(
 )
 
 client = OpenAI::Client.new(
+  api_key: nil,
   workload_identity: workload_identity,
 )
 ```
@@ -601,6 +608,7 @@ workload_identity = OpenAI::Auth::WorkloadIdentity.new(
 )
 
 client = OpenAI::Client.new(
+  api_key: nil,
   workload_identity: workload_identity,
   organization: ENV["OPENAI_ORG_ID"],
   project: ENV["OPENAI_PROJECT_ID"]

--- a/test/openai/workload_identity_readme_test.rb
+++ b/test/openai/workload_identity_readme_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rbconfig"
+
+require_relative "test_helper"
+
+class OpenAI::Test::WorkloadIdentityReadmeTest < Minitest::Test
+  extend Minitest::Serial
+
+  README_PATH = File.expand_path("../../README.md", __dir__)
+  LIB_PATH = File.expand_path("../../lib", __dir__)
+  HEADINGS = [
+    "Kubernetes Service Account",
+    "Azure Managed Identity",
+    "GCP Metadata Server",
+    "Custom Token Providers"
+  ].freeze
+  CHILD_SCRIPT = <<~RUBY
+    require "openai"
+    require "webmock"
+
+    WebMock.enable!
+    WebMock.disable_net_connect!
+
+    client = eval(ARGV.fetch(0), binding, "README.md", 1)
+    abort "README setup did not construct workload identity" if client.workload_identity_auth.nil?
+  RUBY
+    .freeze
+  ISOLATED_ENVIRONMENT = {
+    "OPENAI_ADMIN_KEY" => nil,
+    "OPENAI_API_KEY" => nil,
+    "OPENAI_BASE_URL" => nil,
+    "OPENAI_ORG_ID" => "org_synthetic_readme",
+    "OPENAI_PROJECT_ID" => "proj_synthetic_readme",
+    "IDENTITY_PROVIDER_ID" => "idp_synthetic_readme",
+    "SERVICE_ACCOUNT_ID" => "svc_synthetic_readme",
+    "RUBYLIB" => $LOAD_PATH.join(File::PATH_SEPARATOR)
+  }.freeze
+
+  def test_workload_identity_setup_snippets_construct_with_or_without_ambient_api_key
+    snippets = setup_snippets
+
+    HEADINGS.each do |heading|
+      [nil, "sk-synthetic-ambient-key"].each do |api_key|
+        _stdout, stderr, status = Open3.capture3(
+          ISOLATED_ENVIRONMENT.merge("OPENAI_API_KEY" => api_key),
+          RbConfig.ruby,
+          "-I",
+          LIB_PATH,
+          "-e",
+          CHILD_SCRIPT,
+          "--",
+          snippets.fetch(heading),
+          unsetenv_others: true
+        )
+
+        assert(
+          status.success?,
+          "#{heading} setup failed with OPENAI_API_KEY=#{api_key.nil? ? "unset" : "set"}: #{stderr}"
+        )
+      end
+    end
+  end
+
+  private
+
+  def setup_snippets
+    readme = File.read(README_PATH)
+
+    HEADINGS.to_h do |heading|
+      section = readme.split("### #{heading}\n", 2).fetch(1).split(/^###? /, 2).first
+      code = section.match(/```ruby\n(.*?)\n```/m)[1]
+
+      # This verifies README setup only, not live cloud authentication. Stop
+      # before the Kubernetes snippet's documented API request.
+      [heading, code.split("\nresponse = client.chat.completions.create(", 2).first]
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The README's Kubernetes, Azure managed identity, GCP metadata, and custom token provider workload-identity setup examples relied on ambient credential resolution. A reader who already had `OPENAI_API_KEY` set would copy a snippet and get:

```text
ArgumentError: `api_key` and `workload_identity` are mutually exclusive
```

This is an onboarding/copy-and-paste example defect. Customer incidence is unmeasured; the deterministic proof uses only synthetic values and does not perform a live token exchange or API request.

## Fix

Each affected constructor now uses the existing explicit API-key opt-out, and the surrounding prose explains why:

```ruby
client = OpenAI::Client.new(
  api_key: nil,
  workload_identity: workload_identity
)
```

Safe synthetic before/after:

```text
OPENAI_API_KEY=sk-synthetic-ambient-key
before: ArgumentError: `api_key` and `workload_identity` are mutually exclusive
after:  workload_identity client constructs successfully
```

The fix preserves provider choices, identity IDs, custom organization/project settings, runtime authentication precedence, and explicit-credential conflict checks. It does not change SDK runtime code, public APIs, providers, dependencies, generated files, CI, X.509 guidance, or unrelated README sections.

## Regression coverage

`test/openai/workload_identity_readme_test.rb` extracts the four actual fenced README snippets and runs their setup portions through the real `OpenAI::Client` constructor in isolated subprocesses, both with no API key and with a synthetic ambient API key. Network is disabled, and the Kubernetes snippet stops before its documented API call; this verifies setup only, not live cloud authentication.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/workload_identity_readme_test.rb` — 1 run, 8 assertions, 0 failures, 0 errors, 0 skips
- `mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/client_options_test.rb` — 13 runs, 87 assertions, 0 failures, 0 errors, 0 skips
- `mise exec ruby@4.0.6 -- bundle exec rake test TEST=test/openai/client_authentication_test.rb` — 11 runs, 25 assertions, 0 failures, 0 errors, 0 skips
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubyfmt`
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2,908 files inspected, no offenses
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck` — RBS validation and Sorbet passed
- `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1,709 runs, 14,916 assertions, 0 failures, 0 errors, 1 skip
- Trusted current-main public custom-code budget check against committed candidate — success, 3,365 / 4,000 custom lines

## Review and security

Four adversarial-review rounds were run with two fresh read-only reviewers per round. The first two rounds identified and resolved subprocess environment isolation and Bundler load-path portability gaps; the final two consecutive rounds were clean on unchanged code. A proportionate credential-selection security review found no secret material, new network behavior, or runtime authentication change.

Limitations: coverage intentionally does not invoke metadata servers, token providers, issuer exchange, or a live API request.
