### PR TITLE
fix: match the multipart request content type case-insensitively

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -449,6 +449,8 @@ module OpenAI
       JSON_CONTENT = %r{\Aapplication/(?:[a-z0-9.-]+\+)?json[ \t]*(?:;|\z)}i
       # @type [Regexp]
       JSONL_CONTENT = %r{\Aapplication/(?:x-[nl]djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i
+      # @type [Regexp]
+      MULTIPART_CONTENT = %r{\Amultipart/form-data[ \t]*(?:;|\z)}i
 
       class << self
         # @api private
@@ -634,7 +636,7 @@ module OpenAI
             [headers, JSON.generate(body)]
           in [OpenAI::Internal::Util::JSONL_CONTENT, Enumerable] unless OpenAI::Internal::Type::FileInput === body
             [headers, body.lazy.map { "#{JSON.generate(_1)}\n" }]
-          in [%r{^multipart/form-data}, Hash | OpenAI::Internal::Type::FileInput]
+          in [OpenAI::Internal::Util::MULTIPART_CONTENT, Hash | OpenAI::Internal::Type::FileInput]
             boundary, strio = encode_multipart_streaming(body)
             headers = {**headers, "content-type" => "#{content_type}; boundary=#{boundary}"}
             [headers, strio]

--- a/rbi/openai/internal/util.rbi
+++ b/rbi/openai/internal/util.rbi
@@ -268,6 +268,7 @@ module OpenAI
         %r{\Aapplication/(?:x-[nl]djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i,
         Regexp
       )
+      MULTIPART_CONTENT = T.let(%r{\Amultipart/form-data[ \t]*(?:;|\z)}i, Regexp)
 
       class << self
         # @api private

--- a/sig/openai/internal/util.rbs
+++ b/sig/openai/internal/util.rbs
@@ -93,6 +93,7 @@ module OpenAI
 
       JSON_CONTENT: Regexp
       JSONL_CONTENT: Regexp
+      MULTIPART_CONTENT: Regexp
 
       def encode_query_params: (
         ::Hash[Symbol, top] query

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -364,7 +364,7 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
       body = stream.respond_to?(:read) ? stream.read : stream.to_a.join
 
       assert_match(/\Amultipart\/form-data; boundary=/i, headers.fetch("content-type"), content_type)
-      assert_includes(body, %{filename="a.txt"}, content_type)
+      assert_includes(body, "filename=\"a.txt\"", content_type)
     end
   end
 

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -352,6 +352,34 @@ class OpenAI::Test::UtilFormDataEncodingTest < Minitest::Test
     writer&.close
   end
 
+  def test_multipart_content_type_matching_ignores_case
+    # Media type names are case-insensitive, and the sibling patterns in the same
+    # `case` (JSON_CONTENT, JSONL_CONTENT) already ignore case. Matching only the
+    # lowercase spelling left the body unencoded and the boundary unset, so the
+    # request went out as an inspected Hash rather than a multipart payload.
+    file = OpenAI::FilePart.new(StringIO.new("x"), filename: "a.txt")
+
+    ["multipart/form-data", "Multipart/Form-Data", "MULTIPART/FORM-DATA"].each do |content_type|
+      headers, stream = OpenAI::Internal::Util.encode_content({"content-type" => content_type}, {file: file})
+      body = stream.respond_to?(:read) ? stream.read : stream.to_a.join
+
+      assert_match(/\Amultipart\/form-data; boundary=/i, headers.fetch("content-type"), content_type)
+      assert_includes(body, %{filename="a.txt"}, content_type)
+    end
+  end
+
+  def test_multipart_content_type_requires_a_full_media_type
+    # The name has to end at a parameter delimiter or the end of the header, so a
+    # longer media type that merely starts with it is not multipart.
+    file = OpenAI::FilePart.new(StringIO.new("x"), filename: "a.txt")
+
+    ["multipart/form-dataX", "multipart/mixed"].each do |content_type|
+      headers, = OpenAI::Internal::Util.encode_content({"content-type" => content_type}, {file: file})
+
+      refute_includes(headers.fetch("content-type"), "boundary", content_type)
+    end
+  end
+
   def test_multipart_filename_quoting
     file = OpenAI::FilePart.new(StringIO.new("x"), filename: "a \"b\"\r\nEvil: 1.md")
     _headers, stream = OpenAI::Internal::Util.encode_content(


### PR DESCRIPTION
## Problem

`encode_content` dispatches multipart bodies on an inline pattern, the only one in that `case` that is not a named, anchored, case-insensitive constant:

https://github.com/openai/openai-ruby/blob/a63eda82/lib/openai/internal/util.rb#L637

Its siblings a few lines above are both `%r{\A...[ \t]*(?:;|\z)}i`:

```ruby
JSON_CONTENT  = %r{\Aapplication/(?:[a-z0-9.-]+\+)?json[ \t]*(?:;|\z)}i
JSONL_CONTENT = %r{\Aapplication/(?:x-[nl]djson|(?:x-)?jsonl)[ \t]*(?:;|\z)}i
```

Media type names are case-insensitive, so `Multipart/Form-Data` names the same type. It did not match:

```ruby
file = OpenAI::FilePart.new(StringIO.new("x"), filename: "a.txt")

OpenAI::Internal::Util.encode_content({"content-type" => "Multipart/Form-Data"}, {file: file})
# => ["Multipart/Form-Data", {file: #<OpenAI::FilePart:0x...>}]
```

The body falls through to the pass-through branch, so no boundary is added and the parts are never encoded. Nothing raises: the request goes out with a content type promising multipart and a body that is the `Hash`'s `to_s`.

The unanchored prefix match was wrong in the other direction too, since `multipart/form-dataX` matched and was encoded as multipart with a boundary appended to that media type.

## Fix

Add `MULTIPART_CONTENT` next to the other two, with the same shape, and match against it:

```ruby
MULTIPART_CONTENT = %r{\Amultipart/form-data[ \t]*(?:;|\z)}i
```

| `content-type` | before | after |
| --- | --- | --- |
| `multipart/form-data` | encoded | encoded |
| `Multipart/Form-Data` | **not encoded** | encoded |
| `MULTIPART/FORM-DATA` | **not encoded** | encoded |
| `multipart/form-data; boundary=zzz` | encoded | encoded |
| `multipart/form-dataX` | **encoded** | not encoded |
| `multipart/mixed` | not encoded | not encoded |

`sig` and `rbi` declare the new constant alongside the existing two.

## Tests

`test_multipart_content_type_matching_ignores_case` asserts the boundary is set and the part is written for all three spellings. `test_multipart_content_type_requires_a_full_media_type` covers the over-match. Both fail on `main`.
