### PR TITLE
fix: correct Responses stream RBS contract

### DIFF
--- a/sig/openai/helpers/streaming/response_stream.rbs
+++ b/sig/openai/helpers/streaming/response_stream.rbs
@@ -1,10 +1,33 @@
 module OpenAI
   module Helpers
     module Streaming
+      type response_stream_event =
+        OpenAI::Helpers::Streaming::ResponseTextDeltaEvent
+        | OpenAI::Helpers::Streaming::ResponseTextDoneEvent
+        | OpenAI::Helpers::Streaming::ResponseFunctionCallArgumentsDeltaEvent
+        | OpenAI::Helpers::Streaming::ResponseCompletedEvent
+        | OpenAI::Models::Responses::response_stream_event
+        | OpenAI::Helpers::Streaming::UnknownStreamEvent
+
+      class ResponseTextDeltaEvent < OpenAI::Models::Responses::ResponseTextDeltaEvent
+        def snapshot: -> String?
+      end
+
+      class ResponseTextDoneEvent < OpenAI::Models::Responses::ResponseTextDoneEvent
+        def parsed: -> untyped
+      end
+
+      class ResponseFunctionCallArgumentsDeltaEvent < OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
+        def snapshot: -> String?
+      end
+
+      class ResponseCompletedEvent < OpenAI::Models::Responses::ResponseCompletedEvent
+        def response: -> OpenAI::Responses::Response
+      end
+
       class ResponseStream
         include OpenAI::Internal::Type::BaseStream[OpenAI::Models::Responses::response_stream_event
-        | OpenAI::Helpers::Streaming::UnknownStreamEvent, OpenAI::Models::Responses::response_stream_event
-        | OpenAI::Helpers::Streaming::UnknownStreamEvent]
+        | OpenAI::Helpers::Streaming::UnknownStreamEvent, OpenAI::Helpers::Streaming::response_stream_event]
 
         # @api private
         def initialize: (

--- a/sig/openai/helpers/streaming/response_stream.rbs
+++ b/sig/openai/helpers/streaming/response_stream.rbs
@@ -1,0 +1,24 @@
+module OpenAI
+  module Helpers
+    module Streaming
+      class ResponseStream
+        include OpenAI::Internal::Type::BaseStream[OpenAI::Models::Responses::response_stream_event
+        | OpenAI::Helpers::Streaming::UnknownStreamEvent, OpenAI::Models::Responses::response_stream_event
+        | OpenAI::Helpers::Streaming::UnknownStreamEvent]
+
+        # @api private
+        def initialize: (
+          raw_stream: OpenAI::Internal::Stream[OpenAI::Models::Responses::response_stream_event
+          | OpenAI::Helpers::Streaming::UnknownStreamEvent],
+          ?text_format: untyped,
+          ?starting_after: Integer?
+        ) -> void
+
+        def until_done: -> self
+        def text: -> Enumerator[String]
+        def get_final_response: -> OpenAI::Responses::Response
+        def get_output_text: -> String
+      end
+    end
+  end
+end

--- a/sig/openai/helpers/streaming/response_stream.rbs
+++ b/sig/openai/helpers/streaming/response_stream.rbs
@@ -6,8 +6,64 @@ module OpenAI
         | OpenAI::Helpers::Streaming::ResponseTextDoneEvent
         | OpenAI::Helpers::Streaming::ResponseFunctionCallArgumentsDeltaEvent
         | OpenAI::Helpers::Streaming::ResponseCompletedEvent
-        | OpenAI::Models::Responses::response_stream_event
+        | OpenAI::Helpers::Streaming::response_stream_passthrough_event
         | OpenAI::Helpers::Streaming::UnknownStreamEvent
+
+      type response_stream_passthrough_event =
+        OpenAI::Responses::ResponseAudioDeltaEvent
+        | OpenAI::Responses::ResponseAudioDoneEvent
+        | OpenAI::Responses::ResponseAudioTranscriptDeltaEvent
+        | OpenAI::Responses::ResponseAudioTranscriptDoneEvent
+        | OpenAI::Responses::ResponseCodeInterpreterCallCodeDeltaEvent
+        | OpenAI::Responses::ResponseCodeInterpreterCallCodeDoneEvent
+        | OpenAI::Responses::ResponseCodeInterpreterCallCompletedEvent
+        | OpenAI::Responses::ResponseCodeInterpreterCallInProgressEvent
+        | OpenAI::Responses::ResponseCodeInterpreterCallInterpretingEvent
+        | OpenAI::Responses::ResponseContentPartAddedEvent
+        | OpenAI::Responses::ResponseContentPartDoneEvent
+        | OpenAI::Responses::ResponseCreatedEvent
+        | OpenAI::Responses::ResponseErrorEvent
+        | OpenAI::Responses::ResponseFileSearchCallCompletedEvent
+        | OpenAI::Responses::ResponseFileSearchCallInProgressEvent
+        | OpenAI::Responses::ResponseFileSearchCallSearchingEvent
+        | OpenAI::Responses::ResponseFunctionCallArgumentsDoneEvent
+        | OpenAI::Responses::ResponseShellCallCommandAddedEvent
+        | OpenAI::Responses::ResponseShellCallCommandDeltaEvent
+        | OpenAI::Responses::ResponseShellCallCommandDoneEvent
+        | OpenAI::Responses::ResponseShellCallOutputContentDeltaEvent
+        | OpenAI::Responses::ResponseShellCallOutputContentDoneEvent
+        | OpenAI::Responses::ResponseInProgressEvent
+        | OpenAI::Responses::ResponseFailedEvent
+        | OpenAI::Responses::ResponseIncompleteEvent
+        | OpenAI::Responses::ResponseOutputItemAddedEvent
+        | OpenAI::Responses::ResponseOutputItemDoneEvent
+        | OpenAI::Responses::ResponseReasoningSummaryPartAddedEvent
+        | OpenAI::Responses::ResponseReasoningSummaryPartDoneEvent
+        | OpenAI::Responses::ResponseReasoningSummaryTextDeltaEvent
+        | OpenAI::Responses::ResponseReasoningSummaryTextDoneEvent
+        | OpenAI::Responses::ResponseReasoningTextDeltaEvent
+        | OpenAI::Responses::ResponseReasoningTextDoneEvent
+        | OpenAI::Responses::ResponseRefusalDeltaEvent
+        | OpenAI::Responses::ResponseRefusalDoneEvent
+        | OpenAI::Responses::ResponseWebSearchCallCompletedEvent
+        | OpenAI::Responses::ResponseWebSearchCallInProgressEvent
+        | OpenAI::Responses::ResponseWebSearchCallSearchingEvent
+        | OpenAI::Responses::ResponseImageGenCallCompletedEvent
+        | OpenAI::Responses::ResponseImageGenCallGeneratingEvent
+        | OpenAI::Responses::ResponseImageGenCallInProgressEvent
+        | OpenAI::Responses::ResponseImageGenCallPartialImageEvent
+        | OpenAI::Responses::ResponseMcpCallArgumentsDeltaEvent
+        | OpenAI::Responses::ResponseMcpCallArgumentsDoneEvent
+        | OpenAI::Responses::ResponseMcpCallCompletedEvent
+        | OpenAI::Responses::ResponseMcpCallFailedEvent
+        | OpenAI::Responses::ResponseMcpCallInProgressEvent
+        | OpenAI::Responses::ResponseMcpListToolsCompletedEvent
+        | OpenAI::Responses::ResponseMcpListToolsFailedEvent
+        | OpenAI::Responses::ResponseMcpListToolsInProgressEvent
+        | OpenAI::Responses::ResponseOutputTextAnnotationAddedEvent
+        | OpenAI::Responses::ResponseQueuedEvent
+        | OpenAI::Responses::ResponseCustomToolCallInputDeltaEvent
+        | OpenAI::Responses::ResponseCustomToolCallInputDoneEvent
 
       class ResponseTextDeltaEvent < OpenAI::Models::Responses::ResponseTextDeltaEvent
         def snapshot: -> String?

--- a/sig/openai/resources/responses.rbs
+++ b/sig/openai/resources/responses.rbs
@@ -102,8 +102,7 @@ module OpenAI
         ?truncation: OpenAI::Models::Responses::ResponseCreateParams::truncation?,
         ?user: String,
         ?request_options: OpenAI::request_opts
-      ) -> OpenAI::Internal::Stream[(OpenAI::Models::Responses::response_stream_event
-      | OpenAI::Streaming::UnknownStreamEvent)]
+      ) -> OpenAI::Streaming::ResponseStream
 
       def retrieve: (
         String response_id,

--- a/sig/openai/streaming.rbs
+++ b/sig/openai/streaming.rbs
@@ -1,5 +1,7 @@
 module OpenAI
   module Streaming
+    class ResponseStream = Helpers::Streaming::ResponseStream
+
     class UnknownStreamEvent = Helpers::Streaming::UnknownStreamEvent
   end
 end

--- a/sig/openai/streaming.rbs
+++ b/sig/openai/streaming.rbs
@@ -1,5 +1,13 @@
 module OpenAI
   module Streaming
+    class ResponseTextDeltaEvent = Helpers::Streaming::ResponseTextDeltaEvent
+
+    class ResponseTextDoneEvent = Helpers::Streaming::ResponseTextDoneEvent
+
+    class ResponseFunctionCallArgumentsDeltaEvent = Helpers::Streaming::ResponseFunctionCallArgumentsDeltaEvent
+
+    class ResponseCompletedEvent = Helpers::Streaming::ResponseCompletedEvent
+
     class ResponseStream = Helpers::Streaming::ResponseStream
 
     class UnknownStreamEvent = Helpers::Streaming::UnknownStreamEvent

--- a/test/openai/helpers/response_stream_rbs_test.rb
+++ b/test/openai/helpers/response_stream_rbs_test.rb
@@ -64,6 +64,13 @@ class OpenAI::Test::ResponseStreamRBSTest < Minitest::Test
     assert(response_stream.methods.key?(:close), "stream mixin should expose #close")
     each_types = response_stream.methods.fetch(:each).method_types.map(&:to_s)
     assert_includes(each_types.join, "::OpenAI::Helpers::Streaming::response_stream_event")
+
+    passthrough = type_alias("::OpenAI::Helpers::Streaming::response_stream_passthrough_event")
+    assert_includes(passthrough, "::OpenAI::Models::Responses::ResponseAudioDeltaEvent")
+    refute_includes(passthrough, "::OpenAI::Models::Responses::ResponseTextDeltaEvent")
+    refute_includes(passthrough, "::OpenAI::Models::Responses::ResponseTextDoneEvent")
+    refute_includes(passthrough, "::OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent")
+    refute_includes(passthrough, "::OpenAI::Models::Responses::ResponseCompletedEvent")
   end
 
   def test_shipped_rbs_type_checks_enhanced_response_events
@@ -120,11 +127,18 @@ class OpenAI::Test::ResponseStreamRBSTest < Minitest::Test
   private
 
   def definition(type_name)
+    RBS::DefinitionBuilder.new(env: environment).build_instance(RBS::TypeName.parse(type_name))
+  end
+
+  def type_alias(type_name)
+    environment.type_alias_decls.fetch(RBS::TypeName.parse(type_name)).decl.type.to_s
+  end
+
+  def environment
     loader = RBS::EnvironmentLoader.new
     loader.add(path: ROOT.join("sig"))
     loader.add(library: "net-http")
-    environment = RBS::Environment.from_loader(loader).resolve_type_names
-    RBS::DefinitionBuilder.new(env: environment).build_instance(RBS::TypeName.parse(type_name))
+    RBS::Environment.from_loader(loader).resolve_type_names
   end
 
   def return_types(method)

--- a/test/openai/helpers/response_stream_rbs_test.rb
+++ b/test/openai/helpers/response_stream_rbs_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "rbs"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ResponseStreamRBSTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  ROOT = Pathname(__dir__).join("../../..").expand_path
+  STREAM_EVENT = "OpenAI::Models::Responses::response_stream_event"
+  UNKNOWN_EVENT = "OpenAI::Helpers::Streaming::UnknownStreamEvent"
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_shipped_rbs_resolves_high_level_response_stream_contract
+    responses = definition("::OpenAI::Resources::Responses")
+    stream = responses.methods.fetch(:stream)
+    stream_raw = responses.methods.fetch(:stream_raw)
+
+    assert_equal(
+      ["::OpenAI::Helpers::Streaming::ResponseStream"],
+      return_types(stream)
+    )
+    assert_equal(
+      ["::OpenAI::Internal::Stream[::#{STREAM_EVENT} | ::#{UNKNOWN_EVENT}]"],
+      return_types(stream_raw)
+    )
+
+    response_stream = definition("::OpenAI::Streaming::ResponseStream")
+    initialize_types = response_stream.methods.fetch(:initialize).method_types.map(&:to_s)
+    assert_equal(1, initialize_types.size)
+    assert_includes(initialize_types.fetch(0), "raw_stream:")
+    refute_includes(initialize_types.fetch(0), "model:")
+    assert_equal(["self"], return_types(response_stream.methods.fetch(:until_done)))
+    assert_equal(
+      ["::Enumerator[::String]"],
+      return_types(response_stream.methods.fetch(:text))
+    )
+    assert_equal(
+      ["::OpenAI::Models::Responses::Response"],
+      return_types(response_stream.methods.fetch(:get_final_response))
+    )
+    assert_equal(["::String"], return_types(response_stream.methods.fetch(:get_output_text)))
+    assert(response_stream.methods.key?(:each), "stream mixin should expose #each")
+    assert(response_stream.methods.key?(:close), "stream mixin should expose #close")
+  end
+
+  def test_public_response_stream_runtime_supports_declared_helpers
+    stub_request(:post, "http://localhost/responses")
+      .with(body: hash_including(model: "gpt-4o-mini", input: "synthetic", stream: true))
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: synthetic_text_stream
+      )
+
+    client = OpenAI::Client.new(
+      base_url: "http://localhost",
+      api_key: "test-key"
+    )
+    stream = client.responses.stream(model: "gpt-4o-mini", input: "synthetic")
+
+    assert_instance_of(OpenAI::Helpers::Streaming::ResponseStream, stream)
+    text = stream.text
+    assert_instance_of(Enumerator, text)
+    assert_equal("hello", text.next)
+
+    stream = client.responses.stream(model: "gpt-4o-mini", input: "synthetic")
+    assert_same(stream, stream.until_done)
+    assert_equal("hello", stream.get_output_text)
+    assert_equal("resp_synthetic", stream.get_final_response.id)
+  end
+
+  private
+
+  def definition(type_name)
+    loader = RBS::EnvironmentLoader.new
+    loader.add(path: ROOT.join("sig"))
+    loader.add(library: "net-http")
+    environment = RBS::Environment.from_loader(loader).resolve_type_names
+    RBS::DefinitionBuilder.new(env: environment).build_instance(RBS::TypeName.parse(type_name))
+  end
+
+  def return_types(method)
+    method.method_types.map { |method_type| method_type.type.return_type.to_s }
+  end
+
+  def synthetic_text_stream
+    <<~SSE
+      event: response.created
+      data: {"type":"response.created","sequence_number":1,"response":{"id":"resp_synthetic","object":"realtime.response","status":"in_progress","status_details":null,"output":[],"usage":null,"metadata":null}}
+
+      event: response.output_item.added
+      data: {"type":"response.output_item.added","sequence_number":2,"response_id":"resp_synthetic","output_index":0,"item":{"id":"item_synthetic","object":"realtime.item","type":"message","status":"in_progress","role":"assistant","content":[]}}
+
+      event: response.content_part.added
+      data: {"type":"response.content_part.added","sequence_number":3,"response_id":"resp_synthetic","item_id":"item_synthetic","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}
+
+      event: response.output_text.delta
+      data: {"type":"response.output_text.delta","sequence_number":4,"response_id":"resp_synthetic","item_id":"item_synthetic","output_index":0,"content_index":0,"delta":"hello"}
+
+      event: response.output_text.done
+      data: {"type":"response.output_text.done","sequence_number":5,"response_id":"resp_synthetic","item_id":"item_synthetic","output_index":0,"content_index":0,"text":"hello"}
+
+      event: response.completed
+      data: {"type":"response.completed","sequence_number":6,"response":{"id":"resp_synthetic","object":"realtime.response","status":"completed","status_details":null,"output":[{"id":"item_synthetic","object":"realtime.item","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"total_tokens":2,"input_tokens":1,"output_tokens":1},"metadata":null}}
+
+    SSE
+  end
+end

--- a/test/openai/helpers/response_stream_rbs_test.rb
+++ b/test/openai/helpers/response_stream_rbs_test.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require "fileutils"
+require "open3"
 require "pathname"
 require "rbs"
+require "tmpdir"
 
 require_relative "../test_helper"
 
@@ -59,6 +62,33 @@ class OpenAI::Test::ResponseStreamRBSTest < Minitest::Test
     assert_equal(["::String"], return_types(response_stream.methods.fetch(:get_output_text)))
     assert(response_stream.methods.key?(:each), "stream mixin should expose #each")
     assert(response_stream.methods.key?(:close), "stream mixin should expose #close")
+    each_types = response_stream.methods.fetch(:each).method_types.map(&:to_s)
+    assert_includes(each_types.join, "::OpenAI::Helpers::Streaming::response_stream_event")
+  end
+
+  def test_shipped_rbs_type_checks_enhanced_response_events
+    source = <<~RUBY
+      stream = OpenAI::Client.new(api_key: "test-key").responses.stream(
+        model: "gpt-4o-mini",
+        input: "synthetic"
+      )
+      stream.each do |event|
+        case event
+        when OpenAI::Streaming::ResponseTextDeltaEvent
+          event.snapshot
+        when OpenAI::Streaming::ResponseTextDoneEvent
+          event.parsed
+        when OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent
+          event.snapshot
+        when OpenAI::Streaming::ResponseCompletedEvent
+          event.response
+        end
+      end
+    RUBY
+
+    stdout, stderr, status = steep_check(source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
   end
 
   def test_public_response_stream_runtime_supports_declared_helpers
@@ -99,6 +129,31 @@ class OpenAI::Test::ResponseStreamRBSTest < Minitest::Test
 
   def return_types(method)
     method.method_types.map { |method_type| method_type.type.return_type.to_s }
+  end
+
+  def steep_check(source)
+    Dir.mktmpdir("response-stream-rbs") do |directory|
+      FileUtils.cp_r(ROOT.join("sig"), directory)
+      File.write(File.join(directory, "probe.rb"), source)
+      File.write(
+        File.join(directory, "Steepfile"),
+        <<~RUBY
+          target :lib do
+            signature "sig"
+            library "net-http"
+            check "probe.rb"
+          end
+        RUBY
+      )
+      Open3.capture3(
+        "steep",
+        "check",
+        "--no-daemon",
+        "--jobs=1",
+        "--validate=skip",
+        chdir: directory
+      )
+    end
   end
 
   def synthetic_text_stream


### PR DESCRIPTION
## Problem

The shipped RBS declared the already-supported high-level `client.responses.stream` result as `OpenAI::Internal::Stream[...]`. RBS consumers therefore could not resolve existing helper methods such as `get_final_response`, even though runtime returns `OpenAI::Helpers::Streaming::ResponseStream`.

```ruby
stream = client.responses.stream(model: "gpt-4o-mini", input: "hello")
stream.text.each { |delta| puts(delta) }
response = stream.get_final_response
puts(stream.get_output_text)
```

## Fix

- Change only the high-level `Responses#stream` RBS return to the existing public `OpenAI::Streaming::ResponseStream` alias.
- Add the missing RBS declaration for the existing helper, including `text`, `until_done`, `get_final_response`, `get_output_text`, its runtime constructor shape, and inherited stream behavior.
- Model the four existing enhanced yielded event subclasses and their public `snapshot`/`parsed` members while retaining the raw decoded event union for input messages.
- Use an exact 54-event passthrough union so the four raw events that runtime replaces are not advertised as yielded values.
- Keep `stream_raw` and all runtime code unchanged.
- Add a focused regression using the real RBS environment loader/definition builder, a Steep consumer probe, and a WebMock-backed synthetic public Responses stream.

## Synthetic before and after

Before: resolving `Responses#stream` produced `OpenAI::Internal::Stream[...]`, and resolving `get_final_response` on that declared result failed with `Cannot find method`. Enhanced yielded events were also absent from the declared element union, so a consumer matching `OpenAI::Streaming::ResponseTextDoneEvent` could not read `parsed`.

After: resolving `Responses#stream` produces the existing helper; `text` resolves as `Enumerator[String]`, `until_done` as `self`, `get_final_response` as `OpenAI::Responses::Response`, and `get_output_text` as `String`. Steep accepts narrowing the enhanced yielded events and reading `snapshot`, `parsed`, and the completed `response`. The synthetic runtime path returns the same helper and yields `hello` without any live API request.

## Compatibility and scope

This is a type-only compatibility correction. It introduces no runtime behavior, request argument, transport, generated API, dependency, Chat streaming, Sorbet streaming, or broad event-schema changes. Raw streaming return contracts are preserved. Deterministic local public-path/type-contract behavior is proven; customer incidence is unmeasured.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/helpers/response_stream_rbs_test.rb` — 3 runs, 33 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/openai/resources/responses/streaming_test.rb` — 33 runs, 126 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- bundle exec rake validate:rbs` — validated 1287 RBS files.
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rbs_format` — passed.
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop` — 2921 files inspected, no offenses.
- Final serialized `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1765 runs, 15218 assertions, 0 failures, 0 errors, 1 skip.
- Trusted public custom-code budget check on final committed head — 3449 / 4000 custom lines, 551 lines headroom.
- Adversarial review — every push/update was preceded by fresh two-reviewer rounds; the final rebased candidate completed two consecutive clean rounds with no unresolved in-scope blockers.

No security-sensitive surface is changed.