### PR TITLE
examples: fix README webhook event dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,9 +644,9 @@ post '/webhook' do
     event = client.webhooks.unwrap(request_body, request.env)
     
     case event.type
-    when 'response.completed'
+    when :'response.completed'
       puts "Response completed: #{event.data}"
-    when 'response.failed'
+    when :'response.failed'
       puts "Response failed: #{event.data}"
     else
       puts "Unhandled event type: #{event.type}"

--- a/test/openai/webhook_readme_dispatch_test.rb
+++ b/test/openai/webhook_readme_dispatch_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "openssl"
+require "rbconfig"
+
+require_relative "test_helper"
+
+class OpenAI::Test::WebhookReadmeDispatchTest < Minitest::Test
+  README_PATH = File.expand_path("../../README.md", __dir__)
+  LIB_PATH = File.expand_path("../../lib", __dir__)
+  WEBHOOK_ID = "wh_synthetic_readme_dispatch"
+  WEBHOOK_SECRET = "synthetic readme webhook secret"
+
+  def test_unwrap_handler_dispatches_typed_response_events_and_retains_fallback
+    completed = dispatch("response.completed")
+    failed = dispatch("response.failed")
+    fallback = dispatch("response.cancelled")
+
+    assert_match(/\AResponse completed:/, completed)
+    assert_match(/\AResponse failed:/, failed)
+    assert_equal("Unhandled event type: response.cancelled\n", fallback)
+  end
+
+  private
+
+  def dispatch(type)
+    timestamp = Time.now.to_i.to_s
+    payload = JSON.generate(
+      id: "evt_synthetic_readme_dispatch",
+      object: "event",
+      created_at: timestamp.to_i,
+      type: type,
+      data: {id: "resp_synthetic_readme_dispatch"}
+    )
+    script = <<~RUBY
+        require "json"
+        require "openai"
+        require "webmock"
+
+        WebMock.disable_net_connect!
+        client = OpenAI::Client.new(api_key: "sk-synthetic", webhook_secret: ARGV.fetch(2))
+        payload = ARGV.fetch(0)
+        headers = JSON.parse(ARGV.fetch(1))
+        event = client.webhooks.unwrap(payload, headers)
+      #{readme_dispatch}
+    RUBY
+    stdout, stderr, status = Open3.capture3(
+      {"RUBYLIB" => $LOAD_PATH.join(File::PATH_SEPARATOR)},
+      RbConfig.ruby,
+      "-I",
+      LIB_PATH,
+      "-e",
+      script,
+      "--",
+      payload,
+      JSON.generate(signed_headers(payload, timestamp)),
+      WEBHOOK_SECRET,
+      unsetenv_others: true
+    )
+
+    assert(status.success?, stderr)
+    stdout
+  end
+
+  def readme_dispatch
+    File.read(README_PATH).match(/^    case event\.type\n(?:.*\n)*?^    end$/).to_s
+  end
+
+  def signed_headers(payload, timestamp)
+    signed_payload = "#{WEBHOOK_ID}.#{timestamp}.#{payload}"
+    signature = [OpenSSL::HMAC.digest("sha256", WEBHOOK_SECRET, signed_payload)].pack("m0")
+
+    {
+      "webhook-signature" => "v1,#{signature}",
+      "webhook-timestamp" => timestamp,
+      "webhook-id" => WEBHOOK_ID
+    }
+  end
+end


### PR DESCRIPTION
## Problem

The README's verified webhook example calls `client.webhooks.unwrap`, which returns typed webhook events whose `type` discriminator is a Symbol. The example compared that value with Strings, so valid `response.completed` and `response.failed` events fell through to the fallback branch when copied into an ordinary Ruby app.

This is a deterministic copy-paste example failure, not evidence of a live customer incident; customer incidence is unmeasured.

## User-facing example

```ruby
event = client.webhooks.unwrap(request_body, request.env)

case event.type
when :'response.completed'
  puts "Response completed: #{event.data}"
when :'response.failed'
  puts "Response failed: #{event.data}"
else
  puts "Unhandled event type: #{event.type}"
end
```

With correctly signed synthetic events through the public `unwrap` path:

```text
before: Unhandled event type: response.completed
before: Unhandled event type: response.failed
after:  Response completed: ...
after:  Response failed: ...
```

## Fix

- Change only the two README discriminator comparisons from Strings to Symbols.
- Add a focused regression that extracts and executes the actual README dispatch block in an isolated, network-disabled Ruby process after real public `client.webhooks.unwrap` calls with correctly signed synthetic payloads.
- Cover completed, failed, and a valid typed fallback event without requiring Sinatra or making live API requests.

## Compatibility, scope, and security

The SDK runtime, public API, typed event models, signature verification, parsing, rescue behavior, and direct `verify_signature`/`JSON.parse` example are unchanged. Verification still happens before dispatch. The test uses only clearly synthetic payloads, credentials, webhook ID, and secret.

Non-goals: no runtime/model/generated/auth/verification/logging/dependency/budget/provenance changes and no unrelated README edits.

## Verification

- Red: `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/webhook_readme_dispatch_test.rb` → 1 run, 2 assertions, 1 failure (`Unhandled event type: response.completed`).
- Green: same focused test → 1 run, 8 assertions, 0 failures, 0 errors, 0 skips.
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/webhook_verification_test.rb` → 19 runs, 45 assertions, 0 failures, 0 errors, 0 skips.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` → RuboCop inspected 2,913 files with no offenses; RBS validation and examples Sorbet typecheck passed.
- `mise exec ruby@4.0.6 -- bundle exec rake typecheck` → passed.
- `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` → 1,721 runs, 15,019 assertions, 0 failures, 0 errors, 1 skip.
- Trusted current-main public custom-code budget check on committed candidate → success, 3,365 / 4,000 custom lines.

## Review

Two consecutive adversarial-review rounds completed on unchanged final code, each with two fresh independent read-only reviewers. No meaningful unresolved in-scope findings remained. Security was assessed specifically for webhook verification: the example's verification call and order are unchanged, and no secret, transport, or runtime boundary changed.

Limitation: the test proves deterministic supported public-path behavior with synthetic signed events; it does not measure real-world customer incidence.
