### PR TITLE
fix: preserve documented file inputs on readback

### DIFF
--- a/lib/openai/internal/type/file_input.rb
+++ b/lib/openai/internal/type/file_input.rb
@@ -41,7 +41,7 @@ module OpenAI
         class << self
           # @api private
           #
-          # @param value [StringIO, String, Object]
+          # @param value [Pathname, StringIO, IO, String, OpenAI::FilePart, Object]
           #
           # @param state [Hash{Symbol=>Object}] .
           #
@@ -55,14 +55,14 @@ module OpenAI
           #
           #   @option state [Integer] :branched
           #
-          # @return [StringIO, Object]
+          # @return [Pathname, StringIO, IO, OpenAI::FilePart, Object]
           def coerce(value, state:)
             exactness = state.fetch(:exactness)
             case value
             in String
               exactness[:yes] += 1
               StringIO.new(value)
-            in StringIO
+            in Pathname | StringIO | IO | OpenAI::FilePart
               exactness[:yes] += 1
               value
             else

--- a/test/openai/file_input_readback_test.rb
+++ b/test/openai/file_input_readback_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+require_relative "test_helper"
+
+class OpenAI::Test::FileInputReadbackTest < Minitest::Test
+  def test_constructor_and_setter_read_back_documented_inputs
+    with_documented_inputs do |input|
+      params = OpenAI::FileCreateParams.new(file: input, purpose: :assistants)
+
+      assert_same(input, params.file)
+      assert_same(input, params.to_h.fetch(:file))
+
+      replacement = OpenAI::FileCreateParams.new(file: StringIO.new("initial"), purpose: :assistants)
+      replacement.file = input
+
+      assert_same(input, replacement.file)
+      assert_same(input, replacement.to_h.fetch(:file))
+    end
+  end
+
+  def test_string_readback_still_materializes_binary_string_io
+    state = OpenAI::Internal::Type::Converter.new_coerce_state
+    file = OpenAI::Internal::Type::Converter.coerce(
+      OpenAI::Internal::Type::FileInput,
+      "synthetic bytes",
+      state: state
+    )
+
+    assert_instance_of(StringIO, file)
+    assert_equal("synthetic bytes", file.string)
+  end
+
+  def test_invalid_input_still_raises_on_readback
+    params = OpenAI::FileCreateParams.new(file: Object.new, purpose: :assistants)
+
+    assert_raises(OpenAI::Errors::ConversionError) { params.file }
+  end
+
+  def test_readback_preserves_native_upload_dump_and_retry_eligibility
+    source = StringIO.new("synthetic bytes")
+    params = OpenAI::FileCreateParams.new(file: source, purpose: :assistants)
+
+    assert_same(source, params.file)
+
+    dumped, options = OpenAI::FileCreateParams.dump_request(params)
+    part = dumped.fetch(:file)
+
+    assert_instance_of(OpenAI::FilePart, part)
+    assert_same(source, part.content)
+    assert_equal("synthetic bytes", part.content.string)
+    refute_includes(options, :max_retries)
+
+    Dir.mktmpdir("openai-file-input-readback") do |dir|
+      path = File.join(dir, "synthetic.jsonl")
+      File.binwrite(path, "synthetic bytes")
+
+      File.open(path, "rb") do |file|
+        file.pos = 3
+        params = OpenAI::FileCreateParams.new(file: file, purpose: :assistants)
+
+        assert_same(file, params.file)
+        assert_equal(3, file.pos)
+        refute_predicate(file, :closed?)
+
+        dumped, options = OpenAI::FileCreateParams.dump_request(params)
+
+        assert_same(file, dumped.fetch(:file))
+        assert_equal(0, options.fetch(:max_retries))
+        assert_equal(3, file.pos)
+        refute_predicate(file, :closed?)
+      end
+    end
+  end
+
+  private def with_documented_inputs
+    Dir.mktmpdir("openai-file-input-readback") do |dir|
+      path = Pathname(File.join(dir, "synthetic.jsonl"))
+      File.binwrite(path, "synthetic bytes")
+      string_io = StringIO.new("synthetic bytes")
+      file_part = OpenAI::FilePart.new(StringIO.new("synthetic bytes"), filename: "synthetic.jsonl")
+
+      File.open(path, "rb") do |file|
+        [path, string_io, file, "synthetic bytes", file_part].each { yield(_1) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

FileInput already documents and recognizes Pathname, StringIO, IO, String, and
OpenAI::FilePart, but its readback coercion accepted only String and StringIO.
Reading a valid request parameter therefore raised a conversion error for
documented non-String file inputs.

This change makes the existing coercion boundary preserve Pathname, IO, and
OpenAI::FilePart by identity, alongside the existing StringIO behavior.
String response values still materialize as StringIO.

~~~ruby
params = OpenAI::FileCreateParams.new(
  file: Pathname("/synthetic/file.jsonl"),
  purpose: :assistants
)

params.file # => the same Pathname, without opening it
~~~

## Before / after

With safe synthetic values on the assigned base:

~~~text
before: Pathname => OpenAI::Errors::ConversionError
before: OpenAI::FilePart => OpenAI::Errors::ConversionError
before: StringIO => StringIO
after:  Pathname => same Pathname
after:  OpenAI::FilePart => same OpenAI::FilePart
after:  StringIO => same StringIO
~~~

Customer incidence is unmeasured; this is a deterministic failure in a
documented public request-model property path.

## Compatibility and scope

- Keeps request-model raw to_h storage intact.
- Does not consume, copy, close, or open caller file objects during readback.
- Keeps String-to-StringIO response coercion intact.
- Leaves FileInput.dump, multipart encoding, upload bytes, and IO retry
  eligibility unchanged.
- No public API, general model/accessor, filename, FilePart, transport,
  dependency, generated metadata, or budget changes.

## Verification

- Focused regression: 4 runs, 38 assertions, 0 failures, 0 errors.
- Raw-value contract: 9 runs, 39 assertions, 0 failures, 0 errors.
- Raw StringIO request behavior: 3 runs, 70 assertions, 0 failures, 0 errors.
- Internal upload utility: 64 runs, 296 assertions, 0 failures, 0 errors.
- Full suite: 1782 runs, 15296 assertions, 0 failures, 0 errors, 1 skip.
- rake lint passed; RuboCop inspected 2925 files with no offenses, Sorbet
  reported no errors, and 1287 RBS files validated.
- Explicit new-file rubyfmt --check and targeted RuboCop passed.
- Trusted fresh-main public custom-code budget check passed: 3449 / 4000
  custom lines, 551 lines headroom.
- Two consecutive adversarial rounds, each with two fresh independent read-only
  reviewers, had no supported unresolved in-scope blockers.
- Dedicated file/transport security review found no new reads, ownership,
  logging, upload, retry, or sensitive-data risk.
