### PR TITLE
fix: avoid unused Responses stream snapshot copies

### DIFF
--- a/lib/openai/helpers/streaming/response_stream.rb
+++ b/lib/openai/helpers/streaming/response_stream.rb
@@ -19,18 +19,26 @@ module OpenAI
         end
 
         def until_done
-          each { |_event| next }
+          text.each { |_delta| nil }
           self
         end
 
         def text
           OpenAI::Internal::Util.chain_fused(@iterator) do |yielder|
+            @text_only = true
             @iterator.each do |event|
+              # Restore normal event snapshots while caller code is running.
+              @text_only = false
               case event
               when OpenAI::Models::Responses::ResponseTextDeltaEvent
                 yielder << event.delta
               end
+
+              @text_only = true
             end
+
+          ensure
+            @text_only = false
           end
         end
 
@@ -63,7 +71,7 @@ module OpenAI
         def iterator
           @iterator ||= OpenAI::Internal::Util.chain_fused(@raw_stream) do |y|
             @raw_stream.each do |raw_event|
-              events_to_yield = @state.handle_event(raw_event)
+              events_to_yield = @state.handle_event(raw_event, text_only: @text_only == true)
               events_to_yield.each do |event|
                 y << event if after_starting_event?(event)
               end
@@ -87,9 +95,10 @@ module OpenAI
           @completed_response = nil
           @text_format = text_format
           @resumed = !starting_after.nil?
+          @unexposed_buffers = {}.compare_by_identity
         end
 
-        def handle_event(event)
+        def handle_event(event, text_only: false)
           return [event] if event.is_a?(UnknownStreamEvent)
 
           @current_snapshot = accumulate_event(
@@ -101,6 +110,8 @@ module OpenAI
 
           case event
           when OpenAI::Models::Responses::ResponseTextDeltaEvent
+            return [event] if text_only
+
             snapshot = nil
             if @current_snapshot
               output = @current_snapshot.output[event.output_index]
@@ -109,6 +120,8 @@ module OpenAI
                 snapshot = content.text if content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
               end
             end
+
+            @unexposed_buffers.delete(snapshot)
 
             # A server-directed resumed stream or an unknown future snapshot value
             # has no complete prefix from which to build a truthful snapshot.
@@ -141,6 +154,8 @@ module OpenAI
               )
 
           when OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
+            return [event] if text_only
+
             snapshot = nil
             if @current_snapshot
               output = @current_snapshot.output[event.output_index]
@@ -148,6 +163,8 @@ module OpenAI
                 snapshot = output.arguments
               end
             end
+
+            @unexposed_buffers.delete(snapshot)
 
             # See the text-delta branch above: a partial server resume or an
             # unknown future output item has no truthful accumulated prefix.
@@ -206,7 +223,7 @@ module OpenAI
             if output.is_a?(OpenAI::Models::Responses::ResponseOutputMessage)
               content = output.content[event.content_index]
               if content.is_a?(OpenAI::Models::Responses::ResponseOutputText)
-                content.text += event.delta
+                content.text = append_delta(content.text, event.delta)
                 output.content[event.content_index] = content
                 current_snapshot.output[event.output_index] = output
               end
@@ -215,7 +232,7 @@ module OpenAI
           when OpenAI::Models::Responses::ResponseFunctionCallArgumentsDeltaEvent
             output = current_snapshot.output[event.output_index]
             if output.is_a?(OpenAI::Models::Responses::ResponseFunctionToolCall)
-              output.arguments = (output.arguments || "") + event.delta
+              output.arguments = append_delta(output.arguments || "", event.delta)
               current_snapshot.output[event.output_index] = output
             end
 
@@ -227,6 +244,16 @@ module OpenAI
         end
 
         private
+
+        # Reuse a buffer only until it becomes a caller-visible snapshot. The
+        # first append also isolates strings belonging to incoming wire events.
+        def append_delta(value, delta)
+          return value << delta if @unexposed_buffers.key?(value)
+
+          buffer = value + delta
+          @unexposed_buffers[buffer] = true
+          buffer
+        end
 
         # Materialize fresh containers before snapshot accumulation mutates them.
         # Coercing an already-typed model returns it unchanged, so first use the

--- a/rbi/openai/helpers/streaming/response_stream.rbi
+++ b/rbi/openai/helpers/streaming/response_stream.rbi
@@ -82,8 +82,8 @@ module OpenAI
         def initialize(text_format:, starting_after: nil)
         end
 
-        sig { params(event: T.untyped).returns(T::Array[T.untyped]) }
-        def handle_event(event)
+        sig { params(event: T.untyped, text_only: T::Boolean).returns(T::Array[T.untyped]) }
+        def handle_event(event, text_only: false)
         end
 
         sig do
@@ -97,6 +97,10 @@ module OpenAI
         end
 
         private
+
+        sig { params(value: String, delta: String).returns(String) }
+        def append_delta(value, delta)
+        end
 
         sig { params(text: T.nilable(String)).returns(T.untyped) }
         def parse_structured_text(text)

--- a/test/openai/helpers/response_stream_isolation_test.rb
+++ b/test/openai/helpers/response_stream_isolation_test.rb
@@ -194,7 +194,138 @@ class OpenAI::Test::ResponseStreamIsolationTest < Minitest::Test
     assert_nil(structured_done.parsed)
   end
 
+  def test_text_consumption_does_not_copy_each_accumulated_prefix
+    events = repeated_delta_events
+    stub_stream(events)
+    stream = @client.responses.stream(model: "test", input: "synthetic")
+    text = +""
+
+    copied_bytes = copied_snapshot_bytes do
+      stream.text.each { |delta| text << delta }
+    end
+
+    assert_equal("x" * 200_000, text)
+    assert_equal(text, stream.get_output_text)
+    assert_equal("y" * 200_000, stream.get_final_response.output.fetch(1).arguments)
+    assert_operator(copied_bytes, :<, 2_000_000)
+  ensure
+    stream&.close
+  end
+
+  def test_until_done_does_not_copy_each_accumulated_prefix
+    stub_stream(repeated_delta_events)
+    stream = @client.responses.stream(model: "test", input: "synthetic")
+
+    copied_bytes = copied_snapshot_bytes { assert_same(stream, stream.until_done) }
+
+    assert_equal("x" * 200_000, stream.get_output_text)
+    assert_equal("y" * 200_000, stream.get_final_response.output.fetch(1).arguments)
+    assert_operator(copied_bytes, :<, 2_000_000)
+  ensure
+    stream&.close
+  end
+
+  def test_unconsumed_text_enumerator_preserves_event_snapshots
+    stub_stream(repeated_delta_events(count: 3))
+    stream = @client.responses.stream(model: "test", input: "synthetic")
+    stream.text
+
+    events = stream.to_a
+    text_events = events.grep(OpenAI::Streaming::ResponseTextDeltaEvent)
+    arguments_events = events.grep(OpenAI::Streaming::ResponseFunctionCallArgumentsDeltaEvent)
+
+    assert_equal([100, 200, 300], text_events.map { |event| event.snapshot.length })
+    assert_equal([100, 200, 300], arguments_events.map { |event| event.snapshot.length })
+    assert_equal("x" * 300, stream.get_output_text)
+  ensure
+    stream&.close
+  end
+
+  def test_snapshots_stay_isolated_when_consumption_changes
+    events = repeated_delta_events(count: 4).map { |event| coerce_event(event) }
+    state = OpenAI::Helpers::Streaming::ResponseStreamState.new(text_format: nil)
+    created = events.shift
+    state.handle_event(created)
+
+    first_text = state.handle_event(events.shift).fetch(0)
+    first_arguments = state.handle_event(events.shift).fetch(0)
+    4.times { state.handle_event(events.shift, text_only: true) }
+    last_text = state.handle_event(events.shift).fetch(0)
+    last_arguments = state.handle_event(events.shift).fetch(0)
+
+    assert_equal("x" * 100, first_text.snapshot)
+    assert_equal("y" * 100, first_arguments.snapshot)
+    assert_equal("x" * 400, last_text.snapshot)
+    assert_equal("y" * 400, last_arguments.snapshot)
+    assert_equal("", created.response.output.fetch(0).content.fetch(0).text)
+    assert_equal("", created.response.output.fetch(1).arguments)
+  end
+
   private
+
+  # Count materialized String results in the accumulator, not elapsed time or
+  # process-wide allocations. The bound allows linear growth but catches full
+  # prefix copies for these synthetic text and argument deltas.
+  def copied_snapshot_bytes
+    bytes = 0
+    accumulator = File.expand_path("../../../lib/openai/helpers/streaming/response_stream.rb", __dir__)
+    trace = TracePoint.new(:c_return) do |event|
+      next unless event.defined_class == String
+      next unless [:+, :dup, :clone].include?(event.method_id)
+      next unless File.expand_path(event.path) == accumulator
+
+      bytes += event.return_value.bytesize
+    end
+
+    trace.enable(target_thread: Thread.current) { yield }
+    bytes
+  ensure
+    trace&.disable
+  end
+
+  def repeated_delta_events(count: 2000)
+    events = [
+      {
+        type: "response.created",
+        sequence_number: 0,
+        response: response(output: [message_item(content: [part]), function_call])
+      }
+    ]
+    count.times do |index|
+      events <<
+        {
+          type: "response.output_text.delta",
+          sequence_number: (index * 2) + 1,
+          item_id: "msg_synthetic",
+          output_index: 0,
+          content_index: 0,
+          delta: "x" * 100,
+          logprobs: []
+        }
+      events <<
+        {
+          type: "response.function_call_arguments.delta",
+          sequence_number: (index * 2) + 2,
+          item_id: "fc_synthetic",
+          output_index: 1,
+          delta: "y" * 100
+        }
+    end
+
+    events <<
+      {
+        type: "response.completed",
+        sequence_number: (count * 2) + 1,
+        response: response(
+          status: "completed",
+          output: [
+            message_item(status: "completed", content: [part(text: "x" * count * 100)]),
+            function_call(arguments: "y" * count * 100)
+          ]
+        )
+      }
+    events
+  end
 
   def coerce_event(event)
     OpenAI::Internal::Type::Converter.coerce(OpenAI::Models::Responses::ResponseStreamEvent, event)


### PR DESCRIPTION
## Summary

Responses streams built full text and function-argument snapshots for every delta even when callers consumed only .text or requested the final response. These paths now reuse private accumulation buffers and skip unused snapshot construction. A buffer stops being reused as soon as an event exposes it, preserving retained snapshots and wire events.

No public options, model shapes, payload limits, or transport behavior change. Normal .each consumption still materializes the full per-event snapshots that callers request; this optimization does not remove that inherent cost.

## Validation

- Added deterministic public-entrypoint regressions for interleaved text/tool deltas and final-response consumption, plus retained-snapshot and consumption-mode coverage. The performance regressions fail on the original implementation and pass with this change.
- Helper suites, unknown/resumed Responses events, and Responses streaming: **223 tests, 1,405 assertions passed**.
- bundle exec rake lint: passed (RuboCop, formatting, directives, Sorbet and RBS validation).
- Two independent reviewers per round; two consecutive clean adversarial review rounds.

The change stays inside the handwritten Responses helper, its RBI declaration, and focused tests. Buffer ownership was reviewed for input/event aliasing and cleanup; no new parsing, network, authentication, logging, or dependency behavior is introduced.
