### PR TITLE
fix: handle non-object OAuth error bodies

### DIFF
--- a/lib/openai/errors.rb
+++ b/lib/openai/errors.rb
@@ -554,10 +554,11 @@ module OpenAI
       attr_reader :error_code
 
       def initialize(status:, body:, headers:)
-        @error_code = OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::OAuthErrorCode, body&.dig(:error))
+        error = OpenAI::Internal::Util.dig(body, :error)
+        @error_code = OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::OAuthErrorCode, error)
 
-        message = if body&.dig(:error_description)
-          body[:error_description]
+        message = if (error_description = OpenAI::Internal::Util.dig(body, :error_description))
+          error_description
         elsif @error_code
           @error_code
         else

--- a/test/openai/auth/workload_identity_error_types_test.rb
+++ b/test/openai/auth/workload_identity_error_types_test.rb
@@ -64,6 +64,33 @@ class OpenAI::Test::WorkloadIdentityErrorTypesTest < Minitest::Test
     assert_not_requested(:get, "https://api.openai.com/v1/models")
   end
 
+  def test_public_models_request_preserves_oauth_error_for_non_object_json_body
+    stub_request(:post, "https://auth.openai.com/oauth/token")
+      .to_return(
+        status: 401,
+        headers: {"Content-Type" => "application/json"},
+        body: JSON.generate("invalid_client")
+      )
+
+    Tempfile.create("synthetic-k8s-token") do |token_file|
+      token_file.write("synthetic-subject-token")
+      token_file.flush
+      provider = OpenAI::Auth::SubjectTokenProviders::K8sServiceAccountTokenProvider.new(token_path: token_file.path)
+
+      error = assert_raises(OpenAI::Errors::OAuthError) do
+        workload_identity_client(provider).models.list
+      end
+
+      assert_equal(401, error.status)
+      assert_equal("OAuth2 authentication error", error.message)
+      assert_nil(error.error_code)
+      assert_equal("invalid_client", error.body)
+    end
+
+    assert_requested(:post, "https://auth.openai.com/oauth/token", times: 1)
+    assert_not_requested(:get, "https://api.openai.com/v1/models")
+  end
+
   def test_shipped_rbi_types_error_rescues_and_metadata
     stdout, stderr, status = sorbet_typecheck(sorbet_source)
 


### PR DESCRIPTION
## Summary\n- handle valid non-object JSON OAuth error bodies without raising NoMethodError\n- preserve existing OAuth error code, description, and default-message behavior\n- add public workload-identity regression coverage for a scalar JSON token error body\n\nFixes #672\n\n## Tests\n- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/auth/workload_identity_error_types_test.rb\n- mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/errors_test.rb\n- mise exec ruby@4.0.6 -- bundle exec rubocop lib/openai/errors.rb test/openai/auth/workload_identity_error_types_test.rb\n- git diff --check 821d9b3f018040a3a946f714e120f009541c9743\n\n## Review\n- completed two consecutive clean adversarial-review rounds with two fresh read-only reviewers per round\n- completed focused security review of the authentication error path; no logging, credential exposure, coercion, or request-flow changes