### PR TITLE
fix: accept documented RequestOptions extra query values

### DIFF
--- a/lib/openai/request_options.rb
+++ b/lib/openai/request_options.rb
@@ -8,6 +8,16 @@ module OpenAI
   # simply pass a Hash with symbol keys matching the attributes on this class.
   class RequestOptions < OpenAI::Internal::Type::BaseModel
     # @api private
+    module ExtraQueryValue
+      extend OpenAI::Internal::Type::Union
+
+      variant String
+      variant OpenAI::Internal::Type::ArrayOf[String]
+    end
+
+    private_constant :ExtraQueryValue
+
+    # @api private
     #
     # @param opts [OpenAI::RequestOptions, Hash{Symbol=>Object}]
     #
@@ -37,7 +47,10 @@ module OpenAI
     #   `query` given at the client level.
     #
     #   @return [Hash{String=>Array<String>, String, nil}, nil]
-    optional :extra_query, OpenAI::Internal::Type::HashOf[OpenAI::Internal::Type::ArrayOf[String]]
+    optional(
+      :extra_query,
+      OpenAI::Internal::Type::HashOf[{union: ExtraQueryValue}, nil?: true]
+    )
 
     # @!attribute extra_headers
     #   Extra headers to send with the request. These are `.merged`’d into any

--- a/test/openai/request_options_extra_query_test.rb
+++ b/test/openai/request_options_extra_query_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class OpenAI::Test::RequestOptionsExtraQueryTest < Minitest::Test
+  class CaptureHTTPClient < OpenAI::HTTPClient
+    attr_reader :urls
+
+    def initialize
+      super
+      @urls = []
+    end
+
+    def execute(request)
+      @urls << request.url.to_s
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: [JSON.generate(object: "list", data: [], has_more: false)]
+      )
+    end
+  end
+
+  def test_constructor_reads_documented_value_forms_without_replacing_raw_input
+    extra_query = {"purpose" => "batch", "tags" => ["one", "two"], "cursor" => nil}
+    options = OpenAI::RequestOptions.new(extra_query: extra_query)
+
+    assert_same(extra_query, options[:extra_query])
+    assert_equal(extra_query, options.extra_query)
+  end
+
+  def test_setter_reads_documented_value_forms
+    options = OpenAI::RequestOptions.new
+    extra_query = {"purpose" => "batch", "tags" => ["one", "two"], "cursor" => nil}
+
+    options.extra_query = extra_query
+
+    assert_same(extra_query, options[:extra_query])
+    assert_equal(extra_query, options.extra_query)
+  end
+
+  def test_native_request_preserves_scalar_array_and_nil_wire_values
+    transport = CaptureHTTPClient.new
+    client = OpenAI::Client.new(api_key: "fake-key", base_url: "http://localhost", http_client: transport)
+    options = OpenAI::RequestOptions.new(
+      extra_query: {"purpose" => "batch", "tags" => ["one", "two"], "cursor" => nil}
+    )
+
+    client.files.list(request_options: options)
+
+    assert_equal(
+      ["http://localhost/files?purpose=batch&tags=one&tags=two&cursor"],
+      transport.urls
+    )
+  end
+end


### PR DESCRIPTION
# Task 8 PR text

Title: fix: accept documented RequestOptions extra query values

## Summary

OpenAI::RequestOptions#extra_query already documents and statically declares
query values as String, Array<String>, or nil, but its runtime field accepted
only arrays. Reading a public options object created with a scalar or nil value
raised OpenAI::Errors::ConversionError.

~~~ruby
options = OpenAI::RequestOptions.new(
  extra_query: {
    "purpose" => "batch",
    "tags" => ["one", "two"],
    "cursor" => nil
  }
)

options.extra_query
# => {"purpose"=>"batch", "tags"=>["one", "two"], "cursor"=>nil}
~~~

Before, the synthetic public readback
OpenAI::RequestOptions.new(extra_query: {"purpose" => "batch"}).extra_query
raised ConversionError; after, it returns {"purpose" => "batch"}. The existing
array control remains readable, and nil-valued entries now read back too.

## Implementation

The fix changes only the existing extra_query runtime declaration: a private
local union models String | Array<String>, and the existing HashOf primitive
allows nil values. No accessor, storage, query merge, or transport code changes.

The focused regression covers constructor and setter/readback, verifies the
caller-owned raw hash remains the exact stored object, and uses an actual
RequestOptions instance in an offline native request. Wire output remains
purpose=batch&tags=one&tags=two&cursor.

## Scope and compatibility

This is a deterministic documented public readback failure; customer incidence
is unmeasured. The change preserves existing keys, raw storage, caller
ownership, and HTTP query serialization. It does not change BaseClient,
BasePage, BaseModel, HashOf, Union, public RBI/RBS, dependencies, generated
files, or budget metadata.

## Verification

- Focused RequestOptions, query override, nullable collection, and raw-value contract tests passed.
- mise exec ruby@4.0.6 -- bundle exec rake lint passed.
- Trusted freshly fetched main public custom-code budget check passed: 3449 / 4000.
- Adversarial review: two consecutive clean fresh-context rounds on the final formatted diff.

Security assessment: no authentication, transport implementation, logging,
deserialization, dependency, CI, or release surface changed; the offline native
request verifies query serialization without real credentials or network calls.

Limitation: no live API calls were made; deterministic synthetic coverage is
used intentionally.
