### PR TITLE
fix: declare workload identity error types

### DIFF
--- a/rbi/openai/errors.rbi
+++ b/rbi/openai/errors.rbi
@@ -267,5 +267,42 @@ module OpenAI
     class InternalServerError < OpenAI::Errors::APIStatusError
       HTTP_STATUS = T.let((500..), T::Range[Integer])
     end
+
+    class OAuthError < OpenAI::Errors::APIStatusError
+      sig { returns(T.nilable(OpenAI::Models::OAuthErrorCode::Variants)) }
+      attr_reader :error_code
+
+      # @api private
+      sig do
+        params(
+          status: Integer,
+          body: T.nilable(Object),
+          headers: T.nilable(T::Hash[String, String])
+        )
+          .returns(T.attached_class)
+      end
+      def self.new(status:, body:, headers:)
+      end
+    end
+
+    class SubjectTokenProviderError < OpenAI::Errors::Error
+      sig { returns(String) }
+      attr_reader :provider
+
+      sig { returns(T.nilable(StandardError)) }
+      attr_accessor :cause
+
+      # @api private
+      sig do
+        params(
+          message: String,
+          provider: String,
+          cause: T.nilable(StandardError)
+        )
+          .returns(T.attached_class)
+      end
+      def self.new(message:, provider:, cause: nil)
+      end
+    end
   end
 end

--- a/sig/openai/errors.rbs
+++ b/sig/openai/errors.rbs
@@ -138,5 +138,29 @@ module OpenAI
     class InternalServerError < OpenAI::Errors::APIStatusError
       HTTP_STATUS: Range[Integer]
     end
+
+    class OAuthError < OpenAI::Errors::APIStatusError
+      def status: -> Integer
+
+      attr_reader error_code: OpenAI::Models::oauth_error_code?
+
+      def initialize: (
+        status: Integer,
+        body: Object?,
+        headers: ::Hash[String, String]?
+      ) -> void
+    end
+
+    class SubjectTokenProviderError < OpenAI::Errors::Error
+      attr_reader provider: String
+
+      attr_accessor cause: StandardError?
+
+      def initialize: (
+        message: String,
+        provider: String,
+        ?cause: StandardError?
+      ) -> void
+    end
   end
 end

--- a/sig/openai/errors.rbs
+++ b/sig/openai/errors.rbs
@@ -142,6 +142,8 @@ module OpenAI
     class OAuthError < OpenAI::Errors::APIStatusError
       def status: -> Integer
 
+      def status=: (Integer) -> Integer
+
       attr_reader error_code: OpenAI::Models::oauth_error_code?
 
       def initialize: (

--- a/test/openai/auth/workload_identity_error_types_test.rb
+++ b/test/openai/auth/workload_identity_error_types_test.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tempfile"
+require "tmpdir"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::WorkloadIdentityErrorTypesTest < Minitest::Test
+  extend Minitest::Serial
+  include WebMock::API
+
+  def before_all
+    super
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  def teardown
+    WebMock.reset!
+    super
+  end
+
+  def after_all
+    WebMock.disable!
+    super
+  end
+
+  def test_public_models_request_exposes_kubernetes_provider_failure_metadata
+    missing_path = File.join(Dir.tmpdir, "synthetic-k8s-token-#{SecureRandom.hex}")
+    provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new(token_path: missing_path)
+
+    error = assert_raises(OpenAI::Errors::SubjectTokenProviderError) do
+      workload_identity_client(provider).models.list
+    end
+
+    assert_equal("kubernetes", error.provider)
+    assert_kind_of(Errno::ENOENT, error.cause)
+  end
+
+  def test_public_models_request_exposes_oauth_failure_metadata
+    stub_request(:post, "https://auth.openai.com/oauth/token")
+      .to_return(
+        status: 401,
+        headers: {"Content-Type" => "application/json"},
+        body: JSON.generate(error: "invalid_grant", error_description: "Synthetic token exchange failure")
+      )
+
+    Tempfile.create("synthetic-k8s-token") do |token_file|
+      token_file.write("synthetic-subject-token")
+      token_file.flush
+      provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new(token_path: token_file.path)
+
+      error = assert_raises(OpenAI::Errors::OAuthError) do
+        workload_identity_client(provider).models.list
+      end
+
+      assert_equal(401, error.status)
+      assert_equal(:invalid_grant, error.error_code)
+    end
+
+    assert_requested(:post, "https://auth.openai.com/oauth/token", times: 1)
+    assert_not_requested(:get, "https://api.openai.com/v1/models")
+  end
+
+  def test_shipped_rbi_types_error_rescues_and_metadata
+    stdout, stderr, status = sorbet_typecheck(sorbet_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbi_rejects_incorrect_metadata_type
+    source = sorbet_source.sub(
+      "T.let(error.status, Integer)",
+      "T.let(error.status, String)"
+    )
+    stdout, stderr, status = sorbet_typecheck(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "String")
+  end
+
+  def test_shipped_rbs_types_error_rescues_and_metadata
+    stdout, stderr, status = steep_check(rbs_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbs_rejects_incorrect_metadata_type
+    source = rbs_source.sub("error.status + 1", "error.status + \"one\"")
+    stdout, stderr, status = steep_check(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "error.status")
+  end
+
+  private
+
+  def workload_identity_client(provider)
+    identity = OpenAI::Auth::WorkloadIdentity.new(
+      provider: provider,
+      identity_provider_id: "ip_synthetic",
+      service_account_id: "sa_synthetic"
+    )
+    OpenAI::Client.new(
+      api_key: nil,
+      workload_identity: identity,
+      organization: "org_synthetic",
+      max_retries: 0
+    )
+  end
+
+  def sorbet_source
+    <<~RUBY
+      # typed: true
+
+      begin
+        raise "synthetic"
+      rescue OpenAI::Errors::SubjectTokenProviderError => error
+        provider = T.let(error.provider, String)
+        cause = T.let(error.cause, T.nilable(StandardError))
+        puts(provider, cause&.message)
+      rescue OpenAI::Errors::OAuthError => error
+        code = T.let(error.error_code, T.nilable(OpenAI::Models::OAuthErrorCode::Variants))
+        status = T.let(error.status, Integer)
+        puts(code, status)
+      end
+    RUBY
+  end
+
+  def rbs_source
+    <<~RUBY
+      begin
+        raise "synthetic"
+      rescue OpenAI::Errors::SubjectTokenProviderError => error
+        error.provider.upcase
+        error.cause&.message
+      rescue OpenAI::Errors::OAuthError => error
+        error.error_code&.to_s
+        error.status + 1
+      end
+    RUBY
+  end
+
+  def sorbet_typecheck(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Tempfile.create(["workload-identity-error-sorbet", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+    end
+  end
+
+  def steep_check(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Dir.mktmpdir("workload-identity-error-rbs") do |directory|
+      FileUtils.cp_r(File.join(root, "sig"), directory)
+      File.write(File.join(directory, "probe.rb"), source)
+      File.write(
+        File.join(directory, "Steepfile"),
+        <<~RUBY
+          target :lib do
+            signature "sig"
+            library "net-http"
+            check "probe.rb"
+          end
+        RUBY
+      )
+      Open3.capture3(
+        "steep",
+        "check",
+        "--no-daemon",
+        "--jobs=1",
+        "--validate=skip",
+        chdir: directory
+      )
+    end
+  end
+end

--- a/test/openai/auth/workload_identity_error_types_test.rb
+++ b/test/openai/auth/workload_identity_error_types_test.rb
@@ -88,7 +88,7 @@ class OpenAI::Test::WorkloadIdentityErrorTypesTest < Minitest::Test
   end
 
   def test_shipped_rbs_rejects_incorrect_metadata_type
-    source = rbs_source.sub("error.status + 1", "error.status + \"one\"")
+    source = rbs_source.sub("error.status = 401", "error.status = nil")
     stdout, stderr, status = steep_check(source)
 
     refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
@@ -138,6 +138,7 @@ class OpenAI::Test::WorkloadIdentityErrorTypesTest < Minitest::Test
         error.cause&.message
       rescue OpenAI::Errors::OAuthError => error
         error.error_code&.to_s
+        error.status = 401
         error.status + 1
       end
     RUBY


### PR DESCRIPTION
## Problem

The runtime already raises `OpenAI::Errors::SubjectTokenProviderError` and `OpenAI::Errors::OAuthError` during workload-identity authentication, but the shipped RBI and RBS omitted both classes. Typed applications could hit unresolved-constant errors when rescuing these supported failures, and could not type-check reads of their existing metadata.

## User-facing example

```ruby
begin
  client.models.list
rescue OpenAI::Errors::SubjectTokenProviderError => error
  warn "#{error.provider}: #{error.cause&.message}"
rescue OpenAI::Errors::OAuthError => error
  warn "OAuth #{error.status}: #{error.error_code}"
end
```

## Change

- Declares the two existing runtime classes in `rbi/openai/errors.rbi` and `sig/openai/errors.rbs` with their existing inheritance and keyword constructors.
- Declares `provider`, nullable `cause`, `error_code`, and the concrete OAuth status reader using the existing OAuth error-code union.
- Adds one focused offline regression that exercises public `Client(...workload_identity...).models.list` failures and positive/negative checks against the shipped Sorbet and RBS declarations.

Synthetic before/after:

- Before: the Sorbet probe reports unresolved `SubjectTokenProviderError` and `OAuthError` constants plus missing `provider`/`error_code`; RBS reports both constants missing.
- After: the same positive probes pass; deliberate `status` type mismatches remain rejected. Offline runtime probes observe `provider == "kubernetes"` with an `Errno::ENOENT` cause, and a WebMock 401 exchange with `status == 401` and `error_code == :invalid_grant`.

## Compatibility and scope

This is a type-only correction: runtime error classes, authentication behavior, providers, transports, and public APIs are unchanged. It intentionally does not add the separately scoped provider declarations or perform broader auth-type cleanup. All test values are synthetic and live network access is disabled.

Security assessment: the diff only declares existing authentication error types and adds offline synthetic tests; it changes no credential acquisition, token exchange, transport, logging, dependencies, CI, or release behavior. `@openai/sdks-team` review is requested because the declarations describe authentication-facing errors.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/workload_identity_error_types_test.rb` — 6 runs, 18 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/workload_identity_test.rb` — 30 runs, 130 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/workload_identity_error_headers_test.rb` — 3 runs, 34 assertions, 0 failures
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop 2,921 files, Sorbet clean, 1,286 RBS files validated
- Serialized `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1,768 runs, 15,203 assertions, 0 failures, 0 errors, 1 skip
- Trusted current-main public custom-code budget check on committed candidate — success, 3,450 / 4,000 custom lines

## Adversarial review

Two consecutive unchanged-code rounds completed, each with two new independent read-only reviewers: correctness/security/contracts and architecture/simplicity/ownership. All four reviews were clean with no supported in-scope blocking findings.

Limitations: customer incidence is unmeasured; the failure and fix are demonstrated deterministically with synthetic offline data.
