### PR TITLE
fix: suppress Responses WebSocket exception causes

### DIFF
--- a/lib/openai/helpers/websocket/async_websocket_transport.rb
+++ b/lib/openai/helpers/websocket/async_websocket_transport.rb
@@ -170,20 +170,23 @@ module OpenAI
         def read
           @connection.read
         rescue StandardError => e
-          raise @error_factory.call(url: @url, cause: e)
+          error = @error_factory.call(url: @url, cause: e)
+          raise error, cause: error.cause
         end
 
         def write(message)
           @connection.write(message)
           @connection.flush
         rescue StandardError => e
-          raise @error_factory.call(url: @url, cause: e)
+          error = @error_factory.call(url: @url, cause: e)
+          raise error, cause: error.cause
         end
 
         def close(code: 1000, reason: "")
           @connection.close(code, reason)
         rescue StandardError => e
-          raise @error_factory.call(url: @url, cause: e)
+          error = @error_factory.call(url: @url, cause: e)
+          raise error, cause: error.cause
         end
 
         # @api private
@@ -193,7 +196,8 @@ module OpenAI
           framer.abort
           @aborted = true
         rescue StandardError => e
-          raise @error_factory.call(url: @url, cause: e)
+          error = @error_factory.call(url: @url, cause: e)
+          raise error, cause: error.cause
         end
 
         # @api private
@@ -294,7 +298,8 @@ module OpenAI
         raise if @error_class === e
         raise if e.equal?(block_error)
 
-        raise @error_factory.call(url: url, cause: e, http_status: handshake_status(e))
+        error = @error_factory.call(url: url, cause: e, http_status: handshake_status(e))
+        raise error, cause: error.cause
       end
 
       private def negotiate(client, endpoint, request_target:, headers:, timeout:)
@@ -357,7 +362,8 @@ module OpenAI
         message = @dependency_message ||
           "#{@product_name} WebSockets require the `async-websocket` gem. " \
             "Add `gem \"async-websocket\"` to your Gemfile."
-        raise @error_factory.call(url: url, message: message, cause: e)
+        error = @error_factory.call(url: url, message: message, cause: e)
+        raise error, cause: error.cause
       end
 
       private def authority(url, include_default_port: false)

--- a/test/openai/responses_websocket/errors_test.rb
+++ b/test/openai/responses_websocket/errors_test.rb
@@ -15,4 +15,24 @@ class OpenAI::Test::ResponsesWebSocketErrorsTest < Minitest::Test
     refute_includes(error.url.to_s, "fragment-secret")
     assert_nil(error.cause)
   end
+
+  def test_shared_transport_does_not_retain_a_suppressed_responses_cause
+    secret = "synthetic-private-close-reason"
+    connection = Object.new
+    connection.define_singleton_method(:read) { raise IOError, secret }
+    error_factory = lambda do |url:, **_options|
+      OpenAI::Errors::ResponsesConnectionError.new(url: url)
+    end
+
+    socket = OpenAI::WebSocket::AsyncWebSocketTransport::Socket.new(
+      connection,
+      url: URI("wss://example.com/v1/responses"),
+      error_factory: error_factory
+    )
+
+    error = assert_raises(OpenAI::Errors::ResponsesConnectionError) { socket.read }
+
+    assert_nil(error.cause)
+    refute_includes(error.full_message, secret)
+  end
 end


### PR DESCRIPTION
## Summary
- explicitly apply each WebSocket product error cause policy at shared raise boundaries
- prevent Responses errors from retaining suppressed implicit Ruby causes in full_message
- preserve Realtime cause propagation

## Validation
- direct trigger: Responses cause nil and full_message leak false
- Responses WebSocket errors: 2 runs, 11 assertions
- Responses WebSocket connection: 47 runs, 213 assertions
- Realtime async WebSocket transport: 13 runs, 63 assertions
- rake lint:rubocop: 2,910 files, no offenses
- security diff review: complete, no findings
- adversarial review: two consecutive clean rounds, four fresh-context reviewers

## Note
- Full rake test reached 1,715 runs / 14,947 assertions and failed only on the unrelated existing Safety Alerts fixture 404; the same failure reproduced in isolation.