### PR TITLE
fix: avoid retrying ambiguous non-idempotent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,15 @@ for more information.
 
 Certain errors will be automatically retried 2 times by default, with a short exponential backoff.
 
-Connection errors (for example, due to a network connectivity problem), 408 Request Timeout, 409 Conflict, 429 Rate Limit, >=500 Internal errors, and timeouts will all be retried by default.
+Requests are automatically retried only when their bodies are replayable. For
+those requests, after transport execution begins, connection errors (for
+example, due to a network connectivity problem) and timeouts are retried by
+default only for idempotent HTTP methods or requests carrying a non-empty
+`Idempotency-Key` header. Failures while preparing a request or its
+authentication retain the configured retry behavior because no API request has
+been dispatched.
+408 Request Timeout, 409 Conflict, 429 Rate Limit, and >=500 Internal errors
+are retried by default regardless of the HTTP method.
 
 You can use the `max_retries` option to configure or disable this:
 
@@ -1082,7 +1090,10 @@ openai.chat.completions.create(
 
 On timeout, `OpenAI::Errors::APITimeoutError` is raised.
 
-Note that requests that time out are retried by default.
+After transport execution begins, requests with replayable bodies that time out
+are retried by default only for idempotent HTTP methods or requests carrying a
+non-empty `Idempotency-Key` header. Preparation and authentication timeouts
+before dispatch retain the configured retry behavior.
 
 ## Advanced concepts
 

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -499,6 +499,20 @@ module OpenAI
           self.class.request_body_replayable?(request[:body])
         end
 
+        # A connection failure after dispatch has an unknown outcome: the peer
+        # may have committed the request before the response was lost. Retrying
+        # is only safe when the HTTP method itself is idempotent or the caller
+        # supplied a stable idempotency key.
+        #
+        # @api private
+        private def request_retryable_after_connection_error?(request)
+          return true if Net::HTTP::IDEMPOTENT_METHODS_.include?(request.fetch(:method).to_s.upcase)
+
+          request.fetch(:headers).any? do |name, value|
+            name.to_s.casecmp?("idempotency-key") && !value.to_s.empty?
+          end
+        end
+
         # @api private
         #
         # @param headers [Hash{String=>String}]
@@ -593,6 +607,7 @@ module OpenAI
           authorized_url = url.class.new(*URI.split(url.to_s))
           prepared_request = request
           trusted_origin = request[:redirect_trusted_origin]
+          request_dispatched = false
 
           begin
             encoded_headers, encoded_body = OpenAI::Internal::Util.encode_content(
@@ -654,6 +669,7 @@ module OpenAI
               timeout: timeout
             )
             log_context.request_started(input, redirect_count: redirect_count)
+            request_dispatched = true
             http_response = @requester.execute(input)
             unless http_response.is_a?(OpenAI::HTTPClient::Response)
               raise TypeError, "`http_client#execute` must return an OpenAI::HTTPClient::Response"
@@ -689,6 +705,12 @@ module OpenAI
             )
           end
 
+          if status.is_a?(OpenAI::Errors::APIConnectionError) &&
+              (retry_count >= max_retries ||
+                (request_dispatched && !request_retryable_after_connection_error?(prepared_request)))
+            raise status
+          end
+
           case status
           in ..299
             http_response
@@ -721,8 +743,6 @@ module OpenAI
               send_retry_header: send_retry_header,
               &context_provider
             )
-          in OpenAI::Errors::APIConnectionError if retry_count >= max_retries
-            raise status
           in (400..) | OpenAI::Errors::APIConnectionError
             self.class.reap_connection!(status, stream: stream)
 

--- a/rbi/openai/internal/transport/base_client.rbi
+++ b/rbi/openai/internal/transport/base_client.rbi
@@ -268,6 +268,16 @@ module OpenAI
         # @api private
         sig do
           params(
+            request: OpenAI::Internal::Transport::BaseClient::RequestInput
+          )
+            .returns(T::Boolean)
+        end
+        private def request_retryable_after_connection_error?(request)
+        end
+
+        # @api private
+        sig do
+          params(
             headers: T::Hash[String, String],
             retry_count: Integer
           )

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -126,6 +126,10 @@ module OpenAI
           OpenAI::Internal::Transport::BaseClient::request_input request
         ) -> bool
 
+        private def request_retryable_after_connection_error?: (
+          OpenAI::Internal::Transport::BaseClient::request_input request
+        ) -> bool
+
         private def retry_delay: (
           ::Hash[String, String] headers,
           retry_count: Integer

--- a/test/openai/auth/workload_identity_test.rb
+++ b/test/openai/auth/workload_identity_test.rb
@@ -746,6 +746,40 @@ class WorkloadIdentityTest < Minitest::Test
     refute_nil(client.workload_identity_auth)
   end
 
+  def test_workload_identity_retries_a_pre_dispatch_timeout_for_a_post
+    File.write(@token_path, "k8s-jwt-token")
+    provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new(
+      token_path: @token_path
+    )
+    config = OpenAI::Auth::WorkloadIdentity.new(
+      identity_provider_id: "idp-123",
+      service_account_id: "sa-456",
+      provider: provider
+    )
+
+    stub_request(:post, "https://auth.openai.com/oauth/token")
+      .to_timeout
+      .then
+      .to_return(status: 200, body: JSON.generate({"access_token" => "token", "expires_in" => 3600}))
+    stub_request(:post, "http://localhost/probe")
+      .to_return(status: 200, body: JSON.generate({"ok" => true}), headers: {"Content-Type" => "application/json"})
+
+    client = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: nil,
+      workload_identity: config,
+      max_retries: 1,
+      initial_retry_delay: 0,
+      max_retry_delay: 0
+    )
+
+    response = client.request(method: :post, path: "probe", body: {value: "payload"})
+
+    assert_equal(true, response[:ok])
+    assert_requested(:post, "https://auth.openai.com/oauth/token", times: 2)
+    assert_requested(:post, "http://localhost/probe", times: 1)
+  end
+
   def test_workload_identity_mutually_exclusive_with_api_key
     provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
     config = OpenAI::Auth::WorkloadIdentity.new(

--- a/test/openai/http_client_test.rb
+++ b/test/openai/http_client_test.rb
@@ -461,6 +461,65 @@ class HTTPClientTest < Minitest::Test
     assert_equal(2, attempts)
   end
 
+  def test_sdk_does_not_retry_connection_errors_for_non_idempotent_requests
+    [OpenAI::Errors::APIConnectionError, OpenAI::Errors::APITimeoutError].each do |error_class|
+      attempts = 0
+      effects = 0
+      http_client = StubHTTPClient.new do |request|
+        attempts += 1
+        effects += 1
+        raise error_class.new(url: request.url)
+      end
+
+      client = OpenAI::Client.new(
+        api_key: "test-key",
+        http_client: http_client,
+        max_retries: 1,
+        initial_retry_delay: 0,
+        max_retry_delay: 0
+      )
+
+      assert_raises(error_class) do
+        client.request(method: :post, path: "probe", body: {value: "payload"})
+      end
+
+      assert_equal(1, attempts)
+      assert_equal(1, effects)
+    end
+  end
+
+  def test_sdk_retries_connection_errors_for_requests_with_an_idempotency_key
+    attempts = 0
+    http_client = StubHTTPClient.new do |request|
+      attempts += 1
+      raise OpenAI::Errors::APIConnectionError.new(url: request.url) if attempts == 1
+
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: "{\"ok\":true}"
+      )
+    end
+
+    client = OpenAI::Client.new(
+      api_key: "test-key",
+      http_client: http_client,
+      max_retries: 1,
+      initial_retry_delay: 0,
+      max_retry_delay: 0
+    )
+
+    response = client.request(
+      method: :post,
+      path: "probe",
+      headers: {"Idempotency-Key" => "stable-operation"},
+      body: {value: "payload"}
+    )
+
+    assert_equal(true, response[:ok])
+    assert_equal(2, attempts)
+  end
+
   def test_sdk_follows_redirects_from_a_custom_http_client
     requests = []
     http_client = StubHTTPClient.new do |request|


### PR DESCRIPTION
## Summary
- stop automatic connection and timeout retries after non-idempotent HTTP methods
- preserve connection retries for idempotent methods and response-driven retries for replayable requests
- add deterministic regression coverage plus aligned README, RBI, and RBS declarations

## Security validation
A public client.request POST with a replayable body can reach the shared retry loop after a transport raises APIConnectionError. A deterministic probe modeled a committed first attempt followed by a lost response and observed two effects before the fix. The regression now verifies both APIConnectionError and APITimeoutError produce exactly one attempt and one effect for POST.

## Tests
- /Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin/ruby -S bundle exec /Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin/ruby -Itest test/openai/http_client_test.rb
- /Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin/ruby -S bundle exec /Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin/rake test
- /Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin/ruby -S bundle exec /Users/jbeckwith/.local/share/mise/installs/ruby/4.0.6/bin/rake lint

## Review
- completed six fresh-context adversarial rounds
- rounds 5 and 6 were consecutively clean