### PR TITLE
fix: honor custom idempotency headers for retries

### DIFF
--- a/lib/openai/internal/transport/base_client.rb
+++ b/lib/openai/internal/transport/base_client.rb
@@ -512,8 +512,9 @@ module OpenAI
           return true if false.equal?(error.request_may_have_been_sent?)
           return true if Net::HTTP::IDEMPOTENT_METHODS_.include?(request.fetch(:method).to_s.upcase)
 
+          idempotency_header = @idempotency_header || "idempotency-key"
           request.fetch(:headers).any? do |name, value|
-            name.to_s.casecmp?("idempotency-key") && !value.to_s.empty?
+            name.to_s.casecmp?(idempotency_header) && !value.to_s.empty?
           end
         end
 

--- a/test/openai/internal/transport/base_client_retry_test.rb
+++ b/test/openai/internal/transport/base_client_retry_test.rb
@@ -9,6 +9,18 @@ class OpenAI::Test::BaseClientRetryTest < Minitest::Test
     end
   end
 
+  class CustomIdempotencyClient < OpenAI::Internal::Transport::BaseClient
+    def initialize(**kwargs)
+      super(
+        base_url: "https://example.test/v1",
+        idempotency_header: "x-request-key",
+        **kwargs
+      )
+    end
+
+    private def auth_headers(**_context) = {}
+  end
+
   def setup
     super
     @client = RetryClient.new(api_key: "test-key")
@@ -139,5 +151,44 @@ class OpenAI::Test::BaseClientRetryTest < Minitest::Test
     assert_equal(1, retry_events.length)
     assert_equal(0.5, retry_events.fetch(0).delay)
     assert_equal(429, retry_events.fetch(0).status)
+  end
+
+  def test_custom_idempotency_header_makes_connection_error_retry_safe
+    attempts = 0
+    successful = OpenAI::HTTPClient::Response.new(
+      status: 200,
+      headers: {"content-type" => "application/json"},
+      body: "{\"ok\":true}"
+    )
+    http_client = Minitest::Mock.new(OpenAI::HTTPClient.new)
+    http_client.expect(:execute, nil) do |request|
+      attempts += 1
+      assert_equal("stable-operation", request.headers.fetch("x-request-key"))
+      raise OpenAI::Errors::APIConnectionError.new(url: request.url)
+    end
+
+    http_client.expect(:execute, successful) do |request|
+      attempts += 1
+      assert_equal("stable-operation", request.headers.fetch("x-request-key"))
+      true
+    end
+
+    client = CustomIdempotencyClient.new(
+      http_client: http_client,
+      max_retries: 1,
+      initial_retry_delay: 0,
+      max_retry_delay: 0
+    )
+
+    response = client.request(
+      method: :post,
+      path: "probe",
+      body: {value: "payload"},
+      options: {idempotency_key: "stable-operation"}
+    )
+
+    assert_mock(http_client)
+    assert_equal(true, response[:ok])
+    assert_equal(2, attempts)
   end
 end


### PR DESCRIPTION
Summary:
- use the configured idempotency header when deciding whether an ambiguous connection error is safe to retry
- preserve the existing idempotency-key fallback when no custom header is configured
- add focused coverage for a POST retry with a stable custom header

Tests:
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/transport/base_client_retry_test.rb
- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/client_test.rb
- mise exec ruby@4.0.6 -- bundle exec rubocop lib/openai/internal/transport/base_client.rb test/openai/internal/transport/base_client_retry_test.rb

Closes #671