### PR TITLE
fix: coerce Integer strings as decimal

### DIFF
--- a/lib/openai/internal/type/converter.rb
+++ b/lib/openai/internal/type/converter.rb
@@ -211,7 +211,12 @@ module OpenAI
                   return value
                 else
                   Kernel.then do
-                    return Integer(value).tap { exactness[:maybe] += 1 }
+                    # Wire text is decimal. `Integer(str)` would read a leading `0` as
+                    # octal and `0x`/`0b` as other bases, so "010" became 8 and "08"
+                    # failed outright. Non-strings keep the unbased call, which accepts
+                    # Float and other numerics that reject an explicit base.
+                    coerced = value.is_a?(String) ? Integer(value, 10) : Integer(value)
+                    return coerced.tap { exactness[:maybe] += 1 }
                   rescue ArgumentError, TypeError => e
                     state[:error] = e
                   end

--- a/test/openai/internal/type/base_model_test.rb
+++ b/test/openai/internal/type/base_model_test.rb
@@ -106,6 +106,44 @@ class OpenAI::Test::PrimitiveModelTest < Minitest::Test
     end
   end
 
+  def test_coerce_integer_strings_are_decimal
+    # `Integer(str)` infers a base from the literal's prefix, so a zero-padded
+    # decimal was misread as octal and a base-prefixed literal was accepted.
+    # Values on the wire are decimal, so neither is right.
+    cases = {
+      "10" => [{maybe: 1}, 10],
+      "010" => [{maybe: 1}, 10],
+      "08" => [{maybe: 1}, 8],
+      "007" => [{maybe: 1}, 7],
+      "-010" => [{maybe: 1}, -10],
+      "0x1f" => [{no: 1}, "0x1f"],
+      "0b11" => [{no: 1}, "0b11"],
+      "one" => [{no: 1}, "one"]
+    }
+
+    cases.each do |input, (exactness, expect)|
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+      coerced = OpenAI::Internal::Type::Converter.coerce(Integer, input, state: state)
+
+      assert_equal(expect, coerced, input)
+      assert_equal(exactness, state.fetch(:exactness).filter { _2.nonzero? }.to_h, input)
+    end
+  end
+
+  def test_coerce_integer_keeps_non_string_conversions
+    # An explicit base is only valid for strings, so numerics have to keep the
+    # unbased call and its truncation.
+    cases = {1 => [{yes: 1}, 1], 1.0 => [{maybe: 1}, 1], 3.7 => [{maybe: 1}, 3], -3.7 => [{maybe: 1}, -3]}
+
+    cases.each do |input, (exactness, expect)|
+      state = OpenAI::Internal::Type::Converter.new_coerce_state
+      coerced = OpenAI::Internal::Type::Converter.coerce(Integer, input, state: state)
+
+      assert_equal(expect, coerced, input.to_s)
+      assert_equal(exactness, state.fetch(:exactness).filter { _2.nonzero? }.to_h, input.to_s)
+    end
+  end
+
   def test_coerce_errors
     cases = {
       [Integer, "one"] => ArgumentError,


### PR DESCRIPTION
## Problem

`Converter.coerce` turns a string into an `Integer` with `Integer(value)`:

https://github.com/openai/openai-ruby/blob/a63eda82/lib/openai/internal/type/converter.rb#L214

`Integer(str)` infers the base from the literal's prefix. Text arriving in a payload is decimal, so the inference is wrong in both directions:

```ruby
C = OpenAI::Internal::Type::Converter

C.coerce(Integer, "010")   # => 8      (read as octal)
C.coerce(Integer, "08")    # => "08"   (invalid octal; exactness :no, string kept)
C.coerce(Integer, "09")    # => "09"
C.coerce(Integer, "0x1f")  # => 31     (accepted as hex)
C.coerce(Integer, "0b11")  # => 3
```

Zero-padded numeric strings are ordinary in API payloads. The failure is silent in both modes: either the value is quietly wrong, or the field keeps its string and records an exactness of `no` rather than raising where a caller would see it.

## Fix

Pass an explicit base for strings:

```ruby
coerced = value.is_a?(String) ? Integer(value, 10) : Integer(value)
```

Non-strings keep the unbased call, because `Integer` raises `base specified for non string value` when given one. That preserves `Integer(3.7) # => 3`, which the coercion relies on.

| input | before | after |
| --- | --- | --- |
| `"10"` | `10` | `10` |
| `"010"` | `8` | `10` |
| `"08"` | `"08"` (no match) | `8` |
| `"007"` | `7` | `7` |
| `"-010"` | `-8` | `-10` |
| `"0x1f"` | `31` | `"0x1f"` (no match) |
| `"0b11"` | `3` | `"0b11"` (no match) |
| `3.7` | `3` | `3` |

This is the same defect [#624](https://github.com/openai/openai-ruby/pull/624) fixed for the SSE `retry` field, here in the generic coercion path that every `Integer`-typed model field goes through.

`Float` is deliberately left alone. It has no base parameter, so restricting `Float("0x1f") # => 31.0` would need a format guard rather than a one-argument change, and that is a larger behavior question best kept separate.

## Tests

`test_coerce_integer_strings_are_decimal` covers zero-padded, negative, and base-prefixed strings with their expected exactness. `test_coerce_integer_keeps_non_string_conversions` pins the `Float` truncation that the `is_a?(String)` guard protects. The first fails on `main`.
