### PR TITLE
fix: preserve file semantics for pathless multipart IO

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -554,11 +554,11 @@ module OpenAI
           in OpenAI::FilePart unless val.filename.nil?
             filename = escape_multipart_header_param(val.filename)
             y << "; filename=\"#{filename}\""
-            # `IO#to_path` is nil for a stream with no backing path, such as a pipe
-            # or a socket. Such a part is sent without a filename, which RFC 7578
-            # allows, rather than failing the whole request.
-          in Pathname | IO unless val.to_path.nil?
-            filename = escape_multipart_header_param(::File.basename(val.to_path))
+          in Pathname | IO
+            # Keep raw multipart IO consistent with FileInput.dump: pathless streams
+            # are still file parts and use the same stable fallback filename.
+            filename = val.to_path.nil? ? "upload" : ::File.basename(val.to_path)
+            filename = escape_multipart_header_param(filename)
             y << "; filename=\"#{filename}\""
           else
           end

--- a/test/openai/http_client_test.rb
+++ b/test/openai/http_client_test.rb
@@ -315,6 +315,39 @@ class HTTPClientTest < Minitest::Test
     assert_equal(2, attempts)
   end
 
+  def test_public_request_preserves_file_semantics_for_pathless_io
+    captured_body = nil
+    http_client = StubHTTPClient.new do |request|
+      captured_body = request.body.to_a.join
+      OpenAI::HTTPClient::Response.new(
+        status: 200,
+        headers: {"content-type" => "application/json"},
+        body: "{\"ok\":true}"
+      )
+    end
+    client = OpenAI::Client.new(api_key: "test-key", http_client: http_client)
+    reader, writer = IO.pipe
+    writer.write("piped-body")
+    writer.close
+
+    response = client.request(
+      method: :post,
+      path: "upload",
+      headers: {"content-type" => "multipart/form-data"},
+      body: {file: reader}
+    )
+
+    assert_equal(true, response[:ok])
+    assert_includes(
+      captured_body,
+      "Content-Disposition: form-data; name=\"file\"; filename=\"upload\""
+    )
+    assert_includes(captured_body, "piped-body")
+  ensure
+    reader&.close
+    writer&.close
+  end
+
   def test_sdk_reencodes_replayable_multipart_bodies_for_each_attempt
     requests = []
     http_client = StubHTTPClient.new do |request|

--- a/test/openai/http_client_test.rb
+++ b/test/openai/http_client_test.rb
@@ -325,6 +325,7 @@ class HTTPClientTest < Minitest::Test
         body: "{\"ok\":true}"
       )
     end
+
     client = OpenAI::Client.new(api_key: "test-key", http_client: http_client)
     reader, writer = IO.pipe
     writer.write("piped-body")

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -330,10 +330,7 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     assert_equal(sensitive_prefix.bytesize, file.pos)
   end
 
-  def test_multipart_pathless_io_is_sent_without_a_filename
-    # `IO#to_path` returns nil for a pipe or a socket, and `::File.basename(nil)`
-    # raised `TypeError: no implicit conversion of nil into String`, so uploading
-    # from a stream with no backing path failed before a request was made.
+  def test_multipart_pathless_io_uses_fallback_filename
     reader, writer = IO.pipe
     writer.write("piped-body")
     writer.close
@@ -344,8 +341,7 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     )
     body = stream.respond_to?(:read) ? stream.read : stream.to_a.join
 
-    assert_includes(body, "Content-Disposition: form-data; name=\"file\"")
-    refute_includes(body, "filename=")
+    assert_includes(body, "Content-Disposition: form-data; name=\"file\"; filename=\"upload\"")
     assert_includes(body, "piped-body")
   ensure
     reader&.close


### PR DESCRIPTION
## Summary

- give raw pathless multipart `IO` values the same `upload` fallback filename used by `FileInput.dump`
- preserve existing basenames for path-backed `IO` and `Pathname` values
- cover the behavior both at the multipart encoder boundary and through public `Client#request`

This keeps a pathless stream classified as a file part instead of a regular multipart form value.

Fixes #664.

## Validation

- `bundle _4.0.17_ exec ruby -Itest test/openai/internal/util_test.rb`
- `bundle _4.0.17_ exec ruby -Itest test/openai/http_client_test.rb`
- `bundle _4.0.17_ exec rubocop lib/openai/internal/util.rb test/openai/internal/util_test.rb test/openai/http_client_test.rb`
- `git diff --check`
