### PR TITLE
fix: restore conflict-free exported RBIs for Tapioca

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem "minitest-hooks", ">= 1.5.4"
   gem "minitest-mock", "~> 5.27"
   gem "minitest-proveit"
+  gem "rbi", "~> 0.4.3"
   gem "sorbet-runtime"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbi (0.4.3)
+      prism (~> 1.0)
+      rbs (>= 4.0.1)
     rbs (4.2.0)
       logger
       prism (>= 1.6.0)
@@ -198,6 +201,7 @@ DEPENDENCIES
   minitest-proveit
   openai!
   rake
+  rbi (~> 0.4.3)
   rbs
   rubocop
   sorbet (< 0.6.12760)

--- a/gemfiles/bedrock.gemfile.lock
+++ b/gemfiles/bedrock.gemfile.lock
@@ -134,6 +134,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbi (0.4.3)
+      prism (~> 1.0)
+      rbs (>= 4.0.1)
     rbs (4.1.3)
       logger
       prism (>= 1.6.0)
@@ -215,6 +218,7 @@ DEPENDENCIES
   minitest-proveit
   openai!
   rake
+  rbi (~> 0.4.3)
   rbs
   rubocop
   sorbet (< 0.6.12760)

--- a/rbi/openai/helpers/realtime/extensions.rbi
+++ b/rbi/openai/helpers/realtime/extensions.rbi
@@ -1,7 +1,7 @@
 # typed: strong
 
 module OpenAI
-  class Client
+  class Client < OpenAI::Internal::Transport::BaseClient
     # @api private
     sig do
       params(

--- a/rbi/openai/helpers/responses_websocket/extensions.rbi
+++ b/rbi/openai/helpers/responses_websocket/extensions.rbi
@@ -1,7 +1,7 @@
 # typed: strong
 
 module OpenAI
-  class Client
+  class Client < OpenAI::Internal::Transport::BaseClient
     # @api private
     sig do
       params(

--- a/test/openai/exported_rbi_test.rb
+++ b/test/openai/exported_rbi_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rbi"
+
+require_relative "test_helper"
+
+class OpenAI::Test::ExportedRBITest < Minitest::Test
+  def test_exported_signatures_merge_without_conflicts
+    paths = Dir.glob(File.expand_path("../../rbi/**/*.rbi", __dir__))
+    refute_empty(paths)
+
+    # Tapioca discards the entire exported tree if this merge has any conflicts.
+    merger = RBI::Rewriters::Merge.new(keep: RBI::Rewriters::Merge::Keep::NONE)
+    paths.each { merger.merge(RBI::Parser.parse_file(_1)) }
+
+    conflicts = merger.tree.conflicts.map { "#{_1}: #{_1.left.loc} and #{_1.right.loc}" }
+    assert_empty(conflicts)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #678. Tapioca rejects the entire exported RBI tree when a reopened class disagrees with its primary superclass declaration. Because the SDK intentionally skips reflection during `tapioca gem`, that rejection leaves consumers with an empty RBI.

Declare the existing `OpenAI::Internal::Transport::BaseClient` superclass in both handwritten Client RBI extensions: Realtime and Responses WebSocket. The latter conflict becomes visible after fixing the former. Runtime loading and public APIs are unchanged.

Add a regression that merges every shipped RBI with `RBI::Rewriters::Merge::Keep::NONE`, reporting conflicting file locations. Add `rbi` only to the development/test bundle and update both lockfiles without changing existing dependency versions.

## Validation

- Regression failed before correction; fixing only Realtime exposed the Responses WebSocket conflict.
- Full-tree regression and loader tests: 5 tests, 12 assertions, no failures.
- `bundle exec rake typecheck:sorbet` passed.
- RuboCop and rubyfmt checks passed for all changed Ruby/RBI files.
- Fresh-context adversarial review converged; dependency review found no new transitive dependencies or install hooks. Bedrock release markers are preserved.
