### PR TITLE
fix: preserve hash-form type metadata

### DIFF
--- a/lib/openai/internal/type/converter.rb
+++ b/lib/openai/internal/type/converter.rb
@@ -122,7 +122,10 @@ module OpenAI
           #
           # @return [Hash{Symbol=>Object}]
           def meta_info(type_info, spec)
-            [spec, type_info].grep(Hash).first.to_h.except(:const, :enum, :union, :nil?)
+            [type_info, spec]
+              .grep(Hash)
+              .reduce({}, :merge)
+              .except(:const, :enum, :union, :nil?)
           end
 
           # @api private

--- a/test/openai/helpers/structured_output_test.rb
+++ b/test/openai/helpers/structured_output_test.rb
@@ -36,6 +36,10 @@ class OpenAI::Test::StructuredOutputTest < Minitest::Test
     required :type, const: :m3, doc: "Model M3"
   end
 
+  class HashFormMetadata < OpenAI::BaseModel
+    required :value, enum: -> { String }, pattern: "^[a-z]+$", doc: "Lowercase value"
+  end
+
   class NestedParticipant < OpenAI::BaseModel
     required :name, String
   end
@@ -77,6 +81,13 @@ class OpenAI::Test::StructuredOutputTest < Minitest::Test
         optional(:name, String)
       end
     end
+  end
+
+  def test_hash_form_declaration_metadata_reaches_schema
+    assert_equal(
+      {type: "string", pattern: "^[a-z]+$", description: "Lowercase value"},
+      HashFormMetadata.to_json_schema.dig(:properties, :value)
+    )
   end
 
   def test_direct_structured_output_models_preserve_nested_raw_values
@@ -152,13 +163,13 @@ class OpenAI::Test::StructuredOutputTest < Minitest::Test
         anyOf: [
           {
             type: "object",
-            properties: {type: {const: "m2"}},
+            properties: {type: {const: "m2", description: "Model M2"}},
             required: %w[type],
             additionalProperties: false
           },
           {
             type: "object",
-            properties: {type: {const: "m3"}},
+            properties: {type: {const: "m3", description: "Model M3"}},
             required: %w[type],
             additionalProperties: false
           }

--- a/test/openai/internal/type/base_model_test.rb
+++ b/test/openai/internal/type/base_model_test.rb
@@ -810,10 +810,20 @@ end
 class OpenAI::Test::MetaInfoTest < Minitest::Test
   A1 = OpenAI::Internal::Type::ArrayOf[Integer, nil?: true, doc: "dog"]
   H1 = OpenAI::Internal::Type::HashOf[-> { String }, nil?: true, doc: "dawg"]
+  A2 = OpenAI::Internal::Type::ArrayOf[enum: -> { Integer }, doc: "hash dog"]
+  H2 = OpenAI::Internal::Type::HashOf[enum: -> { String }, doc: "hash dawg"]
 
   class M1 < OpenAI::Internal::Type::BaseModel
     required :a, Integer, doc: "dog"
     optional :b, -> { String }, nil?: true, doc: "dawg"
+  end
+
+  class M2 < OpenAI::Internal::Type::BaseModel
+    required :a, enum: -> { Integer }, doc: "hash dog"
+  end
+
+  class M3 < OpenAI::Internal::Type::BaseModel
+    required :a, {enum: -> { Integer }, doc: "hash dog"}, doc: "spec dog"
   end
 
   module U1
@@ -828,10 +838,14 @@ class OpenAI::Test::MetaInfoTest < Minitest::Test
     m2 = H1.instance_variable_get(:@meta)
     assert_equal({doc: "dog"}, m1)
     assert_equal({doc: "dawg"}, m2)
+    assert_equal({doc: "hash dog"}, A2.instance_variable_get(:@meta))
+    assert_equal({doc: "hash dawg"}, H2.instance_variable_get(:@meta))
 
     ma, mb = M1.fields.fetch_values(:a, :b)
     assert_equal({doc: "dog"}, ma.fetch(:meta))
     assert_equal({doc: "dawg"}, mb.fetch(:meta))
+    assert_equal({doc: "hash dog"}, M2.fields.fetch(:a).fetch(:meta))
+    assert_equal({doc: "spec dog"}, M3.fields.fetch(:a).fetch(:meta))
 
     ua, ub = U1.send(:known_variants).map(&:last)
     assert_equal({doc: "dog"}, ua)


### PR DESCRIPTION
## Summary
- preserve metadata from hash-form type declarations while retaining separate-spec precedence
- keep structural type keys excluded from metadata
- add regressions for BaseModel, ArrayOf, HashOf, precedence, and public structured-output JSON Schema constraints

## Validation
- ruby -Ilib -Itest test/openai/internal/type/base_model_test.rb
- ruby -Ilib -Itest test/openai/helpers/structured_output_test.rb
- ruby -c on changed Ruby files
- git diff --check

## Security
Hash-form metadata can include JSON Schema constraints such as pattern. Before this fix, the empty default spec won over hash-form metadata, weakening the schema sent for lower-trust model output. The shared collector now preserves those constraints without changing structural type selection.