### PR TITLE
fix: redact malformed streamed JSON errors

### DIFF
--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -267,10 +267,10 @@ module OpenAI
           begin
             parsed = JSON.parse(text, symbolize_names: true)
             OpenAI::Internal::Type::Converter.coerce(@text_format, parsed)
-          rescue JSON::ParserError => e
+          rescue JSON::ParserError
             raise(
-              "Failed to parse structured text as JSON for #{@text_format}: #{e.message}. " \
-                "Raw text: #{text.inspect}"
+              "Failed to parse structured text as JSON for #{@text_format}",
+              cause: nil
             )
           end
         end

--- a/test/openai/resources/responses/streaming_test.rb
+++ b/test/openai/resources/responses/streaming_test.rb
@@ -276,7 +276,9 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
     end
 
     assert_match(/Failed to parse structured text as JSON/, error.message)
-    assert_match(/Raw text:/, error.message)
+    refute_match(/Raw text:/, error.message)
+    refute_match(/SENSITIVE_MODEL_OUTPUT/, error.message)
+    assert_nil(error.cause)
   end
 
   def test_function_calling_streaming
@@ -1041,13 +1043,13 @@ class OpenAI::Test::Resources::Responses::StreamingTest < Minitest::Test
       data: {"type":"response.output_text.delta","sequence_number":4,"response_id":"msg_malformed","item_id":"item_malformed","output_index":0,"content_index":0,"delta":"{\\"location\\":\\""}
 
       event: response.output_text.delta
-      data: {"type":"response.output_text.delta","sequence_number":5,"response_id":"msg_malformed","item_id":"item_malformed","output_index":0,"content_index":0,"delta":"San Francisco\\", malformed JSON"}
+      data: {"type":"response.output_text.delta","sequence_number":5,"response_id":"msg_malformed","item_id":"item_malformed","output_index":0,"content_index":0,"delta":"SENSITIVE_MODEL_OUTPUT\\", malformed JSON"}
 
       event: response.output_text.done
-      data: {"type":"response.output_text.done","sequence_number":6,"response_id":"msg_malformed","item_id":"item_malformed","output_index":0,"content_index":0,"text":"{\\"location\\":\\"San Francisco\\", malformed JSON"}
+      data: {"type":"response.output_text.done","sequence_number":6,"response_id":"msg_malformed","item_id":"item_malformed","output_index":0,"content_index":0,"text":"{\\"location\\":\\"SENSITIVE_MODEL_OUTPUT\\", malformed JSON"}
 
       event: response.completed
-      data: {"type":"response.completed","sequence_number":7,"response":{"id":"msg_malformed","object":"realtime.response","status":"completed","status_details":null,"output":[{"id":"item_malformed","object":"realtime.item","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"{\\"location\\":\\"San Francisco\\", malformed JSON"}]}],"usage":{"total_tokens":20,"input_tokens":10,"output_tokens":10},"metadata":null}}
+      data: {"type":"response.completed","sequence_number":7,"response":{"id":"msg_malformed","object":"realtime.response","status":"completed","status_details":null,"output":[{"id":"item_malformed","object":"realtime.item","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"{\\"location\\":\\"SENSITIVE_MODEL_OUTPUT\\", malformed JSON"}]}],"usage":{"total_tokens":20,"input_tokens":10,"output_tokens":10},"metadata":null}}
 
     SSE
   end


### PR DESCRIPTION
## Summary
- remove raw structured model output and parser text from malformed streaming JSON errors
- suppress the rescued parser exception cause to prevent cause-chain disclosure
- add a focused sensitive-marker regression for the public structured streaming path

## Validation
- GEM_HOME=/tmp/openai-ruby-min GEM_PATH=/tmp/openai-ruby-min:/opt/homebrew/lib/ruby/gems/3.2.0 ruby -Itest test/openai/resources/responses/streaming_test.rb --name test_structured_output_streaming_with_malformed_json
- GEM_HOME=/tmp/openai-ruby-min GEM_PATH=/tmp/openai-ruby-min:/opt/homebrew/lib/ruby/gems/3.2.0 ruby -Itest test/openai/resources/responses/streaming_test.rb --name test_structured_output_streaming
- GEM_HOME=/tmp/openai-ruby-min GEM_PATH=/tmp/openai-ruby-min:/opt/homebrew/lib/ruby/gems/3.2.0 ruby -Itest test/openai/resources/responses/streaming_test.rb
- GEM_HOME=/tmp/openai-ruby-min GEM_PATH=/tmp/openai-ruby-min:/opt/homebrew/lib/ruby/gems/3.2.0 ruby -S rubocop --force-exclusion lib/openai/helpers/streaming/response_stream.rb test/openai/resources/responses/streaming_test.rb
- ./scripts/rubyfmt --check -- lib/openai/helpers/streaming/response_stream.rb test/openai/resources/responses/streaming_test.rb
- ruby -c for both changed files
- git diff --check

## Security review
The malformed response text is network/model-derived and can contain customer content. The fix preserves RuntimeError and successful structured parsing while ensuring the propagated error message and cause chain contain no model output or parser excerpt. Two required adversarial-review rounds completed cleanly before push.