### PR TITLE
fix: correct Responses text enumerator Sorbet type

### DIFF
--- a/rbi/openai/helpers/streaming/response_stream.rbi
+++ b/rbi/openai/helpers/streaming/response_stream.rbi
@@ -49,7 +49,7 @@ module OpenAI
         def get_output_text
         end
 
-        sig { returns(T::Enumerator::Lazy[String]) }
+        sig { returns(T::Enumerator[String]) }
         def text
         end
 

--- a/test/openai/helpers/response_text_sorbet_test.rb
+++ b/test/openai/helpers/response_text_sorbet_test.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "open3"
+require "tempfile"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResponseTextSorbetTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def after_all
+    WebMock.allow_net_connect!
+    WebMock.disable!
+    super
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_shipped_rbi_types_text_as_an_eager_string_enumerator
+    source = <<~RUBY
+      # typed: strict
+
+      client = OpenAI::Client.new(api_key: "synthetic-key")
+      stream = client.responses.stream(model: "gpt-4o-mini", input: "Synthetic")
+      texts = stream.text
+
+      T.assert_type!(texts, T::Enumerator[String])
+      mapped = T.let(texts.map { |text| text.upcase }, T::Array[String])
+      taken = T.let(stream.text.take(1), T::Array[String])
+      lazy = T.let(stream.text.lazy.map { |text| text.upcase }, T::Enumerator::Lazy[String])
+
+      T.assert_type!(mapped.fetch(0), String)
+      T.assert_type!(taken.fetch(0), String)
+      T.assert_type!(lazy, T::Enumerator::Lazy[String])
+    RUBY
+
+    stdout, stderr, status = typecheck(source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbi_rejects_lazy_only_operation_on_text
+    source = <<~RUBY
+      # typed: strict
+
+      client = OpenAI::Client.new(api_key: "synthetic-key")
+      stream = client.responses.stream(model: "gpt-4o-mini", input: "Synthetic")
+      texts = stream.text
+      T.assert_type!(texts, T::Enumerator[String])
+      texts.force
+    RUBY
+
+    stdout, stderr, status = typecheck(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "force")
+  end
+
+  def test_public_text_stream_remains_an_eager_enumerator
+    stub_request(:post, "http://localhost/responses").to_return(
+      status: 200,
+      headers: {"Content-Type" => "text/event-stream"},
+      body: sse_response
+    )
+
+    stream = OpenAI::Client
+      .new(
+        api_key: "synthetic-key",
+        base_url: "http://localhost"
+      )
+      .responses
+      .stream(model: "gpt-4o-mini", input: "Synthetic")
+
+    texts = stream.text
+    normalized = texts.map { |text| text.upcase }
+
+    assert_instance_of(Enumerator, texts)
+    refute_instance_of(Enumerator::Lazy, texts)
+    assert_instance_of(Array, normalized)
+    assert_equal(["HELLO", " WORLD"], normalized)
+    assert_equal("hello world", stream.get_output_text)
+    assert_requested(:post, "http://localhost/responses", times: 1)
+  ensure
+    stream&.close
+  end
+
+  private def typecheck(source)
+    root = File.expand_path("../../..", __dir__)
+    Tempfile.create(["response-text-sorbet", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+    end
+  end
+
+  private def sse_response
+    events = [
+      {type: "response.created", sequence_number: 0, response: response},
+      {type: "response.output_item.added", sequence_number: 1, output_index: 0, item: message_item},
+      {
+        type: "response.content_part.added",
+        sequence_number: 2,
+        output_index: 0,
+        item_id: "msg_synthetic",
+        content_index: 0,
+        part: text_part
+      },
+      text_delta(3, "hello"),
+      text_delta(4, " world"),
+      {
+        type: "response.output_text.done",
+        sequence_number: 5,
+        output_index: 0,
+        item_id: "msg_synthetic",
+        content_index: 0,
+        text: "hello world"
+      },
+      {
+        type: "response.completed",
+        sequence_number: 6,
+        response: response.merge(
+          status: "completed",
+          output: [message_item.merge(status: "completed", content: [text_part.merge(text: "hello world")])]
+        )
+      }
+    ]
+
+    events.map { |event| "data: #{JSON.generate(event)}\n\n" }.join
+  end
+
+  private def text_delta(sequence_number, delta)
+    {
+      type: "response.output_text.delta",
+      sequence_number: sequence_number,
+      output_index: 0,
+      item_id: "msg_synthetic",
+      content_index: 0,
+      delta: delta
+    }
+  end
+
+  private def response
+    {
+      id: "resp_synthetic",
+      object: "response",
+      created_at: 1,
+      status: "in_progress",
+      error: nil,
+      incomplete_details: nil,
+      instructions: nil,
+      model: "gpt-4o-mini",
+      output: [],
+      parallel_tool_calls: true,
+      metadata: {},
+      temperature: 1.0,
+      tool_choice: "auto",
+      tools: [],
+      top_p: 1.0
+    }
+  end
+
+  private def message_item
+    {
+      id: "msg_synthetic",
+      type: "message",
+      role: "assistant",
+      status: "in_progress",
+      content: []
+    }
+  end
+
+  private def text_part
+    {type: "output_text", text: "", annotations: [], logprobs: []}
+  end
+end


### PR DESCRIPTION
# fix: correct Responses text enumerator Sorbet type

## Problem

ResponseStream#text returns an ordinary Enumerator at runtime, but its shipped Sorbet declaration described T::Enumerator::Lazy[String]. Sorbet applications using normal eager transforms therefore saw valid code rejected:

~~~ruby
# typed: strict

client = OpenAI::Client.new(api_key: ENV.fetch("OPENAI_API_KEY"))
stream = client.responses.stream(model: "gpt-4o-mini", input: "Summarize this")
normalized = T.let(stream.text.map { |text| text.upcase }, T::Array[String])
~~~

With the previous declaration, the synthetic consumer probe reported Sorbet 7007 because map was inferred as T::Enumerator::Lazy[String] rather than T::Array[String]. Independently, an offline HTTP-stubbed public-stream probe showed the existing runtime already returns Enumerator, eager map produces ["HELLO", " WORLD"], and final output text is "hello world".

## Fix

Change only the handwritten ResponseStream#text RBI return type to T::Enumerator[String], matching the existing runtime behavior. Add a focused regression that verifies:

- eager map and take type-check as T::Array[String];
- the inferred enumerator retains String element typing;
- explicit .text.lazy still type-checks as T::Enumerator::Lazy[String];
- a lazy-only force call on .text is rejected;
- the public Responses stream helper still returns an ordinary enumerator, eagerly maps to an array, accumulates the same final text, uses an HTTP-boundary stub, and closes safely.

## Impact and compatibility

This fixes a shipped static-typing defect for Sorbet consumers transforming Responses text deltas. Runtime streaming behavior and the public runtime API are unchanged. Customer incidence is unmeasured; the evidence is a deterministic synthetic public-path reproduction, not a live API observation or customer report.

## Scope and non-goals

The diff is limited to the text return type in rbi/openai/helpers/streaming/response_stream.rbi and a new focused test. It does not change runtime code, RBS, generated declarations, Chat streaming declarations, other helper signatures, dependencies, docs, budget/provenance, or architecture.

## Verification

- Red baseline: synthetic public Sorbet probe reproduced error 7007 for eager map; offline runtime probe returned ordinary Enumerator, eager Array, ["HELLO", " WORLD"], and "hello world".
- Regression red/green: with the old annotation restored temporarily, the new focused test failed on eager map/take and the lazy-only guard; with the corrected annotation, it passed.
- mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/response_text_sorbet_test.rb — 3 runs, 11 assertions, 0 failures.
- mise exec ruby@4.0.6 -- bundle exec ruby test/openai/resources/responses/streaming_test.rb — 33 runs, 123 assertions, 0 failures.
- mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/response_stream_isolation_test.rb — 3 runs, 24 assertions, 0 failures.
- mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/response_stream_text_logprobs_test.rb — 2 runs, 54 assertions, 0 failures.
- mise exec ruby@4.0.6 -- bundle exec rake lint — RuboCop 2,909 files with no offenses; Sorbet no errors; 1,286 RBS files valid.
- TEST_API_BASE_URL=<coordinator-owned mock> mise exec ruby@4.0.6 -- bundle exec rake test — 1,713 runs, 14,937 assertions, 0 failures, 0 errors, 1 skip.
- Trusted committed-candidate public custom-code budget check against current main 3ea76f49b16f9476d65cfb45bea3dda61f39d85e — success, 3,365 / 4,000 custom lines.
- Adversarial review: round 1 found one narrowly necessary test-strengthening issue and it was fixed; fresh rounds 2 and 3 were both clean.

## Limitations

No live API request was made. The runtime evidence uses synthetic SSE data and a blocked-network HTTP stub.
