### PR TITLE
ci: publish Castiron statuses despite stale PR base metadata

### DIFF
--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -157,7 +157,7 @@ jobs:
               for (const number of [...new Set(pulls.map(pull => pull.number))].sort((a, b) => a - b)) {
                 if (!Number.isInteger(number) || number <= 0) return;
                 const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: number});
-                if (pr.state === 'open' && pr.head.sha === head && pr.base.sha === base &&
+                if (pr.state === 'open' && pr.head.sha === head &&
                     pr.head.ref === run.head_branch && pr.head.repo?.id === headRepository.id &&
                     pr.head.repo?.full_name === headRepository.full_name &&
                     pr.base.ref === branch &&
@@ -167,6 +167,7 @@ jobs:
             } else if (run.event !== 'merge_group' || !run.head_branch.startsWith(`gh-readonly-queue/${branch}/`)) {
               return;
             }
+            // PR base.sha can lag main; freshness is tied to the evaluated Git revision.
             const fresh = base === process.env.BASE_SHA && head === process.env.HEAD_SHA;
             const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             for (const [name, result] of [
@@ -179,6 +180,9 @@ jobs:
                 : 'Budget check failed. See the trusted run summary.';
               await github.rest.repos.createCommitStatus({...context.repo, sha: head, context: name,
                 state, description, target_url: url});
+            }
+            if (!fresh || process.env.ISOLATION_RESULT !== 'success' || process.env.BUDGET_RESULT !== 'success') {
+              core.setFailed('Custom-code evaluation failed or is stale. See the trusted run summary and rerun against current main.');
             }
 
   comment:
@@ -239,7 +243,6 @@ jobs:
                 run.repository.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
             const {data: repository} = await github.rest.repos.get(context.repo);
             const branch = repository.default_branch;
-            const {data: main} = await github.rest.git.getRef({...context.repo, ref: `heads/${branch}`});
             const headRepository = run.head_repository;
             if (!headRepository || !Number.isInteger(headRepository.id) || headRepository.id <= 0 ||
                 !headRepository.full_name || !headRepository.owner?.login || !run.head_branch) return;
@@ -253,7 +256,7 @@ jobs:
               if (pr.state === 'open' && pr.head.sha === run.head_sha &&
                   pr.head.ref === run.head_branch && pr.head.repo?.id === headRepository.id &&
                   pr.head.repo?.full_name === headRepository.full_name &&
-                  pr.base.sha === main.object.sha && pr.base.ref === branch &&
+                  pr.base.ref === branch &&
                   pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) current.push(pr);
             }
             if (current.length !== 1) return;

--- a/.github/workflows/castiron-custom-code.yml
+++ b/.github/workflows/castiron-custom-code.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REPORTER_SHA256: 66b128590c674d4dec7c59b99dc0de54d7d1672eee4ab6d193bfc6b369a664d0
+  REPORTER_SHA256: 3bfaa45352c189c5993ac6359d6350a95d7ac60190268b8c6e214688c4c3db5f
 
 jobs:
   queue-signal:

--- a/scripts/castiron/CUSTOM_CODE.md
+++ b/scripts/castiron/CUSTOM_CODE.md
@@ -59,8 +59,12 @@ For fork PRs, GitHub can omit `workflow_run.pull_requests` while the PR is open.
 The trusted handler then uses the authenticated run's head repository owner and
 branch to list open PRs targeting the default branch, fetches every candidate,
 and accepts exactly one only after matching its head SHA, head repository and
-ref, base repository and ref, and current default-branch SHA. Missing,
-ambiguous, spoofed, or stale metadata still fails closed.
+ref, and base repository and ref. The PR API’s base SHA can lag main and is not
+used to identify the PR. Missing, ambiguous, spoofed, or stale head metadata still
+fails closed. Evaluation uses the independently fetched current default-branch
+SHA; publication compares that revision with live main, never with PR base metadata.
+Unavailable or stale evaluations publish failing statuses for a verified current
+head and fail the publisher job visibly.
 
 The policy is read from the current base commit, not the PR or its merge base.
 Reporter changes in a PR cannot change the checker executing on that PR. Missing

--- a/scripts/castiron/custom_code_budget.py
+++ b/scripts/castiron/custom_code_budget.py
@@ -300,7 +300,7 @@ def github_evaluate(
         raise ValueError("unexpected or superseded source workflow run")
     head = report.require_sha(run["head_sha"])
     if run["event"] == "pull_request":
-        if report.current_pull_request(root, repository, run, branch, main) is None:
+        if report.current_pull_request(root, repository, run, branch) is None:
             raise ValueError("source run must identify exactly one current PR targeting main")
     elif run["event"] == "merge_group":
         if not run["head_branch"].startswith(f"gh-readonly-queue/{branch}/"):

--- a/scripts/castiron/custom_code_report.py
+++ b/scripts/castiron/custom_code_report.py
@@ -786,9 +786,8 @@ def current_pull_request(
     repository: str,
     run: dict[str, Any],
     branch: str,
-    main: str,
 ) -> dict[str, Any] | None:
-    """Resolve one live PR from trusted run metadata, including fork runs."""
+    """Resolve by live repository/ref/head identity; PR base SHA can lag main."""
     head = require_sha(run["head_sha"])
     head_repository = run.get("head_repository")
     if not isinstance(head_repository, dict):
@@ -835,7 +834,6 @@ def current_pull_request(
             and pull_head_repository["full_name"] == head_repository_name
             and pull["base"]["repo"]["full_name"] == repository
             and pull["base"]["ref"] == branch
-            and pull["base"]["sha"] == main
         ):
             current.append(pull)
     if not current:
@@ -869,7 +867,7 @@ def publish_comment(
     metadata = api("GET", root)
     branch = metadata["default_branch"]
     main = require_sha(api("GET", f"{root}/git/ref/heads/{branch}")["object"]["sha"])
-    pull = current_pull_request(root, repository, run, branch, main)
+    pull = current_pull_request(root, repository, run, branch)
     if pull is None or pull["number"] != number:
         raise ReportError("workflow run does not match report PR/head")
     if pull["head"]["sha"] != report["head_sha"] or main != report["target_base_sha"]:
@@ -904,8 +902,10 @@ def publish_comment(
         if found["body"] == body:
             return str(found["html_url"])
     # The workflow serializes publishers; recheck after pagination before writing.
-    pull = current_pull_request(root, repository, run, branch, main)
+    pull = current_pull_request(root, repository, run, branch)
     if pull is None or pull["number"] != number:
+        return "Skipped stale report"
+    if require_sha(api("GET", f"{root}/git/ref/heads/{branch}")["object"]["sha"]) != main:
         return "Skipped stale report"
     if found is not None:
         result = api("PATCH", f"{root}/issues/comments/{found['id']}", {"body": body})
@@ -965,7 +965,7 @@ def trusted_report(repo: Path, repository: str, run_id: int, run_attempt: int, o
     metadata = api("GET", root)
     branch = metadata["default_branch"]
     main = require_sha(api("GET", f"{root}/git/ref/heads/{branch}")["object"]["sha"])
-    pull = current_pull_request(root, repository, run, branch, main)
+    pull = current_pull_request(root, repository, run, branch)
     if pull is None:
         return
     number = int(pull["number"])

--- a/scripts/castiron/test_custom_code_budget.py
+++ b/scripts/castiron/test_custom_code_budget.py
@@ -313,6 +313,7 @@ class StatusPublisherTests(unittest.TestCase):
         head_changed: bool = False,
         base_changed: bool = False,
         no_result: bool = False,
+        stale_pr_base: bool = False,
         failed_budget: bool = False,
         run_overrides: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
@@ -337,6 +338,7 @@ class StatusPublisherTests(unittest.TestCase):
             },
             "run": {**source_run(head, event_name), **(run_overrides or {})},
             "candidates": [{"number": 3}],
+            "main": "c" * 40 if base_changed else base,
             "current": {
                 "state": "open",
                 "head": {
@@ -345,7 +347,7 @@ class StatusPublisherTests(unittest.TestCase):
                     "repo": {"id": 7, "full_name": "fork/example"},
                 },
                 "base": {
-                    "sha": "c" * 40 if base_changed else base,
+                    "sha": "d" * 40 if stale_pr_base else base,
                     "ref": "main",
                     "repo": {"full_name": "openai/example"},
                 },
@@ -370,15 +372,17 @@ class StatusPublisherTests(unittest.TestCase):
             rest: {
             pulls: {list() {}, get: async () => ({data: data.current})},
             actions: {getWorkflowRun: async () => ({data: data.run})},
-            git: {getRef: async () => ({data: {object: {sha: data.current.base.sha}}})},
+            git: {getRef: async () => ({data: {object: {sha: data.main}}})},
             repos: {
               get: async () => ({data: {default_branch: 'main'}}),
               createCommitStatus: async value => published.push(value),
             },
           }};
           const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
-          new AsyncFunction('github','context','process', data.script)(github, data.context, {env:data.env})
-            .then(() => process.stdout.write(JSON.stringify(published)))
+          const failures = [];
+          new AsyncFunction('github','context','process','core', data.script)(
+            github, data.context, {env:data.env}, {setFailed: message => failures.push(message)})
+            .then(() => process.stdout.write(JSON.stringify({published, failures})))
             .catch(error => { console.error(error); process.exitCode = 1; });
         """
         output = subprocess.run(
@@ -388,7 +392,11 @@ class StatusPublisherTests(unittest.TestCase):
             capture_output=True,
             check=True,
         )
-        return cast(list[dict[str, Any]], json.loads(output.stdout))
+        result = json.loads(output.stdout)
+        self.assertEqual(bool(result["failures"]), any(
+            status["state"] == "failure" for status in result["published"]
+        ))
+        return cast(list[dict[str, Any]], result["published"])
 
     def test_statuses_attach_to_candidate_not_main(self) -> None:
         for event in ("pull_request", "merge_group"):
@@ -398,6 +406,15 @@ class StatusPublisherTests(unittest.TestCase):
                 self.assertTrue(
                     all(r["sha"] == "b" * 40 and r["state"] == "success" for r in results)
                 )
+
+    def test_stale_pr_base_does_not_hide_results_or_evaluation_failures(self) -> None:
+        for no_result in (False, True):
+            with self.subTest(no_result=no_result):
+                results = self.publish(stale_pr_base=True, no_result=no_result)
+                self.assertEqual(len(results), 2)
+                self.assertTrue(all(
+                    r["state"] == ("failure" if no_result else "success") for r in results
+                ))
 
     def test_stale_pr_head_is_not_published(self) -> None:
         self.assertEqual(self.publish(head_changed=True), [])
@@ -589,7 +606,7 @@ class GitHubBudgetTests(unittest.TestCase):
         pull = {
             "state": "open",
             "head": {"sha": head, "ref": "sdk", "repo": {"id": 7, "full_name": "fork/example"}},
-            "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
+            "base": {"sha": "d" * 40, "ref": "main", "repo": {"full_name": "openai/example"}},
         }
         responses = [
             {"default_branch": "main", "private": False},
@@ -617,7 +634,7 @@ class GitHubBudgetTests(unittest.TestCase):
             )
 
     def test_stale_pull_and_wrong_target_fail_before_objects_created(self) -> None:
-        for kind in ("head", "base", "repository", "branch", "closed"):
+        for kind in ("head", "repository", "branch", "closed"):
             with self.subTest(kind=kind), tempfile.TemporaryDirectory() as temp:
                 base, head = "a" * 40, "b" * 40
                 event = {
@@ -631,8 +648,6 @@ class GitHubBudgetTests(unittest.TestCase):
                 }
                 if kind == "head":
                     pull["head"]["sha"] = "c" * 40
-                elif kind == "base":
-                    pull["base"]["sha"] = "c" * 40
                 elif kind == "repository":
                     pull["base"]["repo"]["full_name"] = "wrong/repo"
                 elif kind == "branch":

--- a/scripts/castiron/test_custom_code_report.py
+++ b/scripts/castiron/test_custom_code_report.py
@@ -325,7 +325,7 @@ async function check(stale, exists, priorRun, expected) {
     head_branch: 'sdk', head_repository: {id: 7, full_name: 'fork/example', owner: {login: 'fork'}}};
   const current = {number: 1, state: 'open',
     head: {sha: (stale ? 'c' : 'a').repeat(40), ref: 'sdk', repo: {id: 7, full_name: 'fork/example'}},
-    base: {sha: 'b'.repeat(40), ref: 'main', repo: {full_name: 'openai/example'}}};
+    base: {sha: 'd'.repeat(40), ref: 'main', repo: {full_name: 'openai/example'}}};
   const previous = {id: 42, user: {type: 'Bot', login: 'github-actions[bot]'},
     body: `<!-- castiron:custom-code-report:v1 -->\n<!-- castiron:run:v1:${priorRun}:1 -->`};
   const github = {paginate: async () => exists ? [previous] : [], rest: {
@@ -436,6 +436,7 @@ async function check(stale, exists, priorRun, expected) {
                 pull,
                 [],
                 pull,
+                {"object": {"sha": base}},
                 {"html_url": "published"},
             ],
         ) as api:
@@ -498,7 +499,7 @@ async function check(stale, exists, priorRun, expected) {
             with self.subTest(label=label):
                 calls: list[tuple[str, str]] = []
                 bodies: list[str] = []
-                pull = source_pull(revision, base)
+                pull = source_pull(revision, "e" * 40)
                 run = source_run(revision, [])
                 forged: dict[str, Any] = {**legitimate, "head_sha": revision, "files": []}
                 self.assertIn("Generated baselines verified", report.render_report(forged))
@@ -614,7 +615,7 @@ async function check(stale, exists, priorRun, expected) {
         with mock.patch.object(report, "api", side_effect=[[{"number": 1}], pull]) as api:
             self.assertEqual(
                 report.current_pull_request(
-                    "repos/openai/example", "openai/example", run, "main", base
+                    "repos/openai/example", "openai/example", run, "main"
                 ),
                 pull,
             )
@@ -628,7 +629,7 @@ async function check(stale, exists, priorRun, expected) {
                 None,
             ),
             (
-                [[{"number": 1}], {**pull, "base": {**pull["base"], "sha": "c" * 40}}],
+                [[{"number": 1}], {**pull, "base": {**pull["base"], "ref": "other"}}],
                 None,
             ),
             (
@@ -647,12 +648,12 @@ async function check(stale, exists, priorRun, expected) {
                 if expected is report.ReportError:
                     with self.assertRaises(report.ReportError):
                         report.current_pull_request(
-                            "repos/openai/example", "openai/example", run, "main", base
+                            "repos/openai/example", "openai/example", run, "main"
                         )
                 else:
                     self.assertIsNone(
                         report.current_pull_request(
-                            "repos/openai/example", "openai/example", run, "main", base
+                            "repos/openai/example", "openai/example", run, "main"
                         )
                     )
 
@@ -677,12 +678,12 @@ async function check(stale, exists, priorRun, expected) {
                 if ambiguous:
                     with self.assertRaises(report.ReportError):
                         report.current_pull_request(
-                            "repos/openai/example", "openai/example", run, "main", base
+                            "repos/openai/example", "openai/example", run, "main"
                         )
                 else:
                     self.assertEqual(
                         report.current_pull_request(
-                            "repos/openai/example", "openai/example", run, "main", base
+                            "repos/openai/example", "openai/example", run, "main"
                         )["number"],
                         101,
                     )
@@ -950,6 +951,24 @@ async function check(stale, exists, priorRun, expected) {
             with self.assertRaisesRegex(report.ReportError, "does not match report PR"):
                 report.publish_comment(result, "openai/example", 1, 2, 1)
             self.assertFalse(any(method in {"PATCH", "POST"} for method, _, _ in calls))
+
+    def test_comment_rechecks_main_after_pagination(self) -> None:
+        _, base = self.baseline()
+        result, _ = report.build_report(self.repo, base, base)
+        pull = source_pull(base, "e" * 40)
+        with mock.patch.object(
+            report,
+            "api",
+            side_effect=[
+                source_run(base), {"default_branch": "main"},
+                {"object": {"sha": base}}, pull, [], pull,
+                {"object": {"sha": "f" * 40}},
+            ],
+        ) as api:
+            self.assertEqual(
+                report.publish_comment(result, "openai/example", 1, 2, 1), "Skipped stale report"
+            )
+            self.assertTrue(all(call.args[0] == "GET" for call in api.call_args_list))
 
     def test_comment_rejects_older_runs_attempts_and_wrong_pr(self) -> None:
         _, base = self.baseline()


### PR DESCRIPTION
## Summary

GitHub can retain an older `base.sha` on an open PR after main advances. The Castiron handler treated that metadata as PR identity, so rerunning a valid PR could leave both required budget statuses missing while the publisher appeared green.

Resolve the current PR by its verified repository, branch, and head identity. Continue evaluating current-main policy against trusted Git objects and checking the actual evaluation revisions before publication. Publish failing statuses and fail the publisher job when evaluation is unavailable, stale, or fails. Recheck main before writing the report comment.

## Validation

- Castiron suite passed: 55 tests, with the optional compiler contract test skipped (`CASTIRON_TEST_BIN` is unset), including stale PR base metadata, stale heads, evaluation base changes, failure visibility, and comment publication freshness.
- Ruff, actionlint for both Castiron workflows, and `git diff --check` passed.
- Security review and two consecutive clean adversarial-review rounds, with two independent fresh-context reviewers per round.

The trusted workflow runs from main, so the updated publisher takes effect after this PR merges. Budget policy, accounting, and permissions are unchanged.
