### PR TITLE
fix: declare Chat stream finish exception types

### DIFF
--- a/rbi/openai/helpers/streaming/exceptions.rbi
+++ b/rbi/openai/helpers/streaming/exceptions.rbi
@@ -1,0 +1,27 @@
+# typed: strong
+
+module OpenAI
+  module Helpers
+    module Streaming
+      class StreamError < StandardError
+      end
+
+      class LengthFinishReasonError < OpenAI::Helpers::Streaming::StreamError
+        sig { returns(OpenAI::Chat::ParsedChatCompletion) }
+        attr_reader :completion
+
+        sig do
+          params(completion: OpenAI::Chat::ParsedChatCompletion).returns(T.attached_class)
+        end
+        def self.new(completion:)
+        end
+      end
+
+      class ContentFilterFinishReasonError < OpenAI::Helpers::Streaming::StreamError
+      end
+    end
+  end
+
+  LengthFinishReasonError = Helpers::Streaming::LengthFinishReasonError
+  ContentFilterFinishReasonError = Helpers::Streaming::ContentFilterFinishReasonError
+end

--- a/rbi/openai/helpers/streaming/exceptions.rbi
+++ b/rbi/openai/helpers/streaming/exceptions.rbi
@@ -18,6 +18,9 @@ module OpenAI
       end
 
       class ContentFilterFinishReasonError < OpenAI::Helpers::Streaming::StreamError
+        sig { returns(T.attached_class) }
+        def self.new
+        end
       end
     end
   end

--- a/sig/openai/helpers/streaming/exceptions.rbs
+++ b/sig/openai/helpers/streaming/exceptions.rbs
@@ -1,0 +1,23 @@
+module OpenAI
+  module Helpers
+    module Streaming
+      class StreamError < StandardError
+      end
+
+      class LengthFinishReasonError < OpenAI::Helpers::Streaming::StreamError
+        attr_reader completion: OpenAI::Models::Chat::ChatCompletion
+
+        def initialize: (
+          completion: OpenAI::Models::Chat::ChatCompletion
+        ) -> void
+      end
+
+      class ContentFilterFinishReasonError < OpenAI::Helpers::Streaming::StreamError
+      end
+    end
+  end
+
+  class LengthFinishReasonError = Helpers::Streaming::LengthFinishReasonError
+
+  class ContentFilterFinishReasonError = Helpers::Streaming::ContentFilterFinishReasonError
+end

--- a/sig/openai/helpers/streaming/exceptions.rbs
+++ b/sig/openai/helpers/streaming/exceptions.rbs
@@ -13,6 +13,7 @@ module OpenAI
       end
 
       class ContentFilterFinishReasonError < OpenAI::Helpers::Streaming::StreamError
+        def initialize: -> void
       end
     end
   end

--- a/test/openai/helpers/chat_stream_error_types_test.rb
+++ b/test/openai/helpers/chat_stream_error_types_test.rb
@@ -45,6 +45,11 @@ class OpenAI::Test::ChatStreamErrorTypesTest < Minitest::Test
     end
 
     assert_kind_of(OpenAI::Helpers::Streaming::StreamError, content_filter_error)
+    assert_instance_of(
+      OpenAI::ContentFilterFinishReasonError,
+      OpenAI::ContentFilterFinishReasonError.new
+    )
+    assert_raises(ArgumentError) { OpenAI::ContentFilterFinishReasonError.new("message") }
   end
 
   def test_shipped_rbi_types_public_finish_error_rescues_and_completion
@@ -57,6 +62,28 @@ class OpenAI::Test::ChatStreamErrorTypesTest < Minitest::Test
     stdout, stderr, status = steep_check(rbs_source)
 
     assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbi_rejects_content_filter_error_message_constructor
+    source = sorbet_source.sub(
+      "OpenAI::ContentFilterFinishReasonError.new",
+      "OpenAI::ContentFilterFinishReasonError.new(\"message\")"
+    )
+    stdout, stderr, status = sorbet_typecheck(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "Too many arguments")
+  end
+
+  def test_shipped_rbs_rejects_content_filter_error_message_constructor
+    source = rbs_source.sub(
+      "OpenAI::ContentFilterFinishReasonError.new",
+      "OpenAI::ContentFilterFinishReasonError.new(\"message\")"
+    )
+    stdout, stderr, status = steep_check(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "Unexpected positional argument")
   end
 
   private
@@ -106,6 +133,8 @@ class OpenAI::Test::ChatStreamErrorTypesTest < Minitest::Test
       built = OpenAI::LengthFinishReasonError.new(completion: completion)
       T.assert_type!(built, OpenAI::Helpers::Streaming::LengthFinishReasonError)
       T.assert_type!(built.completion, OpenAI::Chat::ParsedChatCompletion)
+      content_filter = OpenAI::ContentFilterFinishReasonError.new
+      T.assert_type!(content_filter, OpenAI::Helpers::Streaming::ContentFilterFinishReasonError)
 
       begin
         raise built
@@ -124,6 +153,8 @@ class OpenAI::Test::ChatStreamErrorTypesTest < Minitest::Test
       inspect_finish_error = ->(completion) do
         error = OpenAI::LengthFinishReasonError.new(completion: completion)
         error.completion.id
+        content_filter = OpenAI::ContentFilterFinishReasonError.new
+        content_filter.class
 
         begin
           raise error

--- a/test/openai/helpers/chat_stream_error_types_test.rb
+++ b/test/openai/helpers/chat_stream_error_types_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tempfile"
+require "tmpdir"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::ChatStreamErrorTypesTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  class SyntheticAnswer < OpenAI::BaseModel
+    required :answer, Integer
+  end
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def test_public_chat_stream_raises_existing_finish_errors
+    length_error = assert_raises(OpenAI::LengthFinishReasonError) do
+      stream_for("length").get_final_completion
+    end
+
+    assert_kind_of(OpenAI::Helpers::Streaming::StreamError, length_error)
+    assert_instance_of(OpenAI::Models::Chat::ParsedChatCompletion, length_error.completion)
+    assert_equal(:length, length_error.completion.choices.first.finish_reason)
+
+    content_filter_error = assert_raises(OpenAI::ContentFilterFinishReasonError) do
+      stream_for("content_filter").get_final_completion
+    end
+
+    assert_kind_of(OpenAI::Helpers::Streaming::StreamError, content_filter_error)
+  end
+
+  def test_shipped_rbi_types_public_finish_error_rescues_and_completion
+    stdout, stderr, status = sorbet_typecheck(sorbet_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbs_types_public_finish_error_rescues_and_completion
+    stdout, stderr, status = steep_check(rbs_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  private
+
+  def stream_for(finish_reason)
+    stub_request(:post, "http://localhost/chat/completions")
+      .to_return(
+        status: 200,
+        headers: {"Content-Type" => "text/event-stream"},
+        body: stream_body(finish_reason)
+      )
+
+    OpenAI::Client
+      .new(base_url: "http://localhost", api_key: "synthetic-key")
+      .chat
+      .completions
+      .stream(
+        model: "gpt-4o-mini",
+        messages: [{role: :user, content: "Synthetic"}],
+        response_format: SyntheticAnswer
+      )
+  end
+
+  def stream_body(finish_reason)
+    payload = {
+      id: "chatcmpl-synthetic-finish",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      choices: [
+        {
+          index: 0,
+          delta: {role: "assistant", content: "{\"answer\":"},
+          finish_reason: finish_reason
+        }
+      ]
+    }
+
+    "data: #{JSON.generate(payload)}\n\ndata: [DONE]\n\n"
+  end
+
+  def sorbet_source
+    <<~RUBY
+      # typed: strict
+
+      completion = T.let(T.unsafe(nil), OpenAI::Chat::ParsedChatCompletion)
+      built = OpenAI::LengthFinishReasonError.new(completion: completion)
+      T.assert_type!(built, OpenAI::Helpers::Streaming::LengthFinishReasonError)
+      T.assert_type!(built.completion, OpenAI::Chat::ParsedChatCompletion)
+
+      begin
+        raise built
+      rescue OpenAI::LengthFinishReasonError => error
+        T.assert_type!(error, OpenAI::Helpers::Streaming::LengthFinishReasonError)
+        T.assert_type!(error.completion, OpenAI::Chat::ParsedChatCompletion)
+      rescue OpenAI::ContentFilterFinishReasonError => error
+        T.assert_type!(error, OpenAI::Helpers::Streaming::ContentFilterFinishReasonError)
+      end
+    RUBY
+  end
+
+  def rbs_source
+    <<~RUBY
+      # @type var inspect_finish_error: ^(OpenAI::Models::Chat::ChatCompletion) -> OpenAI::Helpers::Streaming::StreamError
+      inspect_finish_error = ->(completion) do
+        error = OpenAI::LengthFinishReasonError.new(completion: completion)
+        error.completion.id
+
+        begin
+          raise error
+        rescue OpenAI::LengthFinishReasonError => length_error
+          length_error.completion.id
+          length_error
+        rescue OpenAI::ContentFilterFinishReasonError => content_filter_error
+          content_filter_error
+        end
+      end
+
+      inspect_finish_error
+    RUBY
+  end
+
+  def sorbet_typecheck(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Tempfile.create(["chat-stream-error-sorbet", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+    end
+  end
+
+  def steep_check(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Dir.mktmpdir("chat-stream-error-rbs") do |directory|
+      FileUtils.cp_r(File.join(root, "sig"), directory)
+      File.write(File.join(directory, "probe.rb"), source)
+      File.write(
+        File.join(directory, "Steepfile"),
+        <<~RUBY
+          target :lib do
+            signature "sig"
+            library "net-http"
+            check "probe.rb"
+          end
+        RUBY
+      )
+      Open3.capture3(
+        "steep",
+        "check",
+        "--no-daemon",
+        "--jobs=1",
+        "--validate=skip",
+        chdir: directory
+      )
+    end
+  end
+end


### PR DESCRIPTION
# PR draft

Title: fix: declare Chat stream finish exception types

## Problem

The gem already raises OpenAI::LengthFinishReasonError and
OpenAI::ContentFilterFinishReasonError from structured Chat completion streams,
but shipped Sorbet and RBS declarations omit those public constants and their
OpenAI::Helpers::Streaming::StreamError superclass. Typed applications cannot
rescue the existing errors, and Sorbet cannot inspect the completion carried by
the length error.

## User-facing usage

~~~ruby
begin
  stream.get_final_completion
rescue OpenAI::LengthFinishReasonError => error
  completion = error.completion
  puts completion.choices.first.finish_reason
rescue OpenAI::ContentFilterFinishReasonError
  # Handle the existing content-filter termination.
end
~~~

## Before / after

With a synthetic WebMock-backed structured Chat stream ending in
finish_reason: "length", runtime already raises
OpenAI::LengthFinishReasonError with a parsed completion. Before this change,
Sorbet reports unresolved OpenAI::LengthFinishReasonError and
OpenAI::ContentFilterFinishReasonError, then reports that completion does
not exist; rbs method OpenAI::LengthFinishReasonError completion cannot find
the class. After this change, the same public rescue path resolves in Sorbet
and RBS, and the focused runtime regression still observes the existing length
completion and content-filter error.

## Fix

- Add RBI declarations for the existing helper exception hierarchy, public root
  aliases, and precise parsed-completion reader/keyword constructor.
- Add RBS declarations for the same hierarchy and aliases, using the already
  declared OpenAI::Models::Chat::ChatCompletion supertype rather than creating
  a broader parsed-Chat RBS hierarchy.
- Add one focused regression for both type systems and WebMock-backed public
  Chat streams.
- Explicitly declare the existing zero-argument content-filter constructor in
  both type systems, with positive and negative constructor probes.

## Compatibility and scope

This is declaration-only for existing runtime classes. It does not change
exception behavior, stream parsing, refusal semantics, public APIs, generated
models, dependencies, or Task 1's sig/openai/streaming.rbs.

## Verification

- mise exec ruby@4.0.6 -- bundle exec rake lint
- mise exec ruby@4.0.6 -- bundle exec rake typecheck
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_initial_finish_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/helpers/chat_stream_error_types_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/gem_packaging_test.rb
- TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test
- git diff --check
- Trusted current-main public custom-code budget check: success, 3450/4000.
- Adversarial review: two consecutive clean rounds, each with two new
  independent read-only reviewers.

Full suite result after feedback: 1763 runs, 15187 assertions, 0 failures, 0 errors, 1 skip.

## Limitations

Customer incidence is unmeasured. The regression uses safe synthetic data and
does not make a live API request.
