### PR TITLE
fix: stream container file uploads as multipart

### DIFF
--- a/lib/openai/resources/containers/files.rb
+++ b/lib/openai/resources/containers/files.rb
@@ -37,6 +37,7 @@ module OpenAI
           @client.request(
             method: :post,
             path: ["containers/%1$s/files", container_id],
+            headers: parsed[:file].nil? ? nil : {"content-type" => "multipart/form-data"},
             body: parsed,
             model: OpenAI::Models::Containers::FileCreateResponse,
             security: {bearer_auth: true},

--- a/test/openai/resources/containers/files_test.rb
+++ b/test/openai/resources/containers/files_test.rb
@@ -122,6 +122,7 @@ class OpenAI::Test::Resources::Containers::FilesTest < OpenAI::Test::ResourceTes
       request = value
       true
     end
+
     client = OpenAI::Client.new(
       api_key: "test-key",
       base_url: "http://example.test/v1",

--- a/test/openai/resources/containers/files_test.rb
+++ b/test/openai/resources/containers/files_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../../test_helper"
+require "tempfile"
 
 class OpenAI::Test::Resources::Containers::FilesTest < OpenAI::Test::ResourceTest
   def test_create
@@ -21,6 +22,29 @@ class OpenAI::Test::Resources::Containers::FilesTest < OpenAI::Test::ResourceTes
           source: String
         }
     end
+  end
+
+  def test_create_with_file_streams_multipart_content
+    Tempfile.create(["container-file-", ".txt"]) do |file|
+      file.write("container contents")
+      file.flush
+
+      request = create_request(file: Pathname(file.path))
+      body = request.body.to_a.join
+
+      assert_match(%r{\Amultipart/form-data; boundary=}, request.headers.fetch("content-type"))
+      refute_instance_of(String, request.body)
+      assert_includes(body, "name=\"file\"; filename=\"#{File.basename(file.path)}\"")
+      assert_includes(body, "container contents")
+      refute_includes(body, file.path)
+    end
+  end
+
+  def test_create_with_file_id_preserves_json_request
+    request = create_request(file: nil, file_id: "file_123")
+
+    assert_equal("application/json", request.headers.fetch("content-type"))
+    assert_equal(JSON.generate(file: nil, file_id: "file_123"), request.body)
   end
 
   def test_retrieve_required_params
@@ -76,5 +100,39 @@ class OpenAI::Test::Resources::Containers::FilesTest < OpenAI::Test::ResourceTes
     assert_pattern do
       response => nil
     end
+  end
+
+  private def create_request(params)
+    response = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: JSON.generate(
+        id: "cfile_123",
+        bytes: 18,
+        container_id: "container_id",
+        created_at: 1,
+        object: "container.file",
+        path: "/mnt/data/file.txt",
+        source: "user"
+      )
+    )
+    transport = Minitest::Mock.new(OpenAI::HTTPClient.new)
+    request = nil
+    transport.expect(:execute, response) do |value|
+      request = value
+      true
+    end
+    client = OpenAI::Client.new(
+      api_key: "test-key",
+      base_url: "http://example.test/v1",
+      http_client: transport,
+      max_retries: 0
+    )
+
+    result = client.containers.files.create("container_id", params)
+
+    assert_instance_of(OpenAI::Models::Containers::FileCreateResponse, result)
+    assert_mock(transport)
+    request
   end
 end


### PR DESCRIPTION
## Summary
- route non-nil container file uploads through the existing streaming multipart encoder
- preserve JSON requests for file_id, including callers forwarding file: nil
- add focused public-entrypoint regressions for multipart bytes/path handling and JSON compatibility

## Validation
The finding is real. containers.files.create forwarded file inputs with the default application/json content type, so request encoding JSON-generated the body instead of sending multipart file bytes. The container-files API accepts raw file content as multipart and file_id as JSON.

## Tests
- ruby -c lib/openai/resources/containers/files.rb
- ruby -c test/openai/resources/containers/files_test.rb
- ruby -Itest test/openai/resources/containers/files_test.rb
- ruby -Itest test/openai/internal/multipart_content_type_test.rb
- ruby -Itest test/openai/file_part_test.rb
- ruby -Itest test/openai/internal/util_test.rb
- rubocop --ignore-unrecognized-cops lib/openai/resources/containers/files.rb test/openai/resources/containers/files_test.rb
- git diff --check

The exact locked RuboCop bundle could not activate because the pinned syntax_tree-rbs Git revision is no longer available; the installed fallback RuboCop reported no offenses.

## Security review
The file branch now reaches the existing multipart encoder, preserving basename reduction, multipart header escaping, content-type validation, configured-origin enforcement, and streaming behavior. The file_id JSON branch remains unchanged.