### PR TITLE
ci: allow 15 minutes for Ruby test jobs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -98,7 +98,7 @@ jobs:
         run: bundle exec rake build:gem
 
   test-ruby:
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: test (ruby ${{ matrix.ruby-version }})
     permissions:
       contents: read


### PR DESCRIPTION
Ruby test jobs can run close to the current 10-minute limit, leaving too little headroom for setup and runner variance. Increase the `test-ruby` matrix job timeout to 15 minutes as an interim measure while test-suite performance is investigated separately.

This applies to Ruby 3.3, 3.4, and 4.0. Other job timeouts and test coverage are unchanged.

Validation: reviewed the one-line workflow diff and ran `git diff --check`.
