### PR TITLE
fix: normalize workload identity error headers

### DIFF
--- a/lib/openai/auth/workload_identity_auth.rb
+++ b/lib/openai/auth/workload_identity_auth.rb
@@ -355,7 +355,7 @@ module OpenAI
             OpenAI::Errors::OAuthError.new(
               status: response.code.to_i,
               body: body,
-              headers: response.to_hash
+              headers: response.each_header.to_h
             )
           )
         in Net::HTTPSuccess
@@ -368,7 +368,7 @@ module OpenAI
             OpenAI::Errors::APIError.new(
               url: @token_exchange_url,
               status: response.code.to_i,
-              headers: response.to_hash,
+              headers: response.each_header.to_h,
               body: body,
               message: "Token exchange failed with status #{response.code}"
             )

--- a/test/openai/auth/workload_identity_error_headers_test.rb
+++ b/test/openai/auth/workload_identity_error_headers_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class WorkloadIdentityErrorHeadersTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def test_oauth_exchange_errors_expose_string_headers_and_request_ids
+    [400, 401, 403].each do |status|
+      error = exchange_error(
+        status,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-Request-ID" => "req_synthetic_#{status}",
+          "Retry-After" => "2"
+        }
+      )
+
+      assert_instance_of(OpenAI::Errors::OAuthError, error)
+      assert_equal(status, error.status)
+      assert_equal(:invalid_grant, error.error_code)
+      assert_equal("req_synthetic_#{status}", error.request_id)
+      assert_equal("2", error.headers.fetch("retry-after"))
+      assert(error.headers.all? { |name, value| name.is_a?(String) && name == name.downcase && value.is_a?(String) })
+    end
+  end
+
+  def test_non_oauth_exchange_errors_expose_string_headers_and_request_ids
+    error = exchange_error(
+      500,
+      headers: {
+        "Content-Type" => "application/json",
+        "X-Request-ID" => "req_synthetic_500",
+        "Retry-After" => "2"
+      }
+    )
+
+    assert_instance_of(OpenAI::Errors::APIError, error)
+    assert_equal(500, error.status)
+    assert_equal("req_synthetic_500", error.request_id)
+    assert_equal("2", error.headers.fetch("retry-after"))
+    assert(error.headers.all? { |name, value| name.is_a?(String) && name == name.downcase && value.is_a?(String) })
+  end
+
+  def test_exchange_errors_without_request_ids_keep_nil_request_ids
+    error = exchange_error(401, headers: {"Content-Type" => "application/json"})
+
+    assert_nil(error.request_id)
+  end
+
+  private def exchange_error(status, headers:)
+    WebMock.reset!
+    stub_request(:post, "https://auth.openai.com/oauth/token")
+      .to_return(
+        status: status,
+        headers: headers,
+        body: JSON.generate(error: "invalid_grant", error_description: "Synthetic token exchange failure")
+      )
+    provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
+    identity = OpenAI::Auth::WorkloadIdentity.new(
+      provider: provider,
+      identity_provider_id: "ip_synthetic",
+      service_account_id: "sa_synthetic"
+    )
+    client = OpenAI::Client.new(
+      api_key: nil,
+      workload_identity: identity,
+      organization: "org_synthetic",
+      max_retries: 0
+    )
+    calls = 0
+    get_token = -> {
+      calls += 1
+      "synthetic-subject-token"
+    }
+
+    error = provider.stub(:get_token, get_token) do
+      assert_raises(OpenAI::Errors::APIError) do
+        client.responses.create(model: "gpt-4o-mini", input: "Synthetic")
+      end
+    end
+
+    assert_equal(1, calls)
+    assert_requested(:post, "https://auth.openai.com/oauth/token", times: 1)
+    assert_not_requested(:post, "https://api.openai.com/v1/responses")
+    error
+  end
+end


### PR DESCRIPTION
## Problem

Workload-identity token exchange errors passed `Net::HTTPResponse#to_hash` directly into the SDK error contract. That representation stores header values as Arrays, so ordinary OAuth and non-OAuth exchange failures exposed values such as `["req_synthetic_401"]` and `["2"]` where the rest of the SDK exposes Strings.

Customer incidence is unmeasured. The behavior was reproduced deterministically through the supported public client path with synthetic credentials and network-denied issuer responses; no real provider, issuer, or API call was made.

## User-facing behavior

```ruby
begin
  client.responses.create(model: "gpt-4o-mini", input: "Hello")
rescue OpenAI::Errors::APIError => error
  request_id = error.request_id
  retry_after = error.headers["retry-after"]
end
```

For a synthetic 401 token-exchange response:

```ruby
# Before
request_id # => ["req_synthetic_401"]
retry_after # => ["2"]

# After
request_id # => "req_synthetic_401"
retry_after # => "2"
```

## Fix

The two workload-identity error branches now use `response.each_header.to_h`, matching the existing ordinary NetHTTPClient boundary. This keeps lowercase String header names, String values, and String-or-nil request IDs without introducing a global normalizer or a repeated-header policy.

The regression test drives the real public client path with a framework-stubbed existing subject-token provider and WebMock-backed Net::HTTP responses. It covers OAuth 400/401/403, representative 500, missing request IDs, one provider/exchange call, and confirms failed exchange does not issue an API request.

## Compatibility and scope

This preserves exception classes, status, OAuth error code, message, raw body, token request contents/type, provider calls, refresh/cache/deadline behavior, and success parsing. The diff is limited to the two error-construction branches and one focused test. It does not change shared transport, errors, provider implementations, public APIs, dependencies, generated files, budget, or provenance.

## Verification

- Baseline public reproducer: synthetic 401 and 500 returned Array request IDs and Array `retry-after` values.
- After fix public reproducer: both return String request IDs and String `retry-after` values.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/auth/workload_identity_error_headers_test.rb` — 3 runs, 34 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/auth/workload_identity_test.rb` — 29 runs, 129 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/auth/x509_client_test.rb` — 32 runs, 292 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/auth/x509_contract_test.rb` — 19 runs, 116 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/errors_test.rb` — 36 runs, 3,196 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop 2,911 files, 0 offenses; RBS validation 1,286 files, 0 errors; Sorbet examples typecheck clean.
- `TEST_API_BASE_URL=<current-spec mock> mise exec ruby@4.0.6 -- bundle exec rake test` — 1,717 runs, 14,979 assertions, 0 failures, 0 errors, 1 skip.
- Trusted current-main public custom-code budget check on committed candidate — 3,365 / 4,000 custom lines, success.

## Review

- Adversarial review round 1 found one test-only gap: the header predicate did not explicitly reject Symbol keys. The regression assertion was tightened.
- Fresh independent rounds 2 and 3 were clean, satisfying two consecutive clean rounds on unchanged final code.
- Dedicated auth/security review found no credential destination, token-content, logging, parsing, retry, exception-routing, or dependency change.

## Limitations

- The tests use synthetic network-denied responses; no live issuer or API traffic was exercised.
- Repeated-header behavior remains Net::HTTP's existing `each_header` representation and is intentionally unchanged.
