### PR TITLE
fix: preserve bare CR SSE line boundaries

### DIFF
--- a/lib/openai/internal/util.rb
+++ b/lib/openai/internal/util.rb
@@ -896,7 +896,7 @@ module OpenAI
                 in ["\r", nil]
                   cr_seen = match.end(1)
                   next
-                in ["\r" | "\r\n", Integer]
+                in [terminator, Integer] if terminator != "\n" || match.begin(1) != cr_seen
                   line = buffer.slice!(..(cr_seen.pred))
                   line.force_encoding(encoding) unless encoding.nil?
                   y << line

--- a/test/openai/internal/util_test.rb
+++ b/test/openai/internal/util_test.rb
@@ -982,7 +982,11 @@ class OpenAI::Test::UtilSseTest < Minitest::Test
       %W[\r\r \r] => %W[\r \r \r],
       %W[\r \n] => %W[\r\n],
       %W[\r\r\n] => %W[\r \r\n],
-      %W[\n\r] => %W[\n \r]
+      %W[\n\r] => %W[\n \r],
+      ["A\rB\n"] => ["A\r", "B\n"],
+      ["A\r", "B\n"] => ["A\r", "B\n"],
+      ["A\rB", "\n"] => ["A\r", "B\n"],
+      ["A\r", "\nB\n"] => ["A\r\n", "B\n"]
     }
     cases.each do |enum, expected|
       lines = OpenAI::Internal::Util.decode_lines(enum)


### PR DESCRIPTION
## Summary
- preserve a pending bare CR boundary before a later LF terminator in `decode_lines`
- keep adjacent CRLF, including CRLF split across chunks, as a single terminator
- add focused regression cases for the reported input and chunk boundaries

## Test plan
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/util_test.rb --name '/test_(decode_lines|mixed_decode_lines)$/'`
- `mise exec ruby@4.0.6 -- bundle exec ruby -Itest test/openai/internal/util_test.rb`
- `mise exec ruby@4.0.6 -- bundle exec rake lint:rubocop`
- `git diff --check 821d9b3f018040a3a946f714e120f009541c9743`

## Review
- adversarial review converged after two consecutive clean rounds, each with two fresh independent reviewers
- dedicated SSE parsing safety review found no new limits, logging, dependency, API, buffering-growth, or payload-handling risk

Fixes #670