### PR TITLE
fix: retry only proven unsent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,11 @@ The custom HTTP client owns connection pooling and lifecycle, must enforce
 `request.timeout`, and should raise `OpenAI::Errors::APIConnectionError` or
 `OpenAI::Errors::APITimeoutError` for retryable transport failures. Other
 exceptions propagate without an SDK retry. The SDK does not close an injected
-HTTP client.
+HTTP client. Connection failures are treated as potentially post-send by
+default, so non-idempotent requests are not retried automatically. When a
+transport can prove that no request bytes were sent, it may raise either error
+with `request_may_have_been_sent: false` to allow the SDK retry policy to
+retry a replayable request safely.
 
 The default `OpenAI::NetHTTPClient` implements this contract with pooled
 `Net::HTTP` connections. It accepts an optional block for native connection
@@ -1026,10 +1030,10 @@ Certain errors will be automatically retried 2 times by default, with a short ex
 Requests are automatically retried only when their bodies are replayable. For
 those requests, after transport execution begins, connection errors (for
 example, due to a network connectivity problem) and timeouts are retried by
-default only for idempotent HTTP methods or requests carrying a non-empty
-`Idempotency-Key` header. Failures while preparing a request or its
-authentication retain the configured retry behavior because no API request has
-been dispatched.
+default only when the transport proves that no request bytes were sent, for
+idempotent HTTP methods, or for requests carrying a non-empty
+`Idempotency-Key` header. Failures before transport execution retain the
+configured retry behavior because no request has been dispatched.
 408 Request Timeout, 409 Conflict, 429 Rate Limit, and >=500 Internal errors
 are retried by default regardless of the HTTP method.
 
@@ -1091,9 +1095,10 @@ openai.chat.completions.create(
 On timeout, `OpenAI::Errors::APITimeoutError` is raised.
 
 After transport execution begins, requests with replayable bodies that time out
-are retried by default only for idempotent HTTP methods or requests carrying a
-non-empty `Idempotency-Key` header. Preparation and authentication timeouts
-before dispatch retain the configured retry behavior.
+are retried by default only when the transport proves that no request bytes
+were sent, for idempotent HTTP methods, or for requests carrying a non-empty
+`Idempotency-Key` header. Timeouts before transport execution retain the
+configured retry behavior.
 
 ## Advanced concepts
 

--- a/lib/openai/auth/x509_token_exchange.rb
+++ b/lib/openai/auth/x509_token_exchange.rb
@@ -74,7 +74,13 @@ module OpenAI
 
         raise_error(response, body)
       rescue OpenAI::Errors::APIConnectionError => error
-        raise error.class.new(url: URI(TOKEN_URL)), cause: nil
+        raise(
+          error.class.new(
+            url: URI(TOKEN_URL),
+            request_may_have_been_sent: error.request_may_have_been_sent?
+          ),
+          cause: nil
+        )
       end
 
       private def remaining_timeout(deadline)

--- a/lib/openai/auth/x509_transport.rb
+++ b/lib/openai/auth/x509_transport.rb
@@ -116,21 +116,39 @@ module OpenAI
           native_response
 
         rescue OpenAI::Errors::APIConnectionError => error
-          raise error.class.new(url: sanitized_url(url)), cause: nil
+          raise(
+            error.class.new(
+              url: sanitized_url(url),
+              request_may_have_been_sent: error.request_may_have_been_sent?
+            ),
+            cause: nil
+          )
         end
 
         stream = Enumerator.new do |chunks|
           response.body.each { |chunk| chunks << chunk }
 
         rescue OpenAI::Errors::APIConnectionError => error
-          raise error.class.new(url: sanitized_url(url)), cause: nil
+          raise(
+            error.class.new(
+              url: sanitized_url(url),
+              request_may_have_been_sent: error.request_may_have_been_sent?
+            ),
+            cause: nil
+          )
         end
 
         body = OpenAI::Internal::Util.fused_enum(stream) do
           OpenAI::Internal::Util.close_fused!(response.body)
 
         rescue OpenAI::Errors::APIConnectionError => error
-          raise error.class.new(url: sanitized_url(url)), cause: nil
+          raise(
+            error.class.new(
+              url: sanitized_url(url),
+              request_may_have_been_sent: error.request_may_have_been_sent?
+            ),
+            cause: nil
+          )
         end
 
         OpenAI::HTTPClient::Response.new(status: response.status, headers: response.headers, body: body)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -399,14 +399,16 @@ module OpenAI
       rescue OpenAI::Errors::APIError => error
         status = error.status
         connection_failure = error.is_a?(OpenAI::Errors::APIConnectionError)
-        retryable_status = connection_failure ||
+        retryable_connection_failure = connection_failure &&
+          false.equal?(error.request_may_have_been_sent?)
+        retryable_status = retryable_connection_failure ||
           [408, 409, 429].include?(status) ||
           (status.is_a?(Integer) && (500..599).cover?(status))
         consumed_retries = attempts + previous_issuer_retries + retry_count
         unless x509_transport?(@requester) &&
             retryable_status &&
             consumed_retries < request.fetch(:x509_request_context).fetch(:auth_max_retries) &&
-            (connection_failure || self.class.should_retry?(status, headers: error.headers || {}))
+            (retryable_connection_failure || self.class.should_retry?(status, headers: error.headers || {}))
           raise
         end
 

--- a/lib/openai/errors.rb
+++ b/lib/openai/errors.rb
@@ -141,6 +141,15 @@ module OpenAI
       #
       #   @return [nil]
 
+      # Whether request bytes might have reached the peer before the transport
+      # failed. HTTP clients should only set this to `false` when they can
+      # prove that no request bytes were sent.
+      #
+      # @api private
+      #
+      # @return [Boolean]
+      def request_may_have_been_sent? = @request_may_have_been_sent
+
       # @api private
       #
       # @param url [URI::Generic]
@@ -150,6 +159,7 @@ module OpenAI
       # @param request [nil]
       # @param response [nil]
       # @param message [String, nil]
+      # @param request_may_have_been_sent [Boolean]
       def initialize(
         url:,
         status: nil,
@@ -157,9 +167,11 @@ module OpenAI
         body: nil,
         request: nil,
         response: nil,
-        message: "Connection error."
+        message: "Connection error.",
+        request_may_have_been_sent: true
       )
-        super
+        @request_may_have_been_sent = request_may_have_been_sent
+        super(url:, status:, headers:, body:, request:, response:, message:)
       end
     end
 
@@ -173,6 +185,7 @@ module OpenAI
       # @param request [nil]
       # @param response [nil]
       # @param message [String, nil]
+      # @param request_may_have_been_sent [Boolean]
       def initialize(
         url:,
         status: nil,
@@ -180,7 +193,8 @@ module OpenAI
         body: nil,
         request: nil,
         response: nil,
-        message: "Request timed out."
+        message: "Request timed out.",
+        request_may_have_been_sent: true
       )
         super
       end

--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -502,13 +502,14 @@ module OpenAI
           self.class.request_body_replayable?(request[:body])
         end
 
-        # A connection failure after dispatch has an unknown outcome: the peer
-        # may have committed the request before the response was lost. Retrying
+        # A connection failure has an unknown outcome unless the transport can
+        # prove that no request bytes were sent. Retrying an ambiguous failure
         # is only safe when the HTTP method itself is idempotent or the caller
         # supplied a stable idempotency key.
         #
         # @api private
-        private def request_retryable_after_connection_error?(request)
+        private def request_retryable_after_connection_error?(request, error:)
+          return true if false.equal?(error.request_may_have_been_sent?)
           return true if Net::HTTP::IDEMPOTENT_METHODS_.include?(request.fetch(:method).to_s.upcase)
 
           request.fetch(:headers).any? do |name, value|
@@ -710,7 +711,8 @@ module OpenAI
 
           if status.is_a?(OpenAI::Errors::APIConnectionError) &&
               (retry_count >= max_retries ||
-                (request_dispatched && !request_retryable_after_connection_error?(prepared_request)))
+                (request_dispatched &&
+                  !request_retryable_after_connection_error?(prepared_request, error: status)))
             raise status
           end
 

--- a/lib/openai/net_http_client.rb
+++ b/lib/openai/net_http_client.rb
@@ -244,6 +244,7 @@ module OpenAI
 
       req = nil
       finished = false
+      request_may_have_been_sent = false
 
       # rubocop:disable Metrics/BlockLength
       enum = Enumerator.new do |y|
@@ -285,6 +286,7 @@ module OpenAI
 
               calibrate_socket_timeout(conn, deadline)
               ::Kernel.catch(:jump) do
+                request_may_have_been_sent = true
                 conn.request(req) do |rsp|
                   y << [req, rsp]
                   ::Kernel.throw(:jump) if finished
@@ -313,9 +315,21 @@ module OpenAI
       rescue ConnectionConfigurationError => e
         raise e.original, cause: e.original.cause
       rescue Timeout::Error
-        raise OpenAI::Errors::APITimeoutError.new(url: url, request: req)
+        raise(
+          OpenAI::Errors::APITimeoutError.new(
+            url: url,
+            request: req,
+            request_may_have_been_sent: request_may_have_been_sent
+          )
+        )
       rescue *NETWORK_ERRORS
-        raise OpenAI::Errors::APIConnectionError.new(url: url, request: req)
+        raise(
+          OpenAI::Errors::APIConnectionError.new(
+            url: url,
+            request: req,
+            request_may_have_been_sent: request_may_have_been_sent
+          )
+        )
       end
       # rubocop:enable Metrics/BlockLength
 

--- a/rbi/openai/errors.rbi
+++ b/rbi/openai/errors.rbi
@@ -124,6 +124,11 @@ module OpenAI
       attr_accessor :type
 
       # @api private
+      sig { returns(T::Boolean) }
+      def request_may_have_been_sent?
+      end
+
+      # @api private
       sig do
         params(
           url: URI::Generic,
@@ -132,7 +137,8 @@ module OpenAI
           body: NilClass,
           request: NilClass,
           response: NilClass,
-          message: T.nilable(String)
+          message: T.nilable(String),
+          request_may_have_been_sent: T::Boolean
         )
           .returns(T.attached_class)
       end
@@ -143,7 +149,8 @@ module OpenAI
         body: nil,
         request: nil,
         response: nil,
-        message: "Connection error."
+        message: "Connection error.",
+        request_may_have_been_sent: true
       )
       end
     end
@@ -158,7 +165,8 @@ module OpenAI
           body: NilClass,
           request: NilClass,
           response: NilClass,
-          message: T.nilable(String)
+          message: T.nilable(String),
+          request_may_have_been_sent: T::Boolean
         )
           .returns(T.attached_class)
       end
@@ -169,7 +177,8 @@ module OpenAI
         body: nil,
         request: nil,
         response: nil,
-        message: "Request timed out."
+        message: "Request timed out.",
+        request_may_have_been_sent: true
       )
       end
     end

--- a/rbi/openai/internal/transport/base_client.rbi
+++ b/rbi/openai/internal/transport/base_client.rbi
@@ -268,11 +268,12 @@ module OpenAI
         # @api private
         sig do
           params(
-            request: OpenAI::Internal::Transport::BaseClient::RequestInput
+            request: OpenAI::Internal::Transport::BaseClient::RequestInput,
+            error: OpenAI::Errors::APIConnectionError
           )
             .returns(T::Boolean)
         end
-        private def request_retryable_after_connection_error?(request)
+        private def request_retryable_after_connection_error?(request, error:)
         end
 
         # @api private

--- a/sig/openai/errors.rbs
+++ b/sig/openai/errors.rbs
@@ -62,6 +62,9 @@ module OpenAI
     end
 
     class APIConnectionError < OpenAI::Errors::APIError
+      # @api private
+      def request_may_have_been_sent?: -> bool
+
       def initialize: (
         url: URI::Generic,
         ?status: nil,
@@ -69,7 +72,8 @@ module OpenAI
         ?body: nil,
         ?request: nil,
         ?response: nil,
-        ?message: String?
+        ?message: String?,
+        ?request_may_have_been_sent: bool
       ) -> void
     end
 
@@ -81,7 +85,8 @@ module OpenAI
         ?body: nil,
         ?request: nil,
         ?response: nil,
-        ?message: String?
+        ?message: String?,
+        ?request_may_have_been_sent: bool
       ) -> void
     end
 

--- a/sig/openai/internal/transport/base_client.rbs
+++ b/sig/openai/internal/transport/base_client.rbs
@@ -127,7 +127,8 @@ module OpenAI
         ) -> bool
 
         private def request_retryable_after_connection_error?: (
-          OpenAI::Internal::Transport::BaseClient::request_input request
+          OpenAI::Internal::Transport::BaseClient::request_input request,
+          error: OpenAI::Errors::APIConnectionError
         ) -> bool
 
         private def retry_delay: (

--- a/test/openai/auth/x509_client_test.rb
+++ b/test/openai/auth/x509_client_test.rb
@@ -517,7 +517,13 @@ class OpenAI::Test::X509ClientTest < Minitest::Test
         if request.url.host == "mtls.auth.openai.com"
           issuer_attempts += 1
           if issuer_attempts == 1
-            raise error_class.new(url: request.url, message: "fake-sensitive-network-secret")
+            raise(
+              error_class.new(
+                url: request.url,
+                message: "fake-sensitive-network-secret",
+                request_may_have_been_sent: false
+              )
+            )
           end
 
           x509_issuer_success
@@ -548,7 +554,7 @@ class OpenAI::Test::X509ClientTest < Minitest::Test
     end
   end
 
-  def test_x509_terminal_issuer_connection_failure_is_not_retried_again_by_api_transport
+  def test_x509_ambiguous_issuer_connection_failure_is_not_retried
     events = []
     client = OpenAI::Client.new(
       api_key: nil,
@@ -569,9 +575,8 @@ class OpenAI::Test::X509ClientTest < Minitest::Test
       assert_raises(OpenAI::Errors::APIConnectionError) { client.models.retrieve("fake-model") }
     end
 
-    assert_equal(2, attempts)
-    assert_equal(1, events.length)
-    assert_instance_of(OpenAI::Errors::APIConnectionError, events.fetch(0).error)
+    assert_equal(1, attempts)
+    assert_empty(events)
   end
 
   def test_x509_issuer_connection_retry_consumes_the_shared_api_retry_budget
@@ -591,7 +596,12 @@ class OpenAI::Test::X509ClientTest < Minitest::Test
       if request.url.host == "mtls.auth.openai.com"
         issuer_attempts += 1
         if issuer_attempts == 1
-          raise OpenAI::Errors::APIConnectionError.new(url: request.url)
+          raise(
+            OpenAI::Errors::APIConnectionError.new(
+              url: request.url,
+              request_may_have_been_sent: false
+            )
+          )
         end
 
         x509_issuer_success
@@ -627,7 +637,12 @@ class OpenAI::Test::X509ClientTest < Minitest::Test
     attempts = 0
     dispatch = lambda do |request|
       attempts += 1
-      raise OpenAI::Errors::APIConnectionError.new(url: request.url)
+      raise(
+        OpenAI::Errors::APIConnectionError.new(
+          url: request.url,
+          request_may_have_been_sent: false
+        )
+      )
     end
 
     @native.stub(:execute, dispatch) do

--- a/test/openai/http_client_test.rb
+++ b/test/openai/http_client_test.rb
@@ -30,14 +30,19 @@ class HTTPClientTest < Minitest::Test
       :write_timeout
     )
 
-    def initialize(use_ssl:, request_error: nil)
+    def initialize(use_ssl:, request_error: nil, start_error: nil)
       @use_ssl = use_ssl
       @request_error = request_error
+      @start_error = start_error
       @started = false
       @finished = false
     end
 
-    def start = (@started = true)
+    def start
+      raise @start_error if @start_error
+
+      @started = true
+    end
 
     def finish
       @started = false
@@ -488,6 +493,72 @@ class HTTPClientTest < Minitest::Test
     end
   end
 
+  def test_sdk_retries_non_idempotent_connection_errors_when_request_was_not_sent
+    [OpenAI::Errors::APIConnectionError, OpenAI::Errors::APITimeoutError].each do |error_class|
+      attempts = 0
+      http_client = StubHTTPClient.new do |request|
+        attempts += 1
+        if attempts == 1
+          raise error_class.new(url: request.url, request_may_have_been_sent: false)
+        end
+
+        OpenAI::HTTPClient::Response.new(
+          status: 200,
+          headers: {"content-type" => "application/json"},
+          body: "{\"ok\":true}"
+        )
+      end
+
+      client = OpenAI::Client.new(
+        api_key: "test-key",
+        http_client: http_client,
+        max_retries: 1,
+        initial_retry_delay: 0,
+        max_retry_delay: 0
+      )
+
+      response = client.request(method: :post, path: "probe", body: {value: "payload"})
+
+      assert_equal(true, response[:ok])
+      assert_equal(2, attempts)
+    end
+  end
+
+  def test_sdk_treats_non_false_sent_markers_as_ambiguous_connection_errors
+    false_like = Class
+      .new do
+        def ==(other) = other == false
+      end
+      .new
+
+    [nil, false_like].each do |marker|
+      attempts = 0
+      http_client = StubHTTPClient.new do |request|
+        attempts += 1
+        raise(
+          OpenAI::Errors::APIConnectionError.new(
+            url: request.url,
+            request_may_have_been_sent: marker
+          )
+        )
+      end
+
+      client = OpenAI::Client.new(
+        api_key: "test-key",
+        http_client: http_client,
+        max_retries: 1,
+        initial_retry_delay: 0,
+        max_retry_delay: 0
+      )
+
+      assert_raises(OpenAI::Errors::APIConnectionError) do
+        client.request(method: :post, path: "probe", body: {value: "payload"})
+      end
+
+      assert_equal(1, attempts)
+    end
+  end
+
   def test_sdk_retries_connection_errors_for_requests_with_an_idempotency_key
     attempts = 0
     http_client = StubHTTPClient.new do |request|
@@ -518,6 +589,29 @@ class HTTPClientTest < Minitest::Test
 
     assert_equal(true, response[:ok])
     assert_equal(2, attempts)
+  end
+
+  def test_net_http_client_marks_connection_start_failures_as_not_sent
+    connection = StubNetHTTP.new(use_ssl: true, start_error: SocketError.new("safe network probe"))
+    client_class = Class.new(OpenAI::NetHTTPClient) do
+      define_method(:connect) { |**| connection }
+      private(:connect)
+    end
+
+    http_client = client_class.new
+    request = OpenAI::HTTPClient::Request.new(
+      method: :post,
+      url: URI("https://example.com/v1/probe"),
+      headers: {},
+      body: "{\"value\":\"payload\"}",
+      timeout: 1
+    )
+
+    error = assert_raises(OpenAI::Errors::APIConnectionError) { http_client.execute(request) }
+
+    refute_predicate(error, :request_may_have_been_sent?)
+  ensure
+    http_client&.close
   end
 
   def test_sdk_follows_redirects_from_a_custom_http_client


### PR DESCRIPTION
## Summary
- preserve the conservative no-replay default for ambiguous non-idempotent POST failures
- let transports mark only provably unsent failures so replayable requests can retry safely
- propagate the certainty bit through X.509 sanitization and apply it to issuer retries
- document the retry contract and cover nil/false-like markers, Net::HTTP start failures, and X.509 behavior

## Tests
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/http_client_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/x509_client_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/x509_transport_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/x509_token_exchange_test.rb
- mise exec ruby@4.0.6 -- bundle exec rake lint

## Notes
- Full local rake test still depends on the repository's shared localhost mock service; the generated resource failures were connection errors to that unavailable service.
- This follows RFC 9110 idempotency guidance: ambiguous non-idempotent failures are not replayed automatically unless the operation is known safe.