### PR TITLE
fix: declare built-in workload identity providers

### DIFF
--- a/rbi/openai/auth/subject_token_providers.rbi
+++ b/rbi/openai/auth/subject_token_providers.rbi
@@ -1,0 +1,72 @@
+# typed: strong
+
+module OpenAI
+  module Auth
+    module SubjectTokenProviders
+      class K8sServiceAccountTokenProvider
+        include OpenAI::Auth::SubjectTokenProvider
+
+        sig { params(token_path: String).void }
+        def initialize(token_path: "/var/run/secrets/kubernetes.io/serviceaccount/token")
+        end
+
+        sig { returns(Symbol) }
+        def token_type
+        end
+
+        sig { returns(String) }
+        def get_token
+        end
+      end
+
+      class AzureManagedIdentityTokenProvider
+        include OpenAI::Auth::SubjectTokenProvider
+
+        sig do
+          params(
+            resource: String,
+            object_id: T.nilable(String),
+            client_id: T.nilable(String),
+            msi_res_id: T.nilable(String),
+            api_version: String,
+            timeout: Float
+          )
+            .void
+        end
+        def initialize(
+          resource: "https://management.azure.com/",
+          object_id: nil,
+          client_id: nil,
+          msi_res_id: nil,
+          api_version: "2018-02-01",
+          timeout: 10.0
+        )
+        end
+
+        sig { returns(Symbol) }
+        def token_type
+        end
+
+        sig { returns(String) }
+        def get_token
+        end
+      end
+
+      class GCPIDTokenProvider
+        include OpenAI::Auth::SubjectTokenProvider
+
+        sig { params(audience: String, timeout: Float).void }
+        def initialize(audience: "https://api.openai.com/v1", timeout: 10.0)
+        end
+
+        sig { returns(Symbol) }
+        def token_type
+        end
+
+        sig { returns(String) }
+        def get_token
+        end
+      end
+    end
+  end
+end

--- a/sig/openai/auth/subject_token_providers.rbs
+++ b/sig/openai/auth/subject_token_providers.rbs
@@ -1,0 +1,42 @@
+module OpenAI
+  module Auth
+    module SubjectTokenProviders
+      class K8sServiceAccountTokenProvider
+        include OpenAI::Auth::SubjectTokenProvider
+
+        def initialize: (?token_path: String) -> void
+
+        def token_type: -> Symbol
+
+        def get_token: -> String
+      end
+
+      class AzureManagedIdentityTokenProvider
+        include OpenAI::Auth::SubjectTokenProvider
+
+        def initialize: (
+          ?resource: String,
+          ?object_id: String?,
+          ?client_id: String?,
+          ?msi_res_id: String?,
+          ?api_version: String,
+          ?timeout: Float
+        ) -> void
+
+        def token_type: -> Symbol
+
+        def get_token: -> String
+      end
+
+      class GCPIDTokenProvider
+        include OpenAI::Auth::SubjectTokenProvider
+
+        def initialize: (?audience: String, ?timeout: Float) -> void
+
+        def token_type: -> Symbol
+
+        def get_token: -> String
+      end
+    end
+  end
+end

--- a/test/openai/auth/subject_token_provider_types_test.rb
+++ b/test/openai/auth/subject_token_provider_types_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tempfile"
+require "tmpdir"
+
+require_relative "../test_helper"
+
+class OpenAI::Test::SubjectTokenProviderTypesTest < Minitest::Test
+  extend Minitest::Serial
+
+  def test_shipped_rbi_types_documented_provider_configuration
+    stdout, stderr, status = sorbet_typecheck(typed_configuration_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbi_rejects_invalid_provider_arguments
+    source = typed_configuration_source.sub("token_path: \"/synthetic/token\"", "token_path: 123")
+    stdout, stderr, status = sorbet_typecheck(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "Expected `String`")
+  end
+
+  def test_shipped_rbs_types_documented_provider_configuration
+    stdout, stderr, status = steep_check(rbs_configuration_source)
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+  end
+
+  def test_shipped_rbs_rejects_invalid_provider_arguments
+    source = rbs_configuration_source.sub("token_path: \"/synthetic/token\"", "token_path: 123")
+    stdout, stderr, status = steep_check(source)
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes("#{stdout}\n#{stderr}", "Ruby::ArgumentTypeMismatch")
+  end
+
+  def test_runtime_providers_implement_interface_without_token_access
+    providers = [
+      OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new,
+      OpenAI::Auth::SubjectTokenProviders::AzureManagedIdentityTokenProvider.new,
+      OpenAI::Auth::SubjectTokenProviders::GCPIDTokenProvider.new
+    ]
+
+    assert_equal(
+      [OpenAI::Auth::TokenType::JWT, OpenAI::Auth::TokenType::JWT, OpenAI::Auth::TokenType::ID],
+      providers.map(&:token_type)
+    )
+    providers.each do |provider|
+      assert_kind_of(OpenAI::Auth::SubjectTokenProvider, provider)
+      identity = OpenAI::Auth::WorkloadIdentity.new(
+        provider: provider,
+        identity_provider_id: "ip_synthetic",
+        service_account_id: "sa_synthetic"
+      )
+      assert_same(provider, identity.provider)
+    end
+  end
+
+  private
+
+  def typed_configuration_source
+    <<~RUBY
+      # typed: true
+
+      providers = [
+        OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new(token_path: "/synthetic/token"),
+        OpenAI::Auth::SubjectTokenProviders::AzureManagedIdentityTokenProvider.new(resource: "synthetic", timeout: 1.0),
+        OpenAI::Auth::SubjectTokenProviders::GCPIDTokenProvider.new(audience: "synthetic", timeout: 1.0)
+      ]
+      providers.each do |provider|
+        typed_provider = T.let(provider, OpenAI::Auth::SubjectTokenProvider)
+        OpenAI::Auth::WorkloadIdentity.new(
+          provider: typed_provider,
+          identity_provider_id: "ip_synthetic",
+          service_account_id: "sa_synthetic"
+        )
+        T.assert_type!(typed_provider.token_type, Symbol)
+        T.assert_type!(typed_provider.get_token, String)
+      end
+    RUBY
+  end
+
+  def rbs_configuration_source
+    <<~RUBY
+      providers = [
+        OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new(token_path: "/synthetic/token"),
+        OpenAI::Auth::SubjectTokenProviders::AzureManagedIdentityTokenProvider.new(resource: "synthetic", timeout: 1.0),
+        OpenAI::Auth::SubjectTokenProviders::GCPIDTokenProvider.new(audience: "synthetic", timeout: 1.0)
+      ]
+      providers.each do |provider|
+        identity = OpenAI::Auth::WorkloadIdentity.new(
+          provider: provider,
+          identity_provider_id: "ip_synthetic",
+          service_account_id: "sa_synthetic"
+        )
+        identity.provider.token_type
+        identity.provider.get_token
+      end
+    RUBY
+  end
+
+  def sorbet_typecheck(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Tempfile.create(["subject-token-provider-sorbet", ".rb"]) do |file|
+      file.write(source)
+      file.flush
+      Open3.capture3(
+        {"SRB_SKIP_GEM_RBIS" => "1"},
+        "srb",
+        "typecheck",
+        file.path,
+        chdir: root
+      )
+    end
+  end
+
+  def steep_check(source)
+    root = File.expand_path("../../..", __dir__)
+
+    Dir.mktmpdir("subject-token-provider-rbs") do |directory|
+      FileUtils.cp_r(File.join(root, "sig"), directory)
+      File.write(File.join(directory, "probe.rb"), source)
+      File.write(
+        File.join(directory, "Steepfile"),
+        <<~RUBY
+          target :lib do
+            signature "sig"
+            library "net-http"
+            check "probe.rb"
+          end
+        RUBY
+      )
+      Open3.capture3(
+        "steep",
+        "check",
+        "--no-daemon",
+        "--jobs=1",
+        "--validate=skip",
+        chdir: directory
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The README documents three built-in workload identity subject-token providers, but the shipped Sorbet and RBS graphs did not declare them. Static users could not configure Kubernetes, Azure, or GCP workload identity through the existing `SubjectTokenProvider` contract even though the runtime classes already worked.

## User-facing fix

```ruby
provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new
identity = OpenAI::Auth::WorkloadIdentity.new(
  provider: provider,
  identity_provider_id: "ip_synthetic",
  service_account_id: "sa_synthetic"
)
```

The same typed configuration now works with `AzureManagedIdentityTokenProvider` and `GCPIDTokenProvider`. The new RBI and RBS files declare the existing constructor keywords/default shapes, interface inclusion, and `token_type` / `get_token` contracts.

## Synthetic before/after

- Before: an offline Sorbet probe reported three unresolved `OpenAI::Auth::SubjectTokenProviders` constants; RBS could not resolve the Kubernetes provider.
- After: focused shipped-declaration probes accept all three providers flowing into `WorkloadIdentity`, and negative controls still reject `token_path: 123`.

## Scope and compatibility

- Adds only `rbi/openai/auth/subject_token_providers.rbi`, `sig/openai/auth/subject_token_providers.rbs`, and one focused type test.
- No runtime authentication, token exchange, transport, error, dependency, generated-model, or public API behavior changed.
- Tests use synthetic identifiers, do not call `get_token`, and do not read token files or contact metadata services.

## Verification

- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/subject_token_provider_types_test.rb` — 5 runs, 19 assertions, 0 failures, 0 errors.
- `mise exec ruby@4.0.6 -- bundle exec rake lint` — RuboCop 2,925 files, RBS validation, and Sorbet example typecheck passed.
- `TEST_API_BASE_URL=http://127.0.0.1:49137 mise exec ruby@4.0.6 -- bundle exec rake test` — 1,777 runs, 15,259 assertions, 0 failures, 0 errors, 1 skip.
- Trusted freshly fetched-main public custom-code budget check — isolation success; 3,449 / 4,000 custom lines.
- Adversarial review — two consecutive clean rounds, each with two new independent read-only reviewers.
- Auth-facing security review — declarations and synthetic tests introduce no credential, file, metadata, logging, or network behavior.

## Limitations

Customer incidence is unmeasured. This fixes shipped static declarations for documented runtime workflows; it does not change runtime provider behavior.
