### PR TITLE
examples: cover Responses WebSocket workflows and lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ does not automatically reconnect or replay an ambiguous write. When the server
 closes a connection, open a new connection and continue with
 `previous_response_id` when the response was stored.
 
+See the [Responses WebSocket guide](responses-websocket.md) and
+[runnable workflows](examples/responses/websocket_workflows.rb) for tool turns,
+multiplexing, stored continuation, stateless replay, and operation deadlines.
+
 ### Pagination
 
 List methods in the OpenAI API are paginated.

--- a/examples/e2e.yml
+++ b/examples/e2e.yml
@@ -88,6 +88,9 @@ examples:
   examples/responses/streaming_tools.rb:
     status: covered
     expected_output: parsed outputs from final response
+  examples/responses/websocket_workflows.rb:
+    status: covered
+    expected_output: Responses WebSocket workflow completed.
   examples/streaming.rb:
     status: covered
     expected_output: manual closing of stream

--- a/examples/responses/websocket_workflows.rb
+++ b/examples/responses/websocket_workflows.rb
@@ -1,0 +1,159 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "async"
+
+require_relative "../../lib/openai"
+
+module OpenAI
+  module Examples
+    module ResponsesWebSocketWorkflows
+      module_function
+
+      # One reader drains all requested lanes. This example fails the entire
+      # operation on an error; applications can instead isolate lane-scoped errors.
+      def completed_responses(connection, lanes: [nil])
+        pending = lanes.dup
+        responses = {}
+        connection.each do |event|
+          case event.type.to_s
+          when "response.completed"
+            next unless pending.include?(event.stream_id)
+
+            responses[event.stream_id] = event.response
+            pending.delete(event.stream_id)
+            break if pending.empty?
+          when "response.failed", "response.incomplete", "error"
+            raise "Responses WebSocket operation did not complete."
+          end
+        end
+
+        raise "Responses WebSocket closed with unfinished work." unless pending.empty?
+
+        responses
+      end
+
+      def tools(client:, model:)
+        client.responses.connect do |connection|
+          connection.response.create(
+            model: model,
+            input: "What day will my example delivery arrive?",
+            tools: [
+              {
+                type: :function,
+                name: "get_delivery_day",
+                description: "Return the day of the example delivery.",
+                parameters: {type: :object, properties: {}, required: [], additionalProperties: false},
+                strict: true
+              }
+            ],
+            tool_choice: {type: :function, name: "get_delivery_day"},
+            parallel_tool_calls: false,
+            store: false
+          )
+          first = completed_responses(connection).fetch(nil)
+          calls = first.output.select { |item| item.type.to_s == "function_call" }
+          unless calls.length == 1 && calls.first.name == "get_delivery_day"
+            raise "Expected the example delivery tool call."
+          end
+
+          # Execute only this application's known tool. Never eval model output.
+          connection.response.create(
+            model: model,
+            previous_response_id: first.id,
+            input: [{type: :function_call_output, call_id: calls.first.call_id, output: "Tuesday"}],
+            store: false
+          )
+          completed_responses(connection)
+        end
+      end
+
+      def multiplex(client:, model:)
+        client.responses.connect do |connection|
+          %w[planner critic].each do |lane|
+            connection.response.create(
+              model: model,
+              input: "Say hello as the #{lane}.",
+              stream_id: lane,
+              store: false
+            )
+          end
+
+          completed_responses(connection, lanes: %w[planner critic])
+        end
+      end
+
+      # Deliberately rotate a healthy connection after a completed turn. This does
+      # not retry a failed write or assume an unfinished response was accepted.
+      def reconnect(client:, model:, store:)
+        input = [{role: :user, content: "Remember the example delivery day: Tuesday."}]
+        first = client.responses.connect do |connection|
+          connection.response.create(
+            model: model,
+            input: input,
+            store: store,
+            include: ["reasoning.encrypted_content"]
+          )
+          completed_responses(connection).fetch(nil)
+        end
+
+        follow_up = {role: :user, content: "What is the example delivery day?"}
+        client.responses.connect do |connection|
+          if store
+            connection.response.create(
+              model: model,
+              input: [follow_up],
+              previous_response_id: first.id,
+              store: true
+            )
+          else
+            # Preserve every output item, including encrypted reasoning. The new
+            # connection cannot use the old connection's store=false cache.
+            connection.response.create(
+              model: model,
+              input: input + first.output + [follow_up],
+              store: false
+            )
+          end
+
+          completed_responses(connection)
+        end
+      end
+
+      def run(client:, model:, workflow:, timeout: 60, output: $stdout)
+        Sync do |task|
+          task.with_timeout(timeout) do
+            case workflow
+            when "tools"
+              tools(client: client, model: model)
+            when "multiplex"
+              multiplex(client: client, model: model)
+            when "stored"
+              reconnect(client: client, model: model, store: true)
+            when "stateless"
+              reconnect(client: client, model: model, store: false)
+            else
+              raise ArgumentError, "Choose tools, multiplex, stored, or stateless."
+            end
+          end
+        end
+
+        output.puts("Responses WebSocket workflow completed.")
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  begin
+    OpenAI::Examples::ResponsesWebSocketWorkflows.run(
+      client: OpenAI::Client.new,
+      model: ENV.fetch("OPENAI_RESPONSES_MODEL", "gpt-5.2"),
+      workflow: ARGV.fetch(0, "multiplex"),
+      timeout: Float(ENV.fetch("OPENAI_RESPONSES_TIMEOUT", "60"))
+    )
+  rescue StandardError
+    warn("Responses WebSocket workflow failed; no request or response contents were logged.")
+    exit(1)
+  end
+end

--- a/openai.gemspec
+++ b/openai.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
     ".ignore"
   ] +
     [
+      "examples/responses/websocket_workflows.rb",
       "examples/mtls_custom_http_client.rb",
       "examples/x509_workload_identity.rb",
       "examples/realtime/README.md",
@@ -43,6 +44,7 @@ Gem::Specification.new do |s|
     "azure.md",
     "bedrock.md",
     "realtime.md",
+    "responses-websocket.md",
     "examples/realtime/README.md"
   ]
   s.add_dependency("connection_pool", ">= 2.2.3")

--- a/responses-websocket.md
+++ b/responses-websocket.md
@@ -1,0 +1,182 @@
+# Responses WebSocket workflows
+
+Requires `openai` 0.86.0 or later and the optional `async-websocket` gem:
+
+```ruby
+gem "openai", ">= 0.86.0"
+gem "async-websocket"
+```
+
+Responses WebSocket mode connects to `/v1/responses`. It uses Responses events;
+it is distinct from [Realtime sessions](realtime.md). See the
+[platform guide](https://developers.openai.com/api/docs/guides/websocket-mode)
+for the service contract.
+
+## Run the examples
+
+The [workflow example](examples/responses/websocket_workflows.rb) demonstrates
+four patterns with one reader and no background worker threads. Keep
+`OPENAI_API_KEY` in your environment. These commands make real API calls:
+
+```sh
+bundle exec ruby examples/responses/websocket_workflows.rb tools
+bundle exec ruby examples/responses/websocket_workflows.rb multiplex
+bundle exec ruby examples/responses/websocket_workflows.rb stored
+bundle exec ruby examples/responses/websocket_workflows.rb stateless
+```
+
+Set `OPENAI_RESPONSES_MODEL` to override `gpt-5.2` and
+`OPENAI_RESPONSES_TIMEOUT` to change the 60-second overall deadline. The example
+prints only a completion marker, not prompts, model output, or server errors.
+The default workflow is `multiplex`. The `stored` workflow requires an account
+that allows response storage; use `stateless` with `store=false`/ZDR.
+
+## Connect, send, and receive
+
+```ruby
+client.responses.connect do |connection|
+  connection.response.create(model: "gpt-5.2", input: "Say hello.")
+  connection.each do |event|
+    case event.type.to_s
+    when "response.completed"
+      # Save event.response.id and handle event.response.output here.
+      break
+    when "response.failed", "response.incomplete", "error"
+      raise "Responses operation did not complete."
+    end
+  end
+end
+```
+
+Use the complete example for EOF detection: a connection ending before every
+expected terminal event is not success. `connect` requires a block and closes
+on block exit. Connection options belong in `connect`; model/input fields belong
+in `connection.response.create`.
+
+Known events are decoded into generated models on a best-effort basis. New
+event types arrive as `OpenAI::Responses::UnknownServerEvent`. Preserve or handle
+them explicitly where your application needs them. Do not assume every event
+has a response, text delta, or lane ID.
+
+## Sequential tool turns
+
+The `tools` workflow forces a call to one known, harmless application function.
+After the response completes, it checks the function name and sends its output
+using the original `call_id`. The next create uses `previous_response_id` and
+only the new `function_call_output` item. It does not resend the previous input
+on the same connection.
+
+Tool execution belongs to your application. Validate arguments against your
+tool's contract and authorize effects before execution. Never execute generated
+code or dispatch arbitrary method names from a tool event. The example uses a
+fixed result and does not execute model-provided code.
+
+## Multiplexing and continuation
+
+`stream_id` routes events to a lane; `previous_response_id` selects conversation
+history. They are independent. Reusing a lane without a previous response ID
+starts a new response rather than continuing that lane's conversation.
+
+The `multiplex` workflow writes two creates, then drains both lanes with one
+reader. Events may interleave and the first terminal event does not finish the
+whole operation. Keep a pending-lane set and retain each completed response ID.
+Omitting `stream_id` uses the default lane; its events omit the field as well.
+
+The example fails the whole operation on any error. Production applications can
+route a lane-scoped error to just that lane, while treating a connection-scoped
+error as affecting the connection. Track separate response IDs when multiple
+requests are outstanding within a lane; a lane alone is not a request ID.
+
+The server executes same-lane requests in FIFO order. The SDK does not enforce
+lane grammar, schedule lanes, or manage a per-lane queue. Consult the platform
+guide for the current concurrent-response and named-lane limits.
+
+To fork, send an existing response ID on a different lane. With `store=false`,
+wait for the fork's `response.in_progress` before advancing the source lane so
+its parent remains available in the connection-local cache.
+
+## Reconnect without replaying uncertain work
+
+Both reconnect examples intentionally close a healthy connection **after** a
+completed turn, then open another connection. They do not catch a failed write
+and retry it.
+
+- **Stored:** send only the new input plus the stored `previous_response_id`.
+  If the service cannot retrieve that response, the application must decide
+  whether to reconstruct context and start a new chain.
+- **Stateless:** connection-local state is lost on reconnect. Retain the original
+  inputs and every output item, including reasoning and tool items. Request
+  `include: ["reasoning.encrypted_content"]` for reasoning-model replay. Send the
+  retained history plus new input, omitting `previous_response_id` on the new
+  connection. Do not reduce history to displayed assistant text.
+
+Retained history can contain sensitive data. Apply your application's retention
+policy; neither the SDK nor this example writes a recovery log. A full-context
+replay starts a new chain and is not an exactly-once retry of a failed turn.
+
+Connections have a finite service lifetime (currently up to 60 minutes). Plan
+rotation and persistence at completed-turn boundaries. There is no automatic
+reconnect, rollover, or replay in this SDK connection.
+
+## Deadlines and shutdown
+
+An SDK request timeout bounds connection negotiation, not an established
+session's idle lifetime. The example wraps the complete workflow in an Async
+deadline on the owning thread:
+
+```ruby
+require "async"
+
+Sync do |task|
+  task.with_timeout(60) do
+    client.responses.connect do |connection|
+      # Send and read on this thread, inside the deadline.
+    end
+  end
+end
+```
+
+Connections enforce one owning thread and one active reader. Do not call close
+from another thread or nest `receive` inside an active `each`. The Async deadline
+can interrupt an idle network read on the owning thread; the SDK then aborts and
+cleans up the connection. A timeout inside a transport operation can surface as
+`ResponsesConnectionError`, rather than `Async::TimeoutError`. Application code
+that does CPU-bound work without yielding needs its own cancellation strategy.
+
+Exiting the block normally performs a close. An exception or poisoned connection
+causes an abort, avoiding a flush of uncertain buffered output. The peer may see
+an abrupt disconnect. This is local shutdown, not a server-side cancellation
+acknowledgment, and it does not guarantee that a response stopped executing.
+
+## Error and compatibility boundaries
+
+- `ResponsesSendError#outcome` is `:unknown`: the server may have accepted the
+  event. Stop using that connection; do not automatically resend it.
+- A transport read failure poisons the connection. A server `error` event is
+  delivered as an event and does not by itself poison it.
+- Malformed JSON raises `ResponsesProtocolError` without exposing the payload;
+  the connection permits later reads. Decide whether continuing is appropriate
+  for your application.
+- Raw `send_event` supports generated client models or hashes, including
+  `response.steer`. There is no `connection.response.steer` convenience method.
+- The platform documents `generate: false` warmup. It can be forwarded through
+  create's keyword rest even though 0.86.0 has no named generated `generate`
+  keyword. Follow the platform contract; do not send HTTP-only `stream` or
+  `background` flags just because generated models expose them.
+- X.509 workload identity and provider runtimes are not supported by this
+  entry point. A nonempty `request_options.extra_query` or nonzero
+  `request_options.max_retries` is rejected. Supported workload identity has a
+  narrow pre-handshake 401 refresh; that is not live-session recovery.
+- Large events are valid. Plan memory and application backpressure for your
+  workload without treating a fixed payload size as a protocol maximum.
+
+## Offline verification
+
+```sh
+bundle exec ruby -Itest test/openai/responses_websocket/workflows_test.rb
+```
+
+The tests use real loopback WebSockets and synthetic data, exercise the default
+Responses transport, and make no live API requests. They cover the four example
+patterns, interleaved terminal events, fragmented text, premature EOF, failures,
+idle-read deadlines, and a large event exceeding 32 MiB.

--- a/test/openai/responses_websocket/workflows_test.rb
+++ b/test/openai/responses_websocket/workflows_test.rb
@@ -241,6 +241,7 @@ class OpenAI::Test::ResponsesWebSocketWorkflowsTest < Minitest::Test
       end
     end
 
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     with_server(handler) do |client|
       client.responses.connect do |connection|
         %w[planner critic].each do |lane|
@@ -253,6 +254,13 @@ class OpenAI::Test::ResponsesWebSocketWorkflowsTest < Minitest::Test
             Workflows.completed_responses(connection, lanes: %w[planner critic])
           end
         end
+
+        assert_operator(
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at,
+          :<,
+          5,
+          "The operation deadline must fire before the 10-second harness timeout."
+        )
       end
 
       assert(peer_closed.dequeue)

--- a/test/openai/responses_websocket/workflows_test.rb
+++ b/test/openai/responses_websocket/workflows_test.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require "async/http/server"
+require "async/queue"
+require "async/websocket/adapters/http"
+require "async/websocket/server"
+require "io/endpoint/bound_endpoint"
+require "stringio"
+
+require_relative "../test_helper"
+require_relative "../../../examples/responses/websocket_workflows"
+
+class OpenAI::Test::ResponsesWebSocketWorkflowsTest < Minitest::Test
+  extend Minitest::Serial
+
+  Workflows = OpenAI::Examples::ResponsesWebSocketWorkflows
+
+  # Cross 32 MiB without imposing an API maximum. Keep this probe large and
+  # sequential; never shrink it or raise client limits merely to pass CI.
+  PAYLOAD_BYTES = (32 * 1024 * 1024) + 1
+
+  def test_multiplex_example_waits_for_both_interleaved_lanes
+    handler = lambda do |socket|
+      creates = [read_event(socket), read_event(socket)]
+      assert_equal(%w[planner critic], creates.map { |event| event.fetch("stream_id") })
+      assert_equal(["response.create"], creates.map { |event| event.fetch("type") }.uniq)
+      write_event(socket, type: "response.future_event", stream_id: "critic", extra: "new field")
+      write_completed(socket, id: "resp_critic", lane: "critic")
+      write_delta(socket, "planner is still running", lane: "planner")
+      write_completed(socket, id: "resp_planner", lane: "planner")
+    end
+
+    with_server(handler) do |client|
+      responses = Workflows.multiplex(client: client, model: "example-model")
+      assert_equal("resp_critic", responses.fetch("critic").id)
+      assert_equal("resp_planner", responses.fetch("planner").id)
+    end
+  end
+
+  def test_tool_example_continues_with_only_the_tool_result
+    handler = lambda do |socket|
+      first = read_event(socket)
+      refute(first.key?("stream_id"))
+      assert_equal(false, first.fetch("store"))
+      assert_equal("get_delivery_day", first.fetch("tool_choice").fetch("name"))
+      write_completed(
+        socket,
+        id: "resp_tool",
+        output: [{type: "function_call", id: "fc_1", call_id: "call_1", name: "get_delivery_day", arguments: "{}"}]
+      )
+      second = read_event(socket)
+      assert_equal("resp_tool", second.fetch("previous_response_id"))
+      assert_equal(
+        [{"type" => "function_call_output", "call_id" => "call_1", "output" => "Tuesday"}],
+        second.fetch("input")
+      )
+      assert_equal(false, second.fetch("store"))
+      write_completed(socket, id: "resp_answer")
+    end
+
+    with_server(handler) do |client|
+      assert_equal("resp_answer", Workflows.tools(client: client, model: "example-model").fetch(nil).id)
+    end
+  end
+
+  def test_runner_reports_success_only_after_both_lanes_finish
+    handler = lambda do |socket|
+      2.times { read_event(socket) }
+      write_completed(socket, id: "resp_planner", lane: "planner")
+      write_completed(socket, id: "resp_critic", lane: "critic")
+    end
+
+    with_server(handler) do |client|
+      output = StringIO.new
+      Workflows.run(client: client, model: "example-model", workflow: "multiplex", output: output)
+      assert_equal("Responses WebSocket workflow completed.\n", output.string)
+    end
+  end
+
+  def test_tool_example_rejects_an_unexpected_tool_name
+    handler = lambda do |socket|
+      read_event(socket)
+      write_completed(
+        socket,
+        id: "resp_tool",
+        output: [{type: "function_call", id: "fc_1", call_id: "call_1", name: "unknown_tool", arguments: "{}"}]
+      )
+    end
+
+    with_server(handler) do |client|
+      error = assert_raises(RuntimeError) { Workflows.tools(client: client, model: "example-model") }
+      assert_equal("Expected the example delivery tool call.", error.message)
+    end
+  end
+
+  def test_reconnect_examples_distinguish_stored_ids_from_full_stateless_history
+    [true, false].each do |store|
+      requests = []
+      output = [
+        {type: "reasoning", id: "rs_1", summary: [], encrypted_content: "synthetic-encrypted-state"},
+        {
+          type: "message",
+          id: "msg_1",
+          role: "assistant",
+          status: "completed",
+          content: [{type: "output_text", text: "Tuesday", annotations: []}]
+        }
+      ]
+      handler = lambda do |socket|
+        requests << read_event(socket)
+        write_completed(socket, id: "resp_#{requests.length}", output: output)
+      end
+
+      with_server(handler) do |client|
+        result = Workflows.reconnect(client: client, model: "example-model", store: store)
+        assert_equal("resp_2", result.fetch(nil).id)
+      end
+
+      assert_equal(2, requests.length)
+      first, second = requests
+      assert_includes(first.fetch("include"), "reasoning.encrypted_content")
+      assert_equal(store, second.fetch("store"))
+      if store
+        assert_equal("resp_1", second.fetch("previous_response_id"))
+        assert_equal(1, second.fetch("input").length)
+      else
+        refute(second.key?("previous_response_id"))
+        history = second.fetch("input")
+        assert_equal(first.fetch("input").first, history.first)
+        assert_equal("synthetic-encrypted-state", history.fetch(1).fetch("encrypted_content"))
+        assert_equal("Tuesday", history.fetch(2).fetch("content").first.fetch("text"))
+        assert_equal("user", history.last.fetch("role"))
+        assert_equal(4, history.length)
+      end
+    end
+  end
+
+  def test_premature_eof_is_not_a_successful_workflow
+    handler = lambda do |socket|
+      2.times { read_event(socket) }
+      write_completed(socket, id: "resp_critic", lane: "critic")
+    end
+
+    with_server(handler) do |client|
+      output = StringIO.new
+      error = assert_raises(RuntimeError) do
+        Workflows.run(client: client, model: "example-model", workflow: "multiplex", output: output)
+      end
+
+      assert_equal("Responses WebSocket closed with unfinished work.", error.message)
+      assert_empty(output.string)
+    end
+  end
+
+  def test_failed_incomplete_and_error_events_fail_without_echoing_payloads
+    %w[response.failed response.incomplete error].each do |type|
+      handler = lambda do |socket|
+        2.times { read_event(socket) }
+        write_event(
+          socket,
+          type: type,
+          stream_id: "planner",
+          sequence_number: 1,
+          response: {id: "resp_failed", status: "failed", output: []},
+          error: {type: "server_error", message: "synthetic private prompt"}
+        )
+      end
+
+      with_server(handler) do |client|
+        error = assert_raises(RuntimeError) { Workflows.multiplex(client: client, model: "example-model") }
+        assert_equal("Responses WebSocket operation did not complete.", error.message)
+        refute_includes(error.full_message, "synthetic private prompt")
+      end
+    end
+  end
+
+  def test_fragmented_messages_are_typed_and_eof_prevents_further_writes
+    handler = lambda do |socket|
+      assert_equal("response.create", read_event(socket).fetch("type"))
+      data = JSON.generate(delta_event("hello 🌍", lane: "main"))
+      # Split inside a multi-byte codepoint, not just between JSON tokens.
+      midpoint = data.index("🌍") + 1
+      socket.write_frame(Protocol::WebSocket::TextFrame.new(false).pack(data.byteslice(0, midpoint)))
+      socket.write_frame(Protocol::WebSocket::ContinuationFrame.new(true).pack(data.byteslice(midpoint..)))
+      socket.flush
+    end
+
+    with_server(handler) do |client|
+      client.responses.connect do |connection|
+        connection.response.create(model: "example-model", input: "test", stream_id: "main")
+        event = connection.receive
+        assert_kind_of(OpenAI::Responses::ResponseTextDeltaEvent, event)
+        assert_equal("hello 🌍", event.delta)
+        assert_equal("main", event.stream_id)
+        assert_nil(connection.receive)
+        assert_predicate(connection, :closed?)
+        assert_raises(OpenAI::Errors::ResponsesConnectionError) do
+          connection.response.create(model: "example-model", input: "must not send")
+        end
+      end
+    end
+  end
+
+  def test_large_event_is_preserved_by_the_default_responses_transport
+    text = "x" * PAYLOAD_BYTES
+    handler = lambda do |socket|
+      read_event(socket)
+      write_delta(socket, text, lane: "large")
+    end
+
+    with_server(handler) do |client|
+      client.responses.connect do |connection|
+        connection.response.create(model: "example-model", input: "Synthetic large event", stream_id: "large")
+        event = connection.receive
+        assert_equal(PAYLOAD_BYTES, event.delta.bytesize)
+        assert_equal(Digest::SHA256.hexdigest(text), Digest::SHA256.hexdigest(event.delta))
+        assert_equal("large", event.stream_id)
+      end
+    end
+
+  ensure
+    GC.start
+  end
+
+  def test_operation_deadline_interrupts_an_idle_read_and_does_not_replay
+    requests = []
+    peer_closed = Async::Queue.new
+    ready = Async::Queue.new
+    handler = lambda do |socket|
+      requests << read_event(socket)
+      requests << read_event(socket)
+      ready.enqueue(true)
+      # Stay idle until the client's operation deadline aborts the connection.
+      begin
+        assert_nil(socket.read)
+      rescue EOFError, Protocol::WebSocket::ClosedError
+        # Abort closes the underlying IO without a graceful WebSocket close.
+        nil
+      ensure
+        peer_closed.enqueue(true)
+      end
+    end
+
+    with_server(handler) do |client|
+      client.responses.connect do |connection|
+        %w[planner critic].each do |lane|
+          connection.response.create(model: "example-model", input: "Hello", stream_id: lane)
+        end
+
+        ready.dequeue
+        assert_raises(OpenAI::Errors::ResponsesConnectionError) do
+          Async::Task.current.with_timeout(0.1) do
+            Workflows.completed_responses(connection, lanes: %w[planner critic])
+          end
+        end
+      end
+
+      assert(peer_closed.dequeue)
+      assert_equal(2, requests.length)
+    end
+  end
+
+  private def with_server(handler)
+    Sync do |task|
+      task.with_timeout(10) do
+        endpoint = Async::HTTP::Endpoint.parse("http://127.0.0.1:0")
+        bound = endpoint.bound
+        port = bound.sockets.first.local_address.ip_port
+        fallback = -> (_request) { Protocol::HTTP::Response[404, {}, []] }
+        errors = []
+        websocket = Async::WebSocket::Server.new(fallback) do |socket|
+          handler.call(socket)
+        rescue StandardError, Minitest::Assertion => e
+          errors << e
+        end
+
+        server = Async::HTTP::Server.new(websocket, bound, protocol: endpoint.protocol, scheme: endpoint.scheme)
+        server_task = server.run
+        client = OpenAI::Client.new(api_key: "fake-test-key", base_url: "http://127.0.0.1:#{port}/v1")
+        yield(client)
+        raise errors.first unless errors.empty?
+      ensure
+        server_task&.stop
+        bound&.close
+      end
+    end
+  end
+
+  private def read_event(socket) = JSON.parse(socket.read.to_str)
+
+  private def write_event(socket, **event)
+    socket.write(Protocol::WebSocket::TextMessage.generate(event))
+    socket.flush
+  end
+
+  private def write_completed(socket, id:, lane: nil, output: [])
+    event = {type: "response.completed", sequence_number: 1, response: {id: id, status: "completed", output: output}}
+    event[:stream_id] = lane unless lane.nil?
+    write_event(socket, **event)
+  end
+
+  private def delta_event(text, lane:)
+    {
+      type: "response.output_text.delta",
+      item_id: "msg_1",
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 0,
+      delta: text,
+      stream_id: lane
+    }
+  end
+
+  private def write_delta(socket, text, lane:) = write_event(socket, **delta_event(text, lane: lane))
+end


### PR DESCRIPTION
## Summary

Ruby 0.86.0 ships Responses WebSocket support, but its README only demonstrates a single turn. Add runnable workflows and a linked guide for sequential tools, interleaved lanes, stored-ID reconnect, full stateless replay, terminal outcomes, and operation deadlines. The examples retain application ownership of recovery and never retry uncertain writes.

Package the guide and workflow so both links work from the installed gem.

Add deterministic loopback tests through the default Responses transport, including UTF-8 fragmentation, premature EOF, idle-read cancellation/cleanup, and a synthetic event exceeding 32 MiB. No SDK runtime, public API, dependency, schema, or compiler behavior changes.

## Validation

- Complete Responses WebSocket suite plus shared transport tests: 75 tests, 363 assertions; no failures/errors/skips, using Ruby 4.0.6 and the locked bundle.
- Deadline mutation check: removing the 100 ms operation timeout now fails the monotonic bound at the outer 10-second harness timeout; the normal workflow suite passes in about 0.3 seconds.
- Gem packaging regression tests: 2 tests, 40 assertions; all README-relative links resolve in the built gem.
- RuboCop, rubyfmt, example inventory, and diff whitespace checks pass.
- Custom-code budget: 3,451 / 4,000 lines (549 remaining); no policy changes.
- Adversarial review: seven rounds total, with two fresh consecutive clean rounds after the deadline-test correction; security-sensitive example/transport behavior reviewed.
- Temporary schema-field generation probe: two clean three-way generation passes, model/RBI/RBS propagation, unique helper signature blocks, no helper loss, and 4,309 identical files between passes (excluding generation metadata). The same 75-test suite passes on the regenerated copy.
- No live API calls performed locally. The example is registered in the existing live-example inventory.
