### PR TITLE
docs: clarify Realtime transcription event boundary

### DIFF
--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -126,8 +126,21 @@ Important boundaries:
 - Authenticated Realtime handshakes are a transport boundary distinct from
   event parsing. Bearer credentials, caller-selected WebSocket destinations,
   TLS, proxy credentials, and traces must remain bound to their intended
-  origin and diagnostic audience
-  (`lib/openai/helpers/realtime/client_extension.rb:167-280`,
+  origin and diagnostic audience. Bearer credentials, including ephemeral
+  client secrets passed to client apps, authenticate the handshake before any
+  typed event is sent; post-handshake transcription `session.update` events
+  carry configuration rather than a client secret. The legacy generated
+  `TranscriptionSessionUpdatedEvent` model requires a `client_secret` even
+  though its own documentation says WebSocket updates omit it, but that model
+  is not in the helper's active server-event union: the parser treats its
+  `transcription_session.updated` discriminator as unknown, while current
+  transcription updates use `session.updated`
+  (`lib/openai/helpers/websocket/client_request.rb:89-113`,
+  `lib/openai/helpers/realtime/connection_resources.rb:25-31`,
+  `lib/openai/resources/realtime/client_secrets.rb:10-45`,
+  `lib/openai/models/realtime/transcription_session_updated_event.rb:13-49`,
+  `lib/openai/models/realtime/realtime_server_event.rb:192-199`,
+  `lib/openai/helpers/realtime/connection.rb:32-49`,
   `lib/openai/helpers/realtime/transports/async_websocket.rb:185-224`,
   `lib/openai/helpers/realtime/transports/async_websocket.rb:294-378`).
 - Multipart upload serialization is a file-path and header-integrity boundary.


### PR DESCRIPTION
## Summary
- document the exact Realtime trust boundary for the informational client-secret finding
- clarify that the legacy transcription_session.updated model is outside the active WebSocket server-event union
- keep the disposition narrow without changing runtime behavior or public APIs

## Validation
- finding disposition: non-impacting, high confidence
- active helper parses session.updated; transcription_session.updated becomes UnknownServerEvent before the legacy model can require client_secret
- WebSocket authentication occurs at handshake time; post-handshake transcription updates carry configuration

## Verification
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/realtime/connection_test.rb
- mise exec ruby@4.0.6 -- bundle exec rake build:docs
- git diff --check
- adversarial review: 3 rounds; round 1 correction addressed; rounds 2 and 3 clean

## Scope
- docs-only canonical security-model clarification
- no tracking records, dependency changes, runtime changes, or public API changes