### PR TITLE
ci: bound example runner descendant cleanup

### DIFF
--- a/scripts/examples-e2e.rb
+++ b/scripts/examples-e2e.rb
@@ -211,6 +211,7 @@ module OpenAIExamplesE2E
 
   class Executor
     MAX_CAPTURED_CHARACTERS = 12_000
+    CLEANUP_GRACE_SECONDS = 2
 
     def initialize(root:, timeout:)
       @root = root
@@ -224,20 +225,42 @@ module OpenAIExamplesE2E
       status = nil
       timed_out = false
       example_path = @root.join(example.path).to_s
+      deadline = started_at + @timeout
 
       Dir.mktmpdir("openai-ruby-example-e2e") do |working_directory|
+        spawn_options = {chdir: working_directory}
+        spawn_options[:pgroup] = true unless Gem.win_platform?
         Open3.popen3(
           RbConfig.ruby,
           example_path,
-          chdir: working_directory
+          **spawn_options
         ) do |stdin, stdout, stderr, wait_thread|
           stdin.close
-          stdout_reader = Thread.new { stdout.read }
-          stderr_reader = Thread.new { stderr.read }
+          stdout_reader = Thread.new { read_output(stdout) }
+          stderr_reader = Thread.new { read_output(stderr) }
+          cleanup_attempted = false
 
-          timed_out = wait_thread.join(@timeout).nil?
-          terminate(wait_thread) if timed_out
-          status = wait_thread.value
+          begin
+            timed_out = wait_thread.join(remaining_seconds(deadline)).nil?
+            unless timed_out
+              timed_out = [stdout_reader, stderr_reader].any? do |reader|
+                reader.join(remaining_seconds(deadline)).nil?
+              end
+            end
+            if timed_out
+              terminate(wait_thread)
+              cleanup_attempted = true
+            end
+          ensure
+            needs_cleanup = wait_thread.alive? || stdout_reader.alive? || stderr_reader.alive?
+            terminate(wait_thread) if needs_cleanup && !cleanup_attempted
+            close_output(stdout)
+            close_output(stderr)
+            stdout_reader.join
+            stderr_reader.join
+          end
+
+          status = wait_thread.value unless wait_thread.alive?
           stdout_value = stdout_reader.value
           stderr_value = stderr_reader.value
         end
@@ -268,12 +291,55 @@ module OpenAIExamplesE2E
     private
 
     def terminate(wait_thread)
+      return terminate_process(wait_thread) if Gem.win_platform?
+
+      process_group_id = wait_thread.pid
+      signal_process_group("TERM", process_group_id)
+      cleanup_deadline = monotonic_time + CLEANUP_GRACE_SECONDS
+      sleep(0.01) while process_group_alive?(process_group_id) && monotonic_time < cleanup_deadline
+      signal_process_group("KILL", process_group_id) if process_group_alive?(process_group_id)
+      wait_thread.join(0.1)
+    rescue Errno::ECHILD
+      nil
+    end
+
+    def terminate_process(wait_thread)
       Process.kill("TERM", wait_thread.pid)
-      return if wait_thread.join(2)
+      return if wait_thread.join(CLEANUP_GRACE_SECONDS)
 
       Process.kill("KILL", wait_thread.pid)
-      wait_thread.join
-    rescue Errno::ESRCH, Errno::ECHILD
+      wait_thread.join(0.1)
+    rescue Errno::ECHILD, Errno::ESRCH
+      nil
+    end
+
+    def read_output(pipe)
+      output = +""
+      loop { output << pipe.readpartial(4096) }
+    rescue IOError
+      output
+    end
+
+    def remaining_seconds(deadline) = [deadline - monotonic_time, 0].max
+
+    def monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    def process_group_alive?(process_group_id)
+      Process.kill(0, -process_group_id)
+      true
+    rescue Errno::EPERM, Errno::ESRCH
+      false
+    end
+
+    def signal_process_group(signal, process_group_id)
+      Process.kill(signal, -process_group_id)
+    rescue Errno::EPERM, Errno::ESRCH
+      nil
+    end
+
+    def close_output(pipe)
+      pipe.close unless pipe.closed?
+    rescue IOError
       nil
     end
 

--- a/test/scripts/examples_e2e_descendant_timeout_test.rb
+++ b/test/scripts/examples_e2e_descendant_timeout_test.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "json"
+require "minitest/autorun"
+require "pathname"
+require "rbconfig"
+require "stringio"
+require "timeout"
+require "tmpdir"
+require "yaml"
+
+require_relative "../../scripts/examples-e2e"
+
+class ExamplesE2EDescendantTimeoutTest < Minitest::Test
+  extend Minitest::Serial if defined?(Minitest::Serial)
+
+  MARKER = "synthetic example output"
+  TEST_TIMEOUT = 1
+  MAXIMUM_DURATION = 4
+
+  def test_cli_timeout_bounds_descendant_inherited_output_and_preserves_unrelated_process
+    skip "POSIX process-group behavior" if Gem.win_platform?
+
+    sentinel_pid = Process.spawn(RbConfig.ruby, "-e", "sleep 30", pgroup: true)
+
+    with_example(source: descendant_source(parent_sleep: 30)) do |root, child_pid_path|
+      child_pid = nil
+      status, result, duration = run_cli(root)
+      child_pid = read_pid(child_pid_path)
+
+      assert_equal(1, status)
+      assert_equal("example timed out after 1 seconds", result.fetch("error"))
+      assert_operator(duration, :<, MAXIMUM_DURATION)
+      assert_process_stopped(child_pid)
+      assert_process_alive(sentinel_pid)
+    ensure
+      stop_process(child_pid || read_pid_if_present(child_pid_path))
+    end
+  ensure
+    stop_process_group(sentinel_pid)
+  end
+
+  def test_cli_timeout_bounds_inherited_output_after_parent_exits
+    skip "POSIX process-group behavior" if Gem.win_platform?
+
+    with_example(source: descendant_source(parent_sleep: nil, child_ignores_term: true)) do |root, child_pid_path|
+      child_pid = nil
+      status, result, duration = run_cli(root)
+      child_pid = read_pid(child_pid_path)
+
+      assert_equal(1, status)
+      assert_equal("example timed out after 1 seconds", result.fetch("error"))
+      assert_operator(duration, :<, MAXIMUM_DURATION)
+      assert_process_stopped(child_pid)
+    ensure
+      stop_process(child_pid || read_pid_if_present(child_pid_path))
+    end
+  end
+
+  def test_cli_preserves_normal_output
+    with_example(source: "puts #{MARKER.dump}\n") do |root, _child_pid_path|
+      status, result, duration = run_cli(root)
+
+      assert_equal(0, status)
+      assert(result.fetch("successful"))
+      assert_nil(result.fetch("error"))
+      assert_operator(duration, :<, TEST_TIMEOUT)
+    end
+  end
+
+  def test_cli_bounds_direct_timeout
+    with_example(source: "puts #{MARKER.dump}\nsleep 30\n") do |root, _child_pid_path|
+      status, result, duration = run_cli(root)
+
+      assert_equal(1, status)
+      assert_equal("example timed out after 1 seconds", result.fetch("error"))
+      assert_operator(duration, :<, MAXIMUM_DURATION)
+    end
+  end
+
+  def test_cli_preserves_successful_child_with_detached_output
+    with_example(source: detached_output_descendant_source) do |root, child_pid_path|
+      child_pid = nil
+      status, result, duration = run_cli(root)
+      child_pid = read_pid(child_pid_path)
+
+      assert_equal(0, status)
+      assert(result.fetch("successful"))
+      assert_operator(duration, :<, TEST_TIMEOUT)
+      assert_process_alive(child_pid)
+    ensure
+      stop_process(child_pid || read_pid_if_present(child_pid_path))
+    end
+  end
+
+  private
+
+  def with_example(source:)
+    Dir.mktmpdir("openai-examples-e2e-descendant-timeout-test") do |directory|
+      root = Pathname(directory)
+      child_pid_path = root.join("child.pid")
+      example_path = root.join("examples/example.rb")
+      example_path.dirname.mkpath
+      example_path.write(source.gsub("CHILD_PID_PATH", child_pid_path.to_s))
+      root.join("examples/e2e.yml").write(
+        YAML.dump(
+          "version" => 1,
+          "examples" => {
+            "examples/example.rb" => {"status" => "covered", "expected_output" => MARKER}
+          }
+        )
+      )
+
+      yield(root, child_pid_path)
+    end
+  end
+
+  def descendant_source(parent_sleep:, child_ignores_term: false)
+    child_source = child_ignores_term ? 'trap("TERM") { }; sleep 30' : "sleep 30"
+    source = <<~RUBY
+      # frozen_string_literal: true
+
+      require "rbconfig"
+
+      child = Process.spawn(RbConfig.ruby, "-e", #{child_source.dump})
+      File.write("CHILD_PID_PATH", child.to_s)
+      puts #{MARKER.dump}
+    RUBY
+    source << "sleep #{parent_sleep}\n" if parent_sleep
+    source
+  end
+
+  def detached_output_descendant_source
+    <<~RUBY
+      # frozen_string_literal: true
+
+      require "rbconfig"
+
+      child = Process.spawn(RbConfig.ruby, "-e", "sleep 30", out: File::NULL, err: File::NULL)
+      File.write("CHILD_PID_PATH", child.to_s)
+      puts #{MARKER.dump}
+    RUBY
+  end
+
+  def run_cli(root)
+    output = StringIO.new
+    error_output = StringIO.new
+    report_directory = root.join("artifacts")
+    cli = OpenAIExamplesE2E::CLI.new(root: root, output: output, error_output: error_output)
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    status = Timeout.timeout(MAXIMUM_DURATION + 2) do
+      cli.run(["--timeout", TEST_TIMEOUT.to_s, "--report-dir", report_directory.to_s])
+    end
+    duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    report = JSON.parse(report_directory.join("report.json").read)
+
+    [status, report.fetch("results").fetch(0), duration]
+  end
+
+  def read_pid(path)
+    Timeout.timeout(1) do
+      sleep 0.01 until path.exist?
+      Integer(path.read)
+    end
+  end
+
+  def read_pid_if_present(path)
+    Integer(path.read) if path&.exist?
+  rescue ArgumentError
+    nil
+  end
+
+  def assert_process_stopped(pid)
+    Timeout.timeout(2) do
+      sleep 0.01 while process_alive?(pid)
+    end
+  end
+
+  def assert_process_alive(pid)
+    assert(process_alive?(pid), "expected unrelated process #{pid} to remain alive")
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+
+  def stop_process(pid)
+    return unless pid && process_alive?(pid)
+
+    Process.kill("TERM", pid)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 0.25
+    sleep 0.01 while process_alive?(pid) && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+    Process.kill("KILL", pid) if process_alive?(pid)
+  rescue Errno::ESRCH
+    nil
+  end
+
+  def stop_process_group(pid)
+    Process.kill("TERM", -pid) if pid
+    Process.wait(pid) if pid
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  end
+end


### PR DESCRIPTION
## Problem

The contributor examples E2E runner advertised `--timeout` as a per-example bound, but it only signaled the immediate Ruby process before waiting without a deadline for stdout/stderr readers. If an example-spawned child inherited those pipes, report collection waited for that child to exit.

This is a deterministic contributor-tooling failure, not an SDK runtime request issue. It is not known whether the current examples routinely spawn descendants, and customer incidence is unmeasured.

## Contributor workflow

```ruby
status = OpenAIExamplesE2E::CLI
  .new(root: Pathname("/path/to/openai-ruby"))
  .run(["--timeout", "1"])
```

A safe synthetic example that demonstrates the inherited-pipe lifecycle:

```ruby
require "rbconfig"

Process.spawn(RbConfig.ruby, "-e", "sleep 6")
puts "synthetic child started"
sleep 10
```

Before this change, the one-second CLI timeout returned after 6.23s and reported a 6.23s example duration. After this change, execution and output collection share one monotonic deadline; POSIX cleanup signals only the invocation-owned process group, uses the existing two-second grace, closes only this invocation's pipes, and returns the existing timeout error.

## Change

- Spawn each POSIX example in its own process group and signal only that owned group on timeout.
- Apply one deadline to the immediate process and both output readers.
- Preserve the prior direct-child termination path on Windows while still bounding local pipe collection.
- Keep successful detached-output helpers untouched.
- Preserve output matching, truncation, redacted report fields, and existing exit/error semantics.

## Tests

- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/examples_e2e_descendant_timeout_test.rb` — 5 runs, 23 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/examples_e2e_test.rb` — 17 runs, 199 assertions.
- `mise exec ruby@4.0.6 -- bundle exec ruby test/scripts/examples_e2e_timeout_test.rb` — 8 runs, 51 assertions.
- `mise exec ruby@4.0.6 -- bundle exec rubocop scripts/examples-e2e.rb test/scripts/examples_e2e_descendant_timeout_test.rb` — clean.
- Full `rake test` rerun with mock: 1770 runs, 15222 assertions, 0 failures, 0 errors, 1 skip (seed 16245).

An earlier full-suite attempt at seed 2179 exposed an unrelated preexisting parallel Minitest stub race around `WorkloadIdentityAuth.stub(:new, ...)`; a bounded Queue-coordinated diagnostic reproduced the exact `__minitest_stub__new` collision on both the assigned base and this candidate. No auth or harness code is changed here.

## Review and scope

Six required fresh-context adversarial-review rounds ran; rounds 5 and 6 were consecutive clean rounds on unchanged code. Process ownership was reviewed explicitly: there is no arbitrary process discovery, guessed/global process-group cleanup, or secret-bearing diagnostic output. The diff is limited to the existing Executor lifecycle and one focused regression test.

Non-goals remain unchanged: no generic subprocess framework, dependencies, runner redesign, timeout-policy change, live API calls, manifest/CI/generated/budget changes, or SDK runtime API changes.
