### PR TITLE
fix: preserve unknown discriminated union values

### DIFF
--- a/lib/openai/helpers/streaming/chat_completion_stream.rb
+++ b/lib/openai/helpers/streaming/chat_completion_stream.rb
@@ -265,7 +265,10 @@ module OpenAI
 
           choice.delta.tool_calls.each do |tool_call_delta|
             tool_call = tool_calls_by_index[tool_call_delta.index]
-            next unless tool_call&.type == :function && tool_call_delta.function
+            unless tool_call.is_a?(OpenAI::Chat::ChatCompletionMessageFunctionToolCall) &&
+                tool_call_delta.function
+              next
+            end
 
             parsed_args = if tool_call.function.respond_to?(:parsed)
               tool_call.function.parsed
@@ -326,7 +329,7 @@ module OpenAI
 
           delta_tool_calls.each do |tool_call_chunk|
             tool_call_snapshot = tool_calls_by_index[tool_call_chunk.index]
-            next unless tool_call_snapshot&.type == :function
+            next unless tool_call_snapshot.is_a?(OpenAI::Chat::ChatCompletionMessageFunctionToolCall)
 
             input_tool = find_input_tool(tool_call_snapshot.function.name)
             next unless input_tool&.dig(:function, :strict)
@@ -751,7 +754,7 @@ module OpenAI
           @done_tool_calls.add(tool_index)
 
           tool_call = tool_calls_by_index[tool_index]
-          return nil unless tool_call&.type == :function
+          return nil unless tool_call.is_a?(OpenAI::Chat::ChatCompletionMessageFunctionToolCall)
 
           parsed_args = parse_function_tool_arguments(tool_call.function)
 

--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -46,10 +46,11 @@ module OpenAI
           text_parts = []
 
           response.output.each do |output|
-            next unless output.type == :message
+            next unless output.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
 
             output.content.each do |content|
-              next unless content.type == :output_text
+              next unless content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
+
               text_parts << content.text
             end
           end
@@ -100,39 +101,27 @@ module OpenAI
 
           case event
           when OpenAI::Models::Responses::ResponseTextDeltaEvent
+            snapshot = nil
             if @current_snapshot
               output = @current_snapshot.output[event.output_index]
-              assert_type(output, :message)
-
-              content = output.content[event.content_index]
-              assert_type(content, :output_text)
-              events_to_yield <<
-                OpenAI::Streaming::ResponseTextDeltaEvent.new(
-                  content_index: event.content_index,
-                  delta: event.delta,
-                  item_id: event.item_id,
-                  output_index: event.output_index,
-                  sequence_number: event.sequence_number,
-                  type: event.type,
-                  **event.to_h.slice(:logprobs),
-                  snapshot: content.text
-                )
-            else
-              # A server-directed resumed stream may begin after response.created.
-              # Without the omitted prefix, a snapshot would be incomplete and
-              # materializing every partial prefix would make streaming quadratic.
-              events_to_yield <<
-                OpenAI::Streaming::ResponseTextDeltaEvent.new(event.to_h.merge(snapshot: nil))
+              if output.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
+                content = output.content[event.content_index]
+                snapshot = content.text if content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
+              end
             end
+
+            # A server-directed resumed stream or an unknown future snapshot value
+            # has no complete prefix from which to build a truthful snapshot.
+            events_to_yield <<
+              OpenAI::Streaming::ResponseTextDeltaEvent.new(event.to_h.merge(snapshot: snapshot))
 
           when OpenAI::Models::Responses::ResponseTextDoneEvent
             text = if @current_snapshot
               output = @current_snapshot.output[event.output_index]
-              assert_type(output, :message)
-
-              content = output.content[event.content_index]
-              assert_type(content, :output_text)
-              content.text
+              if output.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
+                content = output.content[event.content_index]
+                content.text if content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
+              end
             else
               event.text
             end
@@ -152,26 +141,20 @@ module OpenAI
               )
 
           when OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
+            snapshot = nil
             if @current_snapshot
               output = @current_snapshot.output[event.output_index]
-              assert_type(output, :function_call)
-              events_to_yield <<
-                OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
-                  delta: event.delta,
-                  item_id: event.item_id,
-                  output_index: event.output_index,
-                  sequence_number: event.sequence_number,
-                  type: event.type,
-                  snapshot: output.arguments
-                )
-            else
-              # See the text-delta branch above: a partial server resume has no
-              # complete argument prefix from which to build a truthful snapshot.
-              events_to_yield <<
-                OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
-                  event.to_h.merge(snapshot: nil)
-                )
+              if output.is_a?(OpenAI::Models::Responses::ResponseFunctionToolCall)
+                snapshot = output.arguments
+              end
             end
+
+            # See the text-delta branch above: a partial server resume or an
+            # unknown future output item has no truthful accumulated prefix.
+            events_to_yield <<
+              OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent.new(
+                event.to_h.merge(snapshot: snapshot)
+              )
 
           when OpenAI::Models::Responses::ResponseCompletedEvent
             events_to_yield <<
@@ -213,16 +196,16 @@ module OpenAI
 
           when OpenAI::Models::Responses::ResponseContentPartAddedEvent
             output = current_snapshot.output[event.output_index]
-            if output && output.type == :message
+            if output.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
               output.content.push(isolated_value(event.part))
               current_snapshot.output[event.output_index] = output
             end
 
           when OpenAI::Models::Responses::ResponseTextDeltaEvent
             output = current_snapshot.output[event.output_index]
-            if output && output.type == :message
+            if output.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
               content = output.content[event.content_index]
-              if content && content.type == :output_text
+              if content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
                 content.text += event.delta
                 output.content[event.content_index] = content
                 current_snapshot.output[event.output_index] = output
@@ -231,7 +214,7 @@ module OpenAI
 
           when OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
             output = current_snapshot.output[event.output_index]
-            if output && output.type == :function_call
+            if output.is_a?(OpenAI::Models::Responses::ResponseFunctionToolCall)
               output.arguments = (output.arguments || "") + event.delta
               current_snapshot.output[event.output_index] = output
             end
@@ -253,12 +236,6 @@ module OpenAI
           return raw unless value.is_a?(OpenAI::Internal::Type::BaseModel)
 
           OpenAI::Internal::Type::Converter.coerce(value.class, raw)
-        end
-
-        def assert_type(object, expected_type)
-          return if object && object.type == expected_type
-          actual_type = object ? object.type : "nil"
-          raise "Invalid state: expected #{expected_type} but got #{actual_type}"
         end
 
         def parse_structured_text(text)

--- a/lib/openai/internal/type/union.rb
+++ b/lib/openai/internal/type/union.rb
@@ -100,8 +100,25 @@ module OpenAI
             return nil if key == OpenAI::Internal::OMIT
 
             key = key.to_sym if key.is_a?(String)
-            _, found = known_variants.find { |k,| k == key }
-            found&.call
+            _, found = known_variants.find { |k,| !k.nil? && k == key }
+            return found.call if found
+
+            known_variants.each do |variant_key, variant_fn|
+              next unless variant_key.nil?
+
+              target = variant_fn.call
+              next unless target.is_a?(Class) && target <= OpenAI::Internal::Type::BaseModel
+
+              field = target.known_fields[@discriminator]
+              next unless field
+
+              type = field.fetch(:type_fn).call
+              next unless OpenAI::Internal::Type::Enum === type
+
+              return target if type === key
+            end
+
+            OpenAI::Internal::Type::Unknown
           else
             nil
           end

--- a/lib/openai/models/responses/response.rb
+++ b/lib/openai/models/responses/response.rb
@@ -359,11 +359,12 @@ module OpenAI
           texts = []
 
           output.each do |item|
-            next unless item.type == :message
+            next unless item.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
+
             item.content.each do |content|
-              if content.type == :output_text
-                texts << content.text
-              end
+              next unless content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
+
+              texts << content.text
             end
           end
 

--- a/test/openai/helpers/chat_completion_stream_test.rb
+++ b/test/openai/helpers/chat_completion_stream_test.rb
@@ -49,6 +49,32 @@ class OpenAI::Test::ChatCompletionStreamTest < Minitest::Test
     end
   end
 
+  def test_stream_preserves_unknown_tool_calls_without_function_events
+    state = OpenAI::Helpers::Streaming::ChatCompletionStreamState.new
+    events = state.handle_chunk(
+      build_chunk(
+        choice_index: 0,
+        delta: {
+          role: :assistant,
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_future",
+              type: :future_tool,
+              future_tool: {opaque: true}
+            }
+          ]
+        },
+        finish_reason: :tool_calls
+      )
+    )
+
+    tool_call = state.get_final_completion.choices.first.message.tool_calls.first
+    assert_instance_of(Hash, tool_call)
+    assert_equal(:future_tool, tool_call[:type])
+    refute(events.any? { |event| event.type.to_s.start_with?("tool_calls.function.") })
+  end
+
   def test_interleaved_indices_remain_ordered_and_independent
     state = OpenAI::Helpers::Streaming::ChatCompletionStreamState.new
     state.handle_chunk(build_chunk(choice_index: 1, delta: {role: :assistant, content: "one"}))

--- a/test/openai/helpers/response_stream_isolation_test.rb
+++ b/test/openai/helpers/response_stream_isolation_test.rb
@@ -107,14 +107,101 @@ class OpenAI::Test::ResponseStreamIsolationTest < Minitest::Test
     refute_same(content_event.part.fetch(:opaque), snapshot_content.fetch(:opaque))
   end
 
+  def test_incremental_events_targeting_unknown_slots_have_nil_snapshots
+    state = state_after_created(
+      response(
+        output: [
+          message_item(content: [{type: "future_content"}, part]),
+          {type: "future_tool", id: "item_future"}
+        ]
+      )
+    )
+
+    unknown_text_delta = state
+      .handle_event(
+        coerce_event(
+          type: "response.output_text.delta",
+          sequence_number: 1,
+          item_id: "msg_synthetic",
+          output_index: 0,
+          content_index: 0,
+          delta: "future",
+          logprobs: []
+        )
+      )
+      .fetch(0)
+    unknown_text_done = state
+      .handle_event(
+        coerce_event(
+          type: "response.output_text.done",
+          sequence_number: 2,
+          item_id: "msg_synthetic",
+          output_index: 0,
+          content_index: 0,
+          text: "future",
+          logprobs: []
+        )
+      )
+      .fetch(0)
+    unknown_arguments_delta = state
+      .handle_event(
+        coerce_event(
+          type: "response.function_call_arguments.delta",
+          sequence_number: 3,
+          item_id: "item_future",
+          output_index: 1,
+          delta: "future"
+        )
+      )
+      .fetch(0)
+    known_text_delta = state
+      .handle_event(
+        coerce_event(
+          type: "response.output_text.delta",
+          sequence_number: 4,
+          item_id: "msg_synthetic",
+          output_index: 0,
+          content_index: 1,
+          delta: "known",
+          logprobs: []
+        )
+      )
+      .fetch(0)
+
+    assert_nil(unknown_text_delta.snapshot)
+    assert_nil(unknown_text_done.parsed)
+    assert_nil(unknown_arguments_delta.snapshot)
+    assert_equal("known", known_text_delta.snapshot)
+
+    structured_state = state_after_created(
+      response(output: [message_item(content: [{type: "future_content"}])]),
+      text_format: Hash
+    )
+    structured_done = structured_state
+      .handle_event(
+        coerce_event(
+          type: "response.output_text.done",
+          sequence_number: 5,
+          item_id: "msg_synthetic",
+          output_index: 0,
+          content_index: 0,
+          text: "not JSON",
+          logprobs: []
+        )
+      )
+      .fetch(0)
+
+    assert_nil(structured_done.parsed)
+  end
+
   private
 
   def coerce_event(event)
     OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::Responses::ResponseStreamEvent, event)
   end
 
-  def state_after_created(response)
-    state = OpenAI::Helpers::Streaming::ResponseStreamState.new(text_format: nil)
+  def state_after_created(response, text_format: nil)
+    state = OpenAI::Helpers::Streaming::ResponseStreamState.new(text_format: text_format)
     state.handle_event(coerce_event(type: "response.created", sequence_number: 0, response: response))
     state
   end

--- a/test/openai/internal/type/union_characterization_test.rb
+++ b/test/openai/internal/type/union_characterization_test.rb
@@ -59,22 +59,22 @@ class OpenAI::Test::UnionCharacterizationTest < Minitest::Test
     assert_equal({"preserved" => true}, unknown_field_body.dig("input", 0, "future_field"))
   end
 
-  def test_explicitly_unknown_stream_tags_retain_current_fallbacks
-    expected_selections = {
-      "responses_unknown_stream_event" => "OpenAI::Models::Responses::ResponseErrorEvent",
-      "responses_unknown_stream_event_symbols" => "OpenAI::Models::Responses::ResponseImageGenCallPartialImageEvent",
-      "beta_unknown_stream_event" => "OpenAI::Models::Beta::BetaResponseErrorEvent",
-      "beta_unknown_stream_event_symbols" => "OpenAI::Models::Beta::BetaResponseImageGenCallPartialImageEvent"
-    }
+  def test_explicitly_unknown_stream_tags_remain_raw
+    ids = %w[
+      responses_unknown_stream_event
+      responses_unknown_stream_event_symbols
+      beta_unknown_stream_event
+      beta_unknown_stream_event_symbols
+    ]
     observations = OpenAI::Test::UnionCharacterization.observe
 
-    expected_selections.each do |id, selected|
+    ids.each do |id|
       observation = observations.fetch(id)
 
       assert_equal("explicitly_unknown", observation.dig("discriminator_evidence", "state"), id)
       assert_empty(observation.fetch("exact_candidates"), id)
-      assert_equal([selected], observation.fetch("best_ranked_fallbacks"), id)
-      assert_equal(selected, observation.fetch("compatibility_selected"), id)
+      refute_empty(observation.fetch("best_ranked_fallbacks"), id)
+      assert_equal("Hash", observation.fetch("compatibility_selected"), id)
       assert_equal(
         {"type" => "future.unmodeled.event", "sequence_number" => 9},
         observation.fetch("serialized_body"),

--- a/test/openai/internal/type/union_state_test.rb
+++ b/test/openai/internal/type/union_state_test.rb
@@ -137,4 +137,82 @@ class OpenAI::Test::UnionStateTest < Minitest::Test
       assert_nil(state.fetch(:error))
     end
   end
+
+  def test_unknown_discriminators_preserve_the_original_value
+    inputs = [
+      {type: :unknown},
+      {type: "unknown"},
+      {type: nil},
+      {"type" => :unknown},
+      {"type" => "unknown"}
+    ]
+
+    inputs.each do |input|
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+
+      assert_same(input, OpenAI::Internal::Type::Converter.coerce(DiscriminatedUnion, input, state: state))
+      assert_equal({yes: 1, no: 0, maybe: 0}, state.fetch(:exactness))
+      assert_nil(state.fetch(:error))
+    end
+  end
+
+  def test_unknown_response_output_item_is_not_a_known_tool_call
+    input = {type: "attacker"}
+
+    output_item = OpenAI::Internal::Type::Converter.coerce(
+      OpenAI::Responses::ResponseOutputItem,
+      input
+    )
+
+    assert_same(input, output_item)
+    refute_instance_of(OpenAI::Responses::ResponseComputerToolCall, output_item)
+  end
+
+  def test_known_unkeyed_discriminator_variants_remain_typed
+    cases = [
+      [OpenAI::Responses::Tool, "web_search", OpenAI::Responses::WebSearchTool],
+      [OpenAI::Responses::Tool, "web_search_2025_08_26", OpenAI::Responses::WebSearchTool],
+      [OpenAI::Responses::Tool, "web_search_preview", OpenAI::Responses::WebSearchPreviewTool],
+      [
+        OpenAI::Responses::Tool,
+        "web_search_preview_2025_03_11",
+        OpenAI::Responses::WebSearchPreviewTool
+      ],
+      [OpenAI::Beta::BetaTool, "web_search", OpenAI::Beta::BetaWebSearchTool],
+      [OpenAI::Beta::BetaTool, "web_search_2025_08_26", OpenAI::Beta::BetaWebSearchTool],
+      [OpenAI::Beta::BetaTool, "web_search_preview", OpenAI::Beta::BetaWebSearchPreviewTool],
+      [
+        OpenAI::Beta::BetaTool,
+        "web_search_preview_2025_03_11",
+        OpenAI::Beta::BetaWebSearchPreviewTool
+      ]
+    ]
+
+    cases.each do |union, type, expected|
+      tool = OpenAI::Internal::Type::Converter.coerce(union, {type: type})
+
+      assert_instance_of(expected, tool)
+    end
+  end
+
+  def test_known_unkeyed_discriminator_ignores_unrelated_inexact_fields
+    cases = [
+      [
+        OpenAI::Responses::Tool,
+        {type: "web_search", external_web_access: "false"},
+        OpenAI::Responses::WebSearchTool
+      ],
+      [
+        OpenAI::Beta::BetaTool,
+        {type: "web_search_preview", search_content_types: ["future"]},
+        OpenAI::Beta::BetaWebSearchPreviewTool
+      ]
+    ]
+
+    cases.each do |union, input, expected|
+      tool = OpenAI::Internal::Type::Converter.coerce(union, input)
+
+      assert_instance_of(expected, tool)
+    end
+  end
 end

--- a/test/openai/unknown_response_stream_event_test.rb
+++ b/test/openai/unknown_response_stream_event_test.rb
@@ -255,6 +255,28 @@ class OpenAI::Test::UnknownResponseStreamEventTest < Minitest::Test
     stream&.close
   end
 
+  def test_create_output_text_skips_unknown_output_items_and_content
+    stub_request(:post, "http://localhost/responses").to_return_json(body: response_with_unknowns)
+
+    response = @client.responses.create(input: "hello", model: "gpt-4o")
+
+    assert_equal("hello", response.output_text)
+  end
+
+  def test_stream_output_text_skips_unknown_output_items_and_content
+    stub_stream(
+      :post,
+      "/responses",
+      events: [lifecycle_event("response.created", 1), completed_event_with_unknowns]
+    )
+
+    stream = @client.responses.stream(input: "hello", model: "gpt-4o")
+
+    assert_equal("hello", stream.get_output_text)
+  ensure
+    stream&.close
+  end
+
   private
 
   def assert_unknown_event(event, union:, sequence_number: 9)
@@ -279,6 +301,14 @@ class OpenAI::Test::UnknownResponseStreamEventTest < Minitest::Test
 
   def completed_event(sequence_number) = lifecycle_event("response.completed", sequence_number)
 
+  def completed_event_with_unknowns
+    {
+      type: "response.completed",
+      sequence_number: 2,
+      response: response_with_unknowns
+    }
+  end
+
   def lifecycle_event(type, sequence_number)
     status = type == "response.created" ? "in_progress" : "completed"
 
@@ -294,6 +324,26 @@ class OpenAI::Test::UnknownResponseStreamEventTest < Minitest::Test
         usage: nil,
         metadata: nil
       }
+    }
+  end
+
+  def response_with_unknowns
+    {
+      id: "resp_unknown",
+      object: "response",
+      output: [
+        {type: "future_tool"},
+        {
+          id: "msg_unknown",
+          type: "message",
+          status: "completed",
+          role: "assistant",
+          content: [
+            {type: "future_content"},
+            {type: "output_text", text: "hello", annotations: [], logprobs: []}
+          ]
+        }
+      ]
     }
   end
 


### PR DESCRIPTION
## Summary
- preserve explicit unregistered discriminators as raw values instead of structurally coercing them into known union variants
- retain existing known-discriminator dispatch and missing-discriminator shorthand matching
- add focused regression coverage for symbol/string discriminator forms, the reported Responses tool-call misclassification, and unknown stream-event serialization

## Validation
- focused tests: 27 runs, 206 assertions, 0 failures
- compatibility probe: unknown tags stay Hash; known computer_call stays ResponseComputerToolCall; absent request tag keeps shorthand conversion
- bundle exec rake lint: passed (RuboCop, directive validation, Sorbet, RBS)
- scoped Codex Security diff review: complete, 0 findings
- adversarial review: two consecutive clean rounds, two fresh independent reviewers per round

## Full suite note
- bundle exec rake test reached 1,716 runs / 14,961 assertions with one unrelated existing fixture-server 404 in OpenAI::Test::Resources::Safety::AlertsTest#test_retrieve; that failure reproduces when run alone.