### PR TITLE
fix: declare webhook signature error types

### DIFF
--- a/rbi/openai/errors.rbi
+++ b/rbi/openai/errors.rbi
@@ -7,6 +7,9 @@ module OpenAI
       attr_reader :cause
     end
 
+    class InvalidWebhookSignatureError < OpenAI::Errors::Error
+    end
+
     class PollingError < OpenAI::Errors::Error
     end
 

--- a/sig/openai/errors.rbs
+++ b/sig/openai/errors.rbs
@@ -4,6 +4,9 @@ module OpenAI
       attr_reader cause: StandardError?
     end
 
+    class InvalidWebhookSignatureError < OpenAI::Errors::Error
+    end
+
     class PollingError < OpenAI::Errors::Error
     end
 

--- a/test/openai/helpers/webhook_error_types_test.rb
+++ b/test/openai/helpers/webhook_error_types_test.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tempfile"
+require "tmpdir"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::WebhookErrorTypesTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_invalid_signature_raises_the_declared_sdk_error_without_network
+    client = OpenAI::Client.new(
+      api_key: "synthetic-key",
+      webhook_secret: "synthetic-webhook-secret"
+    )
+
+    error = assert_raises(OpenAI::Errors::InvalidWebhookSignatureError) do
+      client.webhooks.verify_signature("{}", invalid_signature_headers)
+    end
+
+    assert_kind_of(OpenAI::Errors::Error, error)
+  end
+
+  def test_shipped_rbi_types_the_public_rescue_path
+    stdout, stderr, status = sorbet_typecheck(typed_rescue_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbi_typecheck_has_a_negative_control
+    source = typed_rescue_source.sub(
+      "T.let(error, OpenAI::Errors::Error)",
+      "T.let(error, String)"
+    )
+    stdout, stderr, status = sorbet_typecheck(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "String")
+  end
+
+  def test_shipped_rbs_types_the_public_rescue_path
+    stdout, stderr, status = steep_check(rbs_rescue_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  private
+
+  def invalid_signature_headers
+    {
+      "webhook-id" => "evt_synthetic",
+      "webhook-timestamp" => Time.now.to_i.to_s,
+      "webhook-signature" => "v1,synthetic-invalid-signature"
+    }
+  end
+
+  def typed_rescue_source
+    <<~RUBY
+      # typed: true
+
+      client = OpenAI::Client.new(api_key: "synthetic-key", webhook_secret: "synthetic-webhook-secret")
+      headers = {
+        "webhook-id" => "evt_synthetic",
+        "webhook-timestamp" => Time.now.to_i.to_s,
+        "webhook-signature" => "v1,synthetic-invalid-signature"
+      }
+
+      begin
+        client.webhooks.verify_signature("{}", headers)
+      rescue OpenAI::Errors::InvalidWebhookSignatureError => error
+        exception = T.let(error, OpenAI::Errors::Error)
+        puts(exception.class.name)
+      end
+    RUBY
+  end
+
+  def rbs_rescue_source
+    <<~RUBY
+      client = OpenAI::Client.new(api_key: "synthetic-key", webhook_secret: "synthetic-webhook-secret")
+      headers = {
+        "webhook-id" => "evt_synthetic",
+        "webhook-timestamp" => Time.now.to_i.to_s,
+        "webhook-signature" => "v1,synthetic-invalid-signature"
+      }
+
+      begin
+        client.webhooks.verify_signature("{}", headers)
+      rescue OpenAI::Errors::InvalidWebhookSignatureError => error
+        puts(error.message)
+      end
+    RUBY
+  end
+
+  def sorbet_typecheck(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Tempfile.create(["webhook-error-sorbet", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+    end
+  end
+
+  def steep_check(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Dir.mktmpdir("webhook-error-rbs") do |directory|
+      FileUtils.cp_r(File.join(root, "sig"), directory)
+      File.write(File.join(directory, "probe.rb"), source)
+      File.write(
+        File.join(directory, "Steepfile"),
+        <<~RUBY
+          target :lib do
+            signature "sig"
+            library "net-http"
+            check "probe.rb"
+          end
+        RUBY
+      )
+      Open3.capture3(
+        "steep",
+        "check",
+        "--no-daemon",
+        "--jobs=1",
+        "--validate=skip",
+        chdir: directory
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Problem

OpenAI::Errors::InvalidWebhookSignatureError already exists at runtime and is raised by client.webhooks.verify_signature, but the shipped RBI and RBS error inventories omitted it. Typed applications could not rescue the specific exception without an unresolved-constant error or an untyped workaround.

~~~ruby
client = OpenAI::Client.new(
  api_key: ENV.fetch("OPENAI_API_KEY"),
  webhook_secret: ENV.fetch("OPENAI_WEBHOOK_SECRET")
)

begin
  client.webhooks.verify_signature(payload, headers)
rescue OpenAI::Errors::InvalidWebhookSignatureError => error
  sdk_error = T.let(error, OpenAI::Errors::Error)
  warn(sdk_error.message)
end
~~~

## Before / after

Using a synthetic invalid signature with networking disabled:

- Runtime before and after: {exception: "OpenAI::Errors::InvalidWebhookSignatureError", sdk_error: true}
- Sorbet before: error 5002 for unresolved InvalidWebhookSignatureError, followed by error 7007 when narrowing the rescued value to OpenAI::Errors::Error
- Sorbet after: No errors! Great job.
- Steep before: one Ruby::UnknownConstant diagnostic for InvalidWebhookSignatureError
- Steep after: the public rescue-path consumer type-checks

## Fix

Add only the existing exception declaration to the handwritten RBI and RBS inventories, with the same OpenAI::Errors::Error superclass as runtime. Add a focused offline test for the runtime raise and inheritance, the RBI and RBS public rescue workflows, and a deliberately failing Sorbet narrowing control.

## Compatibility and scope

This is a declaration-only correction. It does not change runtime exception behavior, webhook signature verification, timestamp tolerance, secret handling, request behavior, transport, logging, authentication, dependencies, generated files, or any public API. Customer incidence is unmeasured; the deterministic typed-consumer failure is reproduced locally with synthetic data.

Security assessment: no runtime webhook code changed, so HMAC verification, timing-safe comparison, timestamp checks, and secret handling remain unchanged.

## Verification

- mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/webhook_error_types_test.rb — 4 runs, 10 assertions, 0 failures
- mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/webhook_verification_test.rb — 19 runs, 45 assertions, 0 failures
- SRB_SKIP_GEM_RBIS=1 mise exec ruby@4.0.6 -- bundle exec srb typecheck verify_webhook_error_sorbet.rb — no errors
- mise exec ruby@4.0.6 -- bundle exec rake lint — 2912 files inspected, no offenses; Sorbet examples clean; 1286 RBS files validated
- TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test — 1721 runs, 14989 assertions, 0 failures, 0 errors, 1 skip
- Trusted public custom-code budget against current main 8dba07cda53195755ffbf15634c516e51701ba5a and candidate 7ad87798a5e9fb7def6965f0326add5d5c2f2229 — 3365/4000 custom lines, 635 headroom

An earlier frozen full-suite attempt reported one Realtime negotiation-timeout error; it was not reproduced in isolation, cause remains unproven, and the final-state serialized full suite above passed.

Adversarial review converged after three paired fresh-context rounds. Round 1 was clean, then the test-only WebMock lifecycle was tightened to avoid restoring a broader global network state; rounds 2 and 3 were consecutive clean rounds on the final code.
