### PR TITLE
ci: shard Ruby tests across parallel jobs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -99,7 +99,7 @@ jobs:
 
   test-ruby:
     timeout-minutes: 15
-    name: test (ruby ${{ matrix.ruby-version }})
+    name: test (ruby ${{ matrix.ruby-version }}, shard ${{ matrix.shard }}/3)
     permissions:
       contents: read
     runs-on: ${{ inputs.runner }}
@@ -107,6 +107,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['3.3', '3.4', '4.0']
+        shard: [1, 2, 3]
+    env:
+      TEST_SHARD: ${{ matrix.shard }}/3
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,12 @@ $ ./scripts/mock
 $ bundle exec rake test
 ```
 
+CI partitions the non-Bedrock suite into three disjoint groups of whole test
+files on each supported Ruby version. To reproduce one group locally, run
+`TEST_SHARD=1/3 ./scripts/test` (or `2/3`, `3/3`). Without `TEST_SHARD`, the
+command still runs the complete suite. Each group preserves the suite's serial
+test scheduling, including the large-payload cases.
+
 The primary bundle intentionally omits the optional AWS SDK. Install the
 dedicated Bedrock bundle and run its tests separately:
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ require "rubocop/rake_task"
 
 require_relative "scripts/rubyfmt_policy"
 require_relative "scripts/rbs_format"
+require_relative "scripts/test_sharding"
 
 examples = "examples"
 ignore_file = ".ignore"
@@ -48,7 +49,7 @@ multitask(test: [:"test:examples:inventory"]) do
     abort("Run Bedrock tests with `BUNDLE_GEMFILE=gemfiles/bedrock.gemfile bundle exec rake test:bedrock`")
   end
 
-  run_tests.call(files.exclude(*bedrock_tests))
+  run_tests.call(TestSharding.select(files.exclude(*bedrock_tests).to_a, ENV["TEST_SHARD"]))
 end
 
 desc("Run Bedrock tests with the AWS test bundle")

--- a/scripts/test_sharding.rb
+++ b/scripts/test_sharding.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TestSharding
+  def self.select(files, shard)
+    return files if shard.nil?
+
+    match = /\A([1-9][0-9]*)\/([1-9][0-9]*)\z/.match(shard)
+    raise ArgumentError, "TEST_SHARD must be INDEX/COUNT (for example 1/3)" unless match
+
+    index, count = match.captures.map(&:to_i)
+    raise ArgumentError, "TEST_SHARD index must not exceed its count" if index > count
+
+    # Keep whole files together: global stubs and large-payload cases retain
+    # their existing Minitest::Serial scheduling inside each process.
+    files.sort.each_with_index.filter_map { |file, offset| file if offset % count == index - 1 }
+  end
+end

--- a/test/scripts/test_sharding_test.rb
+++ b/test/scripts/test_sharding_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "yaml"
+
+require_relative "../../scripts/test_sharding"
+
+class TestShardingTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_ci_matrix_covers_every_primary_test_file_exactly_once_per_ruby
+    workflow = YAML.load_file(File.join(ROOT, ".github/workflows/ci-checks.yml"))
+    job = workflow.fetch("jobs").fetch("test-ruby")
+    matrix = job.fetch("strategy").fetch("matrix")
+    assert_equal(%w[3.3 3.4 4.0], matrix.fetch("ruby-version"))
+    assert_equal("${{ matrix.shard }}/3", job.fetch("env").fetch("TEST_SHARD"))
+    assert_equal(false, job.fetch("strategy").fetch("fail-fast"))
+    assert_includes(workflow.fetch("jobs").fetch("required").fetch("needs"), "test-ruby")
+
+    files = Dir
+      .glob(File.join(ROOT, "test/**/*_test.rb"))
+      .reject { _1.match?(%r{/providers/bedrock[^/]*_test\.rb\z}) }
+    groups = matrix.fetch("shard").map { TestSharding.select(files, "#{_1}/3") }
+
+    assert_equal(files.sort, groups.flatten.sort)
+    assert_equal(files.size, groups.flatten.uniq.size)
+    assert(groups.all? { !_1.empty? })
+    assert_equal(1, groups.count { |group| group.any? { _1.end_with?("/large_payload_test.rb") } })
+  end
+
+  def test_selection_is_independent_of_discovery_order_and_unset_means_all
+    files = %w[c.rb a.rb b.rb d.rb]
+
+    assert_equal(TestSharding.select(files, "2/3"), TestSharding.select(files.reverse, "2/3"))
+    assert_equal(files, TestSharding.select(files, nil))
+  end
+
+  def test_invalid_configuration_fails_instead_of_silently_dropping_tests
+    ["", "0/3", "1/0", "4/3", "1", "-1/3", "1/3\n"].each do |shard|
+      assert_raises(ArgumentError) { TestSharding.select(["test.rb"], shard) }
+    end
+  end
+
+  def test_rake_rejects_an_empty_shard
+    stdout, stderr, status = Open3.capture3(
+      {"TEST" => "test/scripts/test_sharding_test.rb", "TEST_SHARD" => "2/3"},
+      "bundle",
+      "exec",
+      "rake",
+      "test",
+      chdir: ROOT
+    )
+
+    refute_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    assert_includes(stderr, "No test files selected")
+  end
+end


### PR DESCRIPTION
The Ruby test matrix determines CI completion: PR #683 spent 6m47s–8m47s in each `Run tests` step while all other CI jobs finished within 53 seconds. Split the primary test suite into three disjoint groups of whole files on each of Ruby 3.3, 3.4, and 4.0. Every existing test still runs on every version, and existing serial scheduling—including large-payload cases—is preserved.

`TEST_SHARD=1/3 ./scripts/test` reproduces a group locally; omitting `TEST_SHARD` still runs the complete primary suite. Invalid configurations and empty groups fail visibly. The existing `ci-required` gate requires all nine matrix jobs to succeed. Permissions, action pins, Bedrock testing, and the 15-minute timeout from #683 are unchanged.

### Validation

- Local Ruby 4.0.6 baseline: 1,872 tests in 254s; zero failures/errors, one platform skip.
- Three local shards: 555 / 671 / 650 tests in 22s / 93s / 143s; zero failures/errors and the same platform skip. Combined count is 1,876, including four new sharding tests.
- Regression coverage verifies exhaustive/disjoint coverage against the repository inventory, all supported Rubies, discovery-order independence, invalid configuration, and empty-selection failure.
- Full lint/formatting, Sorbet, and RBS validation passed; custom-code budget passed at 3,451 / 4,000 lines.
- Independent adversarial review and CI security review completed before pushing. Hosted CI timings will verify the actual wall-time benefit; local measurements are diagnostic and runner performance varies.

Tradeoff: six additional runner jobs add setup overhead and consume more concurrency. This reduces feedback latency while preserving coverage; it does not eliminate the repeated whole-tree typechecking and RBI-merge work identified during profiling.
