### PR TITLE
fix: isolate structured output field metadata

### DIFF
--- a/lib/openai/helpers/structured_output/json_schema_converter.rb
+++ b/lib/openai/helpers/structured_output/json_schema_converter.rb
@@ -109,7 +109,7 @@ module OpenAI
                 stored[OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::RECURSIVE] = true
               end
 
-              pointers.first.except(OpenAI::Helpers::StructuredOutput::JsonSchemaConverter::NO_REF).tap do
+              pointers.first.slice(:$ref).tap do
                 pointers << _1
               end
             else

--- a/test/openai/helpers/structured_output_field_metadata_test.rb
+++ b/test/openai/helpers/structured_output_field_metadata_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OpenAI::Test::StructuredOutputFieldMetadataTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class SyntheticAddress < OpenAI::BaseModel
+    required :city, String
+  end
+
+  class SyntheticOrder < OpenAI::BaseModel
+    required :billing, SyntheticAddress, doc: "Billing address only"
+    required :shipping, SyntheticAddress
+    required :pickup, SyntheticAddress
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def setup
+    super
+    @client = OpenAI::Client.new(base_url: "http://localhost", api_key: "test-key")
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_reused_nested_model_keeps_field_metadata_independent
+    expected = {
+      :$defs => {
+        ".billing" => {
+          type: "object",
+          properties: {city: {type: "string"}},
+          required: ["city"],
+          additionalProperties: false
+        }
+      },
+      :type => "object",
+      :properties => {
+        billing: {
+          description: "Billing address only",
+          type: "object",
+          properties: {city: {type: "string"}},
+          required: ["city"],
+          additionalProperties: false
+        },
+        shipping: {:$ref => "#/$defs/.billing"},
+        pickup: {:$ref => "#/$defs/.billing"}
+      },
+      :required => %w[billing shipping pickup],
+      :additionalProperties => false
+    }
+
+    assert_equal(expected, SyntheticOrder.to_json_schema)
+    assert_equal(expected, SyntheticOrder.to_json_schema)
+  end
+
+  def test_public_chat_completion_request_serializes_independent_field_metadata
+    stub_request(:post, "http://localhost/chat/completions").to_return_json(
+      status: 200,
+      body: {
+        id: "chatcmpl_field_metadata",
+        choices: [
+          {
+            finish_reason: "stop",
+            index: 0,
+            message: {
+              content: "{\"billing\":{\"city\":\"Paris\"},\"shipping\":{\"city\":\"Rome\"},\"pickup\":{\"city\":\"Lima\"}}",
+              role: "assistant"
+            }
+          }
+        ],
+        created: 1_700_000_000,
+        model: "gpt-4o-mini",
+        object: "chat.completion"
+      }
+    )
+
+    @client.chat.completions.create(
+      messages: [{content: "Return addresses", role: :user}],
+      model: "gpt-4o-mini",
+      response_format: SyntheticOrder
+    )
+
+    assert_requested(:post, "http://localhost/chat/completions") do |request|
+      properties = JSON.parse(request.body).dig(
+        "response_format",
+        "json_schema",
+        "schema",
+        "properties"
+      )
+
+      assert_equal("Billing address only", properties.dig("billing", "description"))
+      assert_equal({"$ref" => "#/$defs/.billing"}, properties.fetch("shipping"))
+      assert_equal({"$ref" => "#/$defs/.billing"}, properties.fetch("pickup"))
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When the same nested structured-output model is used by more than one field, metadata attached to the first field could leak onto later fields. For example:

```ruby
class Address < OpenAI::BaseModel
  required :city, String
end

class Order < OpenAI::BaseModel
  required :billing, Address, doc: "Billing address only"
  required :shipping, Address
  required :pickup, Address
end

schema = Order.to_json_schema
```

Before this change, the synthetic public schema incorrectly contained:

```ruby
{
  shipping: {
    allOf: [
      {:$ref => "#/$defs/.billing"},
      {description: "Billing address only"}
    ]
  }
}
```

After this change, only the annotated field retains that metadata:

```ruby
{
  billing: {description: "Billing address only", ...},
  shipping: {:$ref => "#/$defs/.billing"},
  pickup: {:$ref => "#/$defs/.billing"}
}
```

This is deterministic public-method evidence for supported reused nested models. Real-world incidence is unmeasured.

## Fix

At the existing cached-reference reuse boundary, later uses now receive a fresh hash containing only the cached `$ref`. Field-local metadata and internal reference bookkeeping remain attached only to the field that added them.

The fix preserves the existing definition target, schema shape, nilability/recursion handling, repeated conversion behavior, and runtime coercion. It does not add schema keywords, APIs, abstractions, dependencies, or generated-file changes.

## Tests

- Added a focused public `to_json_schema` regression for one documented and two unannotated uses of the same nested model, including deterministic repeated conversion.
- Added a safe synthetic Chat Completions request regression that inspects the serialized request schema through WebMock.
- Proved the new regression red on the old reuse line: 2 runs, 3 assertions, 2 failures.
- Proved it green with the fix: 2 runs, 5 assertions, 0 failures.
- Focused structured-output/reference/nullable coverage: 56 runs, 248 assertions, 0 failures.
- Adjacent constant/Sorbet/Chat Completions parser/Responses parser coverage: 27 runs, 323 assertions, 0 failures.
- `mise exec ruby@4.0.6 -- bundle exec rake lint`
- Full suite with the supported Ruby and local synthetic mock: 1760 runs, 15172 assertions, 0 failures, 0 errors, 1 skip.
- Trusted public custom-code budget against freshly fetched main: success, 3450 / 4000 custom lines.

## Review and security

Two consecutive adversarial-review rounds each used exactly two new independent read-only reviewers. Both rounds were clean with no in-scope findings and no code changes between rounds.

Security assessment: this is a local schema serialization/hash-reuse correction. It does not touch authentication, network transport, deserialization, logging, files, dependencies, CI, or release behavior, and introduces no new trust boundary.

## Scope

Changed only the existing cached-reference reuse line and one focused regression test. Broader schema support audits, model/framework changes, public API redesign, and unrelated cleanup are explicitly out of scope.
